### PR TITLE
renderer: ensure only one buffer reference is added

### DIFF
--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -276,6 +276,7 @@ void CMonitor::onConnect(bool noRule) {
 
         m_output->state->resetExplicitFences();
         m_output->state->setEnabled(false);
+        m_usedAsyncBuffers.clear();
 
         if (!m_state.commit())
             Log::logger->log(Log::ERR, "Couldn't commit disabled state on output {}", m_name);
@@ -2332,6 +2333,7 @@ void CMonitor::setDPMS(bool on) {
 
                 // commit DPMS to disable the monitor, it's fully black now
                 commitDPMSState(false);
+                m_usedAsyncBuffers.clear();
             },
             true);
     }
@@ -2340,6 +2342,8 @@ void CMonitor::setDPMS(bool on) {
 void CMonitor::commitDPMSState(bool state) {
     m_output->state->resetExplicitFences();
     m_output->state->setEnabled(state);
+    if (!state)
+        m_usedAsyncBuffers.clear();
 
     if (!m_state.commit()) {
         Log::logger->log(Log::ERR, "Couldn't commit output {} for DPMS = {}, will retry.", m_name, state);
@@ -2355,6 +2359,9 @@ void CMonitor::commitDPMSState(bool state) {
 
                 m_output->state->resetExplicitFences();
                 m_output->state->setEnabled(m_dpmsStatus);
+                if (!m_dpmsStatus)
+                    m_usedAsyncBuffers.clear();
+
                 if (!m_state.commit()) {
                     Log::logger->log(Log::ERR, "Couldn't retry committing output {} for DPMS = {}", m_name, m_dpmsStatus);
                     return;

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -351,26 +351,27 @@ namespace Monitor {
 
         bool                                                        needsCM();
         /// Can do CM without shader (forDSmode ? check output image description : check workbuffer image description)
-        bool                                canNoShaderCM(bool forDSmode = false);
-        bool                                doesNoShaderCM();
+        bool                                                               canNoShaderCM(bool forDSmode = false);
+        bool                                                               doesNoShaderCM();
 
-        bool                                m_enabled             = false;
-        bool                                m_renderingInitPassed = false;
+        bool                                                               m_enabled             = false;
+        bool                                                               m_renderingInitPassed = false;
 
-        PHLWINDOWREF                        m_previousFSWindow;
-        bool                                m_needsHDRupdate = false;
+        PHLWINDOWREF                                                       m_previousFSWindow;
+        bool                                                               m_needsHDRupdate = false;
 
-        std::optional<dev_t>                m_cachedAllocatorDRMDev;
-        std::optional<dev_t>                m_cachedCompositorDRMDev;
-        int                                 m_cachedAllocatorDRMFD  = -1;
-        int                                 m_cachedCompositorDRMFD = -1;
-        std::optional<bool>                 m_cachedSameGPU;
+        std::optional<dev_t>                                               m_cachedAllocatorDRMDev;
+        std::optional<dev_t>                                               m_cachedCompositorDRMDev;
+        int                                                                m_cachedAllocatorDRMFD  = -1;
+        int                                                                m_cachedCompositorDRMFD = -1;
+        std::optional<bool>                                                m_cachedSameGPU;
 
-        NColorManagement::PImageDescription m_imageDescription = NColorManagement::CImageDescription::from(NColorManagement::SImageDescription{});
-        bool                                m_noShaderCTM      = false; // sets drm CTM, restore needed
+        NColorManagement::PImageDescription                                m_imageDescription = NColorManagement::CImageDescription::from(NColorManagement::SImageDescription{});
+        bool                                                               m_noShaderCTM      = false; // sets drm CTM, restore needed
 
-        bool                                m_blurFBDirty        = true;
-        bool                                m_blurFBShouldRender = false;
+        bool                                                               m_blurFBDirty        = true;
+        bool                                                               m_blurFBShouldRender = false;
+        std::vector<std::pair<WP<CWLSurfaceResource>, CHLBufferReference>> m_usedAsyncBuffers;
 
         // For the list lookup
 

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -401,9 +401,12 @@ void IElementRenderer::preDrawSurface(WP<CSurfacePassElement> element, const CRe
     drawSurface(element, damage);
 
     // add async (dmabuf) buffers to usedBuffers so we can handle release later
-    // sync (shm) buffers will be released in commitState, so no need to track them here
-    if (element->m_data.surface->m_current.buffer && !element->m_data.surface->m_current.buffer->isSynchronous())
-        g_pHyprRenderer->m_usedAsyncBuffers.emplace_back(element->m_data.surface->m_current.buffer);
+    // sync (shm) buffers will be released in commitState, so no need to track them here.
+    if (element->m_data.surface->m_current.buffer && !element->m_data.surface->m_current.buffer->isSynchronous() &&
+        std::ranges::none_of(g_pHyprRenderer->m_usedAsyncBuffers, [&](const auto& e) {
+            return e.first == element->m_data.pMonitor && e.second.first == element->m_data.surface && e.second.second == element->m_data.surface->m_current.buffer;
+        }))
+        g_pHyprRenderer->m_usedAsyncBuffers.emplace_back(element->m_data.pMonitor, std::make_pair(element->m_data.surface, element->m_data.surface->m_current.buffer));
 
     m_renderData.clipBox            = {};
     m_renderData.useNearestNeighbor = false;

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -403,10 +403,9 @@ void IElementRenderer::preDrawSurface(WP<CSurfacePassElement> element, const CRe
     // add async (dmabuf) buffers to usedBuffers so we can handle release later
     // sync (shm) buffers will be released in commitState, so no need to track them here.
     if (element->m_data.surface->m_current.buffer && !element->m_data.surface->m_current.buffer->isSynchronous() &&
-        std::ranges::none_of(g_pHyprRenderer->m_usedAsyncBuffers, [&](const auto& e) {
-            return e.first == element->m_data.pMonitor && e.second.first == element->m_data.surface && e.second.second == element->m_data.surface->m_current.buffer;
-        }))
-        g_pHyprRenderer->m_usedAsyncBuffers.emplace_back(element->m_data.pMonitor, std::make_pair(element->m_data.surface, element->m_data.surface->m_current.buffer));
+        std::ranges::none_of(element->m_data.pMonitor->m_usedAsyncBuffers,
+                             [&](const auto& e) { return e.first == element->m_data.surface && e.second == element->m_data.surface->m_current.buffer; }))
+        element->m_data.pMonitor->m_usedAsyncBuffers.emplace_back(element->m_data.surface, element->m_data.surface->m_current.buffer);
 
     m_renderData.clipBox            = {};
     m_renderData.useNearestNeighbor = false;

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -117,7 +117,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
         else
             glFlush(); // mark an implicit sync point
 
-        m_usedAsyncBuffers.clear(); // release all buffer refs and hope implicit sync works
+        PMONITOR->m_usedAsyncBuffers.clear(); // release all buffer refs and hope implicit sync works
         if (renderingDoneCallback)
             renderingDoneCallback();
 
@@ -126,32 +126,25 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
 
     auto eglSync = createSyncFDManager();
     if LIKELY (eglSync && eglSync->isValid()) {
-        std::vector<CHLBufferReference> bufs;
-        for (auto& buf : m_usedAsyncBuffers) {
-            if (buf.first.expired() || buf.second.first.expired()) // monitor or surface is gone.
+        for (auto& buf : PMONITOR->m_usedAsyncBuffers) {
+            if (buf.first.expired()) // surface is gone.
                 continue;
 
-            if (buf.first != PMONITOR)
-                continue;
-
-            for (const auto& releaser : buf.second.second->m_syncReleasers) {
+            for (const auto& releaser : buf.second->m_syncReleasers) {
                 releaser->addSyncFileFd(eglSync->fd());
             }
-
-            bufs.emplace_back(std::move(buf.second.second));
         }
 
         // release buffer refs with release points now, since syncReleaser handles actual buffer release based on EGLSync
-        std::erase_if(m_usedAsyncBuffers, [](const auto& buf) { return buf.first.expired() || buf.second.first.expired() || !buf.second.second; });
-        std::erase_if(bufs, [](const auto& buf) { return !buf->m_syncReleasers.empty(); });
+        std::erase_if(PMONITOR->m_usedAsyncBuffers, [](const auto& buf) { return buf.first.expired() || !buf.second->m_syncReleasers.empty(); });
 
         // release buffer refs without release points when EGLSync sync_file/fence is signalled
-        g_pEventLoopManager->doOnReadable(eglSync->fd().duplicate(), [renderingDoneCallback, prevbfs = std::move(bufs)]() mutable {
+        g_pEventLoopManager->doOnReadable(eglSync->fd().duplicate(), [renderingDoneCallback, prevbfs = std::move(PMONITOR->m_usedAsyncBuffers)]() mutable {
             prevbfs.clear();
             if (renderingDoneCallback)
                 renderingDoneCallback();
         });
-        m_usedAsyncBuffers.clear();
+        PMONITOR->m_usedAsyncBuffers.clear();
 
         if (m_renderMode == RENDER_MODE_NORMAL) {
             PMONITOR->m_inFence = eglSync->takeFd();
@@ -168,7 +161,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
             PMONITOR->m_output->state->resetExplicitFences();
         }
 
-        m_usedAsyncBuffers.clear();
+        PMONITOR->m_usedAsyncBuffers.clear();
         if (renderingDoneCallback)
             renderingDoneCallback();
     }

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -126,17 +126,27 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
 
     auto eglSync = createSyncFDManager();
     if LIKELY (eglSync && eglSync->isValid()) {
-        for (auto const& buf : m_usedAsyncBuffers) {
-            for (const auto& releaser : buf->m_syncReleasers) {
+        std::vector<CHLBufferReference> bufs;
+        for (auto& buf : m_usedAsyncBuffers) {
+            if (buf.first.expired() || buf.second.first.expired()) // monitor or surface is gone.
+                continue;
+
+            if (buf.first != PMONITOR)
+                continue;
+
+            for (const auto& releaser : buf.second.second->m_syncReleasers) {
                 releaser->addSyncFileFd(eglSync->fd());
             }
+
+            bufs.emplace_back(std::move(buf.second.second));
         }
 
         // release buffer refs with release points now, since syncReleaser handles actual buffer release based on EGLSync
-        std::erase_if(m_usedAsyncBuffers, [](const auto& buf) { return !buf->m_syncReleasers.empty(); });
+        std::erase_if(m_usedAsyncBuffers, [](const auto& buf) { return buf.first.expired() || buf.second.first.expired() || !buf.second.second; });
+        std::erase_if(bufs, [](const auto& buf) { return !buf->m_syncReleasers.empty(); });
 
         // release buffer refs without release points when EGLSync sync_file/fence is signalled
-        g_pEventLoopManager->doOnReadable(eglSync->fd().duplicate(), [renderingDoneCallback, prevbfs = std::move(m_usedAsyncBuffers)]() mutable {
+        g_pEventLoopManager->doOnReadable(eglSync->fd().duplicate(), [renderingDoneCallback, prevbfs = std::move(bufs)]() mutable {
             prevbfs.clear();
             if (renderingDoneCallback)
                 renderingDoneCallback();

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -123,8 +123,6 @@ namespace Render {
         wl_event_source*                    m_crashingLoop       = nullptr;
         wl_event_source*                    m_cursorTicker       = nullptr;
 
-        std::vector<std::pair<PHLMONITORREF, std::pair<WP<CWLSurfaceResource>, CHLBufferReference>>> m_usedAsyncBuffers;
-
         struct {
             int                                          hotspotX      = 0;
             int                                          hotspotY      = 0;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -7,6 +7,8 @@
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <list>
 #include <optional>
+#include <vector>
+#include <utility>
 #include "OpenGL.hpp"
 #include "./SyncFDManager.hpp"
 #include "./pass/Pass.hpp"
@@ -121,7 +123,7 @@ namespace Render {
         wl_event_source*                    m_crashingLoop       = nullptr;
         wl_event_source*                    m_cursorTicker       = nullptr;
 
-        std::vector<CHLBufferReference>     m_usedAsyncBuffers;
+        std::vector<std::pair<PHLMONITORREF, std::pair<WP<CWLSurfaceResource>, CHLBufferReference>>> m_usedAsyncBuffers;
 
         struct {
             int                                          hotspotX      = 0;


### PR DESCRIPTION
not only does snapshots, hit endRender and add the buffer to
m_usedAsyncBuffers but the first real frame does it too, we might have duplicate
buffers added pointing to the same IHLBuffer and fences merging with themself.
so use a std::pair inside the vector to ensure uniquness

this also means we can skip buffers for surfaces that has expired. when
adding fences.


and move buffers per monitor, if they are visible on both a surface pass is added per monitor not per renderer.
might require some testing so a stale buffer now isnt held forever referenced on some weird enabe/disable/dpms combination.


