### PR TITLE
pointerwarp: send mouse frame event after motion

### DIFF
--- a/src/protocols/PointerWarp.cpp
+++ b/src/protocols/PointerWarp.cpp
@@ -75,6 +75,7 @@ void CPointerWarpProtocol::bindManager(wl_client* client, void* data, uint32_t v
 
         Pointer::mgr()->warpTo(GLOBALPOS);
         g_pSeatManager->sendPointerMotion(Time::millis(Time::steadyNow()), LOCALPOS);
+        g_pSeatManager->sendPointerFrame();
     });
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a missing pointer frame after the motion from a pointer-warp-v1 pointer warp.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Same thing as https://github.com/hyprwm/Hyprland/pull/15003

#### Is it ready for merging, or does it need work?
Ready