### PR TITLE
opengl: get rid of VAO stalls once and for all.

### DIFF
--- a/src/output/DamageRing.cpp
+++ b/src/output/DamageRing.cpp
@@ -1,6 +1,9 @@
 #include "DamageRing.hpp"
 
+#include <hyprutils/memory/Casts.hpp>
+
 using namespace Monitor;
+using namespace Hyprutils::Memory;
 
 void CDamageRing::setSize(const Vector2D& size_) {
     if (size_ == m_size)
@@ -56,8 +59,17 @@ CRegion CDamageRing::getBufferDamage(int age) {
     }
 
     // don't return a ludicrous amount of rects
-    if (pixman_region32_n_rects(damage.pixman()) > 8)
-        return damage.getExtents();
+    if (pixman_region32_n_rects(damage.pixman()) > DAMAGE_RING_MAX_RECTS) {
+        const auto EXTENTS = damage.getExtents();
+
+        // but only when the bounding box is not much bigger than the rects it replaces.
+        // scattered damage would otherwise shade most of the screen to save a few draws.
+        double rectsArea = 0;
+        damage.forEachRect([&rectsArea](const auto& RECT) { rectsArea += sc<double>(RECT.x2 - RECT.x1) * (RECT.y2 - RECT.y1); });
+
+        if (EXTENTS.w * EXTENTS.h <= rectsArea * DAMAGE_RING_EXTENTS_FACTOR)
+            return EXTENTS;
+    }
 
     return damage;
 }

--- a/src/output/DamageRing.hpp
+++ b/src/output/DamageRing.hpp
@@ -4,7 +4,9 @@
 #include <array>
 
 namespace Monitor {
-    constexpr static int DAMAGE_RING_PREVIOUS_LEN = 3;
+    constexpr static int   DAMAGE_RING_PREVIOUS_LEN   = 3;
+    constexpr static int   DAMAGE_RING_MAX_RECTS      = 8;
+    constexpr static float DAMAGE_RING_EXTENTS_FACTOR = 2.F;
 
     class CDamageRing {
       public:

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1540,36 +1540,35 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
-    GLCALL(glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO)));
+    const bool  CUSTOMUV   = data.allowCustomUV && data.primarySurfaceUVTopLeft != Vector2D(-1, -1);
+    const GLint CUSTOM_VAO = shader->getUniformLocation(SHADER_SHADER_UV_VAO);
 
-    const bool CUSTOMUV = data.allowCustomUV && data.primarySurfaceUVTopLeft != Vector2D(-1, -1);
-    if (CUSTOMUV || shader->usesCustomUV()) {
-        GLCALL(glBindBuffer(GL_ARRAY_BUFFER, shader->getUniformLocation(SHADER_SHADER_VBO)));
+    if (CUSTOMUV && CUSTOM_VAO) {
+        GLCALL(glBindVertexArray(CUSTOM_VAO));
+        GLCALL(glBindBuffer(GL_ARRAY_BUFFER, shader->getUniformLocation(SHADER_SHADER_UV_VBO)));
 
-        // Keep the old block available to previous draws while custom UVs update, or while restoring the defaults.
+        // Keep the old block available to previous draws while custom UVs update.
         glBufferData(GL_ARRAY_BUFFER, sizeof(fullVerts), nullptr, GL_DYNAMIC_DRAW);
 
-        auto verts = fullVerts;
+        auto        verts = fullVerts;
 
-        if (CUSTOMUV) {
-            const float u0 = data.primarySurfaceUVTopLeft.x;
-            const float v0 = data.primarySurfaceUVTopLeft.y;
-            const float u1 = data.primarySurfaceUVBottomRight.x;
-            const float v1 = data.primarySurfaceUVBottomRight.y;
+        const float u0 = data.primarySurfaceUVTopLeft.x;
+        const float v0 = data.primarySurfaceUVTopLeft.y;
+        const float u1 = data.primarySurfaceUVBottomRight.x;
+        const float v1 = data.primarySurfaceUVBottomRight.y;
 
-            verts[0].u = u0;
-            verts[0].v = v0;
-            verts[1].u = u0;
-            verts[1].v = v1;
-            verts[2].u = u1;
-            verts[2].v = v0;
-            verts[3].u = u1;
-            verts[3].v = v1;
-        }
+        verts[0].u = u0;
+        verts[0].v = v0;
+        verts[1].u = u0;
+        verts[1].v = v1;
+        verts[2].u = u1;
+        verts[2].v = v0;
+        verts[3].u = u1;
+        verts[3].v = v1;
 
         glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(verts), verts.data());
-        shader->setUsesCustomUV(CUSTOMUV);
-    }
+    } else
+        GLCALL(glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO)));
 
     if (!g_pHyprRenderer->m_renderData.clipBox.empty() || !data.clipRegion.empty()) {
         CRegion damageClip = g_pHyprRenderer->m_renderData.clipBox;

--- a/src/render/Shader.cpp
+++ b/src/render/Shader.cpp
@@ -167,8 +167,9 @@ void CShader::getUniformLocations() {
     m_uniformLocations[SHADER_DISCARD_ALPHA_VALUE]    = getUniform("discardAlphaValue");
     /* set in createVao
         m_uniformLocations[SHADER_SHADER_VAO]
-        m_uniformLocations[SHADER_SHADER_VBO_POS]
-        m_uniformLocations[SHADER_SHADER_VBO_UV]
+        m_uniformLocations[SHADER_SHADER_VBO]
+        m_uniformLocations[SHADER_SHADER_UV_VAO]
+        m_uniformLocations[SHADER_SHADER_UV_VBO]
         */
     m_uniformLocations[SHADER_TOP_LEFT]            = getUniform("topLeft");
     m_uniformLocations[SHADER_BOTTOM_RIGHT]        = getUniform("bottomRight");
@@ -226,7 +227,7 @@ void CShader::getUniformLocations() {
 }
 
 void CShader::createVao() {
-    GLuint shaderVao = 0, shaderVbo = 0;
+    GLuint shaderVao = 0, shaderVbo = 0, shaderUvVao = 0, shaderUvVbo = 0;
 
     glGenVertexArrays(1, &shaderVao);
     glBindVertexArray(shaderVao);
@@ -234,14 +235,28 @@ void CShader::createVao() {
     if (m_uniformLocations[SHADER_POS_ATTRIB] != -1) {
         glGenBuffers(1, &shaderVbo);
         glBindBuffer(GL_ARRAY_BUFFER, shaderVbo);
-        glBufferData(GL_ARRAY_BUFFER, sizeof(fullVerts), fullVerts.data(), GL_DYNAMIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(fullVerts), fullVerts.data(), GL_STATIC_DRAW);
         glEnableVertexAttribArray(m_uniformLocations[SHADER_POS_ATTRIB]);
         glVertexAttribPointer(m_uniformLocations[SHADER_POS_ATTRIB], 2, GL_FLOAT, GL_FALSE, sizeof(SVertex), (void*)offsetof(SVertex, x));
     }
 
-    // UV VBO (dynamic, may be updated per frame)
+    // UV VBO (static, default UVs never change)
     if (m_uniformLocations[SHADER_TEX_ATTRIB] != -1 && shaderVbo != 0) {
         glBindBuffer(GL_ARRAY_BUFFER, shaderVbo);
+        glEnableVertexAttribArray(m_uniformLocations[SHADER_TEX_ATTRIB]);
+        glVertexAttribPointer(m_uniformLocations[SHADER_TEX_ATTRIB], 2, GL_FLOAT, GL_FALSE, sizeof(SVertex), (void*)offsetof(SVertex, u));
+    }
+
+    // second, streamed pair, only bound by draws that override the UVs
+    if (m_uniformLocations[SHADER_TEX_ATTRIB] != -1 && shaderVbo != 0) {
+        glGenVertexArrays(1, &shaderUvVao);
+        glBindVertexArray(shaderUvVao);
+
+        glGenBuffers(1, &shaderUvVbo);
+        glBindBuffer(GL_ARRAY_BUFFER, shaderUvVbo);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(fullVerts), fullVerts.data(), GL_DYNAMIC_DRAW);
+        glEnableVertexAttribArray(m_uniformLocations[SHADER_POS_ATTRIB]);
+        glVertexAttribPointer(m_uniformLocations[SHADER_POS_ATTRIB], 2, GL_FLOAT, GL_FALSE, sizeof(SVertex), (void*)offsetof(SVertex, x));
         glEnableVertexAttribArray(m_uniformLocations[SHADER_TEX_ATTRIB]);
         glVertexAttribPointer(m_uniformLocations[SHADER_TEX_ATTRIB], 2, GL_FLOAT, GL_FALSE, sizeof(SVertex), (void*)offsetof(SVertex, u));
     }
@@ -249,12 +264,15 @@ void CShader::createVao() {
     glBindVertexArray(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-    m_uniformLocations[SHADER_SHADER_VAO] = shaderVao;
-    m_uniformLocations[SHADER_SHADER_VBO] = shaderVbo;
-    m_usesCustomUV                        = false;
+    m_uniformLocations[SHADER_SHADER_VAO]    = shaderVao;
+    m_uniformLocations[SHADER_SHADER_VBO]    = shaderVbo;
+    m_uniformLocations[SHADER_SHADER_UV_VAO] = shaderUvVao;
+    m_uniformLocations[SHADER_SHADER_UV_VBO] = shaderUvVbo;
 
     RASSERT(m_uniformLocations[SHADER_SHADER_VAO] >= 0, "SHADER_SHADER_VAO could not be created");
-    RASSERT(m_uniformLocations[SHADER_SHADER_VBO] >= 0, "SHADER_SHADER_VBO_POS could not be created");
+    RASSERT(m_uniformLocations[SHADER_SHADER_VBO] >= 0, "SHADER_SHADER_VBO could not be created");
+    RASSERT(m_uniformLocations[SHADER_SHADER_UV_VAO] >= 0, "SHADER_SHADER_UV_VAO could not be created");
+    RASSERT(m_uniformLocations[SHADER_SHADER_UV_VBO] >= 0, "SHADER_SHADER_UV_VBO could not be created");
 }
 
 void CShader::setUniformInt(eShaderUniform location, GLint v0) {
@@ -406,16 +424,24 @@ void CShader::destroy() {
     if (m_program == 0)
         return;
 
-    GLuint shaderVao, shaderVbo;
+    GLuint shaderVao, shaderVbo, shaderUvVao, shaderUvVbo;
 
-    shaderVao = m_uniformLocations[SHADER_SHADER_VAO] == -1 ? 0 : m_uniformLocations[SHADER_SHADER_VAO];
-    shaderVbo = m_uniformLocations[SHADER_SHADER_VBO] == -1 ? 0 : m_uniformLocations[SHADER_SHADER_VBO];
+    shaderVao   = m_uniformLocations[SHADER_SHADER_VAO] == -1 ? 0 : m_uniformLocations[SHADER_SHADER_VAO];
+    shaderVbo   = m_uniformLocations[SHADER_SHADER_VBO] == -1 ? 0 : m_uniformLocations[SHADER_SHADER_VBO];
+    shaderUvVao = m_uniformLocations[SHADER_SHADER_UV_VAO] == -1 ? 0 : m_uniformLocations[SHADER_SHADER_UV_VAO];
+    shaderUvVbo = m_uniformLocations[SHADER_SHADER_UV_VBO] == -1 ? 0 : m_uniformLocations[SHADER_SHADER_UV_VBO];
 
     if (shaderVao)
         glDeleteVertexArrays(1, &shaderVao);
 
     if (shaderVbo)
         glDeleteBuffers(1, &shaderVbo);
+
+    if (shaderUvVao)
+        glDeleteVertexArrays(1, &shaderUvVao);
+
+    if (shaderUvVbo)
+        glDeleteBuffers(1, &shaderUvVbo);
 
     glDeleteProgram(m_program);
     m_program = 0;
@@ -435,12 +461,4 @@ int CShader::getInitialTime() const {
 
 void CShader::setInitialTime(int time) {
     m_initialTime = time;
-}
-
-bool CShader::usesCustomUV() const {
-    return m_usesCustomUV;
-}
-
-void CShader::setUsesCustomUV(bool usesCustomUV) {
-    m_usesCustomUV = usesCustomUV;
 }

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -32,6 +32,8 @@ enum eShaderUniform : uint8_t {
     SHADER_DISCARD_ALPHA_VALUE,
     SHADER_SHADER_VAO,
     SHADER_SHADER_VBO,
+    SHADER_SHADER_UV_VAO,
+    SHADER_SHADER_UV_VBO,
     SHADER_TOP_LEFT,
     SHADER_BOTTOM_RIGHT,
     SHADER_WINDOW_TOP_LEFT,
@@ -115,13 +117,10 @@ class CShader {
     GLint  getUniformLocation(eShaderUniform location) const;
     int    getInitialTime() const;
     void   setInitialTime(int time);
-    bool   usesCustomUV() const;
-    void   setUsesCustomUV(bool usesCustomUV);
 
   private:
-    GLuint                         m_program      = 0;
-    float                          m_initialTime  = 0;
-    bool                           m_usesCustomUV = false;
+    GLuint                         m_program     = 0;
+    float                          m_initialTime = 0;
     std::array<GLint, SHADER_LAST> m_uniformLocations;
 
     struct SUniformMatrix3Data {


### PR DESCRIPTION
so ive been eyeballing these VAO's since 1 year back now, read specs, manuals ideas on how to not hit a stutter when "if we render a new texture before the previous was done gpu wise its going to stall" i tried orphaning the data https://github.com/hyprwm/Hyprland/pull/12992/changes/52f9126c4da5f76ad537f70a4419c42584ee2c9d , i fiddled with various ideas. while the solution has been staring us in the face all the time. the cost is a few bytes of unused VAO on shaders that dont use it. just add one more!

sometimes you have to make the spaghetti before the sauce can be made...

at the same time the damage ring getextents could use some love aswell. the idea to reduce draw calls if many small rects is fine, however if they are scattered it means full size damage for 8 small blinking dots. so just add an DAMAGE_RING_EXTENTS_FACTOR check if the bounding box is at most 2 times their size. and then we trade a few more draw calls for way less damage size.
