### PR TITLE
re-add groupbar positional dragging

### DIFF
--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -420,16 +420,26 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     static auto PDRAGINTOGROUP                   = CConfigValue<Config::INTEGER>("group:drag_into_group");
     static auto PMERGEFLOATEDINTOTILEDONGROUPBAR = CConfigValue<Config::INTEGER>("group:merge_floated_into_tiled_on_groupbar");
     static auto PMERGEGROUPSONGROUPBAR           = CConfigValue<Config::INTEGER>("group:merge_groups_on_groupbar");
+    static auto PSTACKED                         = CConfigValue<Config::INTEGER>("group:groupbar:stacked");
+    static auto POUTERGAP                        = CConfigValue<Config::INTEGER>("group:groupbar:gaps_out");
+    static auto PINNERGAP                        = CConfigValue<Config::INTEGER>("group:groupbar:gaps_in");
     const bool  FLOATEDINTOTILED                 = !m_window->m_isFloating && !g_layoutManager->dragController()->draggingTiled();
 
     if (!pDraggedWindow->canBeGroupedInto(m_window->m_group) || (*PDRAGINTOGROUP != 1 && *PDRAGINTOGROUP != 2) || (FLOATEDINTOTILED && !*PMERGEFLOATEDINTOTILEDONGROUPBAR) ||
         (!*PMERGEGROUPSONGROUPBAR && pDraggedWindow->m_group))
         return false;
 
-    m_window->m_group->add(pDraggedWindow);
+    const float BARRELATIVE = *PSTACKED ? pos.y - assignedBoxGlobal().y - (m_barHeight + *POUTERGAP) / 2 : pos.x - assignedBoxGlobal().x - m_barWidth / 2;
+    const float BARSIZE     = *PSTACKED ? m_barHeight + *POUTERGAP : m_barWidth + *PINNERGAP;
+    const int   WINDOWINDEX = (BARRELATIVE < 0 ? -1 : BARRELATIVE / BARSIZE) + 1;
 
-    if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR))
+    m_window->m_group->add(pDraggedWindow, WINDOWINDEX);
+
+    if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR)) {
         pDraggedWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pDraggedWindow));
+    }
+
+    Desktop::focusState()->fullWindowFocus(pDraggedWindow->m_target->window(), Desktop::FOCUS_REASON_DESKTOP_STATE_CHANGE);
 
     return true;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -435,9 +435,8 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
 
     m_window->m_group->add(pDraggedWindow, WINDOWINDEX);
 
-    if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR)) {
+    if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR))
         pDraggedWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pDraggedWindow));
-    }
 
     Desktop::focusState()->fullWindowFocus(pDraggedWindow->m_target->window(), Desktop::FOCUS_REASON_DESKTOP_STATE_CHANGE);
 


### PR DESCRIPTION
Adds back positional groupbar dragging removed by 723870337f299d4c80aa0048144f3a1ca1c885bd.
No issues in my testing.
Automated test case would be nice, but not sure mouse emulation is easily doable.