### PR TITLE
config/lua: do not nuke package.path

### DIFF
--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -535,7 +535,14 @@ void CConfigManager::reinitLuaState() {
     std::filesystem::path configDir = std::filesystem::path(m_mainConfigPath).parent_path();
     const std::string     luaPath   = (configDir / "?.lua").string() + ";" + (configDir / "?/init.lua").string();
     lua_getglobal(m_lua, "package");
-    lua_pushstring(m_lua, luaPath.c_str());
+    lua_getfield(m_lua, -1, "path");
+    std::string combinedLuaPath = luaPath;
+    if (const auto* originalLuaPath = lua_tostring(m_lua, -1); originalLuaPath && *originalLuaPath) {
+        combinedLuaPath += ';';
+        combinedLuaPath += originalLuaPath;
+    }
+    lua_pop(m_lua, 1);
+    lua_pushlstring(m_lua, combinedLuaPath.data(), combinedLuaPath.size());
     lua_setfield(m_lua, -2, "path");
     lua_pop(m_lua, 1);
 

--- a/tests/config/lua/LuaBindingsInternal.cpp
+++ b/tests/config/lua/LuaBindingsInternal.cpp
@@ -127,6 +127,18 @@ namespace {
         return path.lexically_normal().string();
     }
 
+    std::string packagePath(lua_State* L) {
+        lua_getglobal(L, "package");
+        lua_getfield(L, -1, "path");
+
+        std::string path;
+        if (const auto* value = lua_tostring(L, -1); value)
+            path = value;
+
+        lua_pop(L, 2);
+        return path;
+    }
+
     void expectTracked(CConfigManager& mgr, const std::filesystem::path& path) {
         const auto& paths = mgr.getConfigPaths();
         EXPECT_NE(std::ranges::find(paths, normalizedPath(path)), paths.end());
@@ -459,4 +471,21 @@ TEST(ConfigLuaRequire, normalModuleRequireStillUsesConfigDirectoryPackagePath) {
     lua_pop(L, 1);
 
     expectTracked(mgr, module);
+}
+
+TEST(ConfigLuaRequire, packagePathPreservesLuaDefaultsAfterConfigDirectory) {
+    CScopedCompositor compositor;
+    CLuaState         defaultState;
+    CTempDir          tmp;
+    const auto        mainConfig = tmp.path() / "hyprland.lua";
+    writeFile(mainConfig, "");
+
+    const auto defaultPath = packagePath(defaultState.get());
+    ASSERT_FALSE(defaultPath.empty());
+
+    CConfigManager mgr;
+    CConfigManagerPluginLuaTestAccessor::initializeOwnedLuaState(mgr, mainConfig);
+
+    const auto configPath = (tmp.path() / "?.lua").string() + ";" + (tmp.path() / "?/init.lua").string();
+    EXPECT_EQ(packagePath(CConfigManagerPluginLuaTestAccessor::luaState(mgr)), configPath + ";" + defaultPath);
 }


### PR DESCRIPTION
Don't nuke path, let it be.

cpath isnt modified by us I think, so idk if naything's to be done there