### PR TITLE
Don't round/truncate `hyprctl monitors` scale

### DIFF
--- a/src/ipc/s1/Commands.cpp
+++ b/src/ipc/s1/Commands.cpp
@@ -228,7 +228,7 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
         "name": "{}"
     }},
     "reserved": [{}, {}, {}, {}],
-    "scale": {:.2f},
+    "scale": {},
     "transform": {},
     "focused": {},
     "dpmsStatus": {},
@@ -244,9 +244,9 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
     "mirrorOf": "{}",
     "availableModes": [{}],
     "colorManagementPreset": "{}",
-    "sdrBrightness": {:.2f},
-    "sdrSaturation": {:.2f},
-    "sdrMinLuminance": {:.2f},
+    "sdrBrightness": {},
+    "sdrSaturation": {},
+    "sdrMinLuminance": {},
     "sdrMaxLuminance": {},
     "hardwareCursorsInUse": {}
 }},)#",
@@ -267,11 +267,11 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
     } else {
         result += std::format(
             "Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tphysical size (mm): {}x{}\n\tserial: {}\n\tactive workspace: {} ({})\n\t"
-            "special workspace: {} ({})\n\treserved: {} {} {} {}\n\tscale: {:.2f}\n\ttransform: {}\n\tfocused: {}\n\t"
+            "special workspace: {} ({})\n\treserved: {} {} {} {}\n\tscale: {}\n\ttransform: {}\n\tfocused: {}\n\t"
             "dpmsStatus: {}\n\tvrr: {}\n\tsolitary: {:x}\n\tsolitaryBlockedBy: {}\n\tactivelyTearing: {}\n\ttearingBlockedBy: {}\n\tdirectScanoutTo: "
             "{:x}\n\tdirectScanoutBlockedBy: {}\n\tdisabled: "
             "{}\n\tcurrentFormat: {}\n\tmirrorOf: "
-            "{}\n\tavailableModes: {}\n\tcolorManagementPreset: {}\n\tsdrBrightness: {:.2f}\n\tsdrSaturation: {:.2f}\n\tsdrMinLuminance: {:.2f}\n\tsdrMaxLuminance: "
+            "{}\n\tavailableModes: {}\n\tcolorManagementPreset: {}\n\tsdrBrightness: {}\n\tsdrSaturation: {}\n\tsdrMinLuminance: {}\n\tsdrMaxLuminance: "
             "{}\n\thardwareCursorsInUse: {}\n\n",
             m->m_name, m->m_id, sc<int>(m->m_pixelSize.x), sc<int>(m->m_pixelSize.y), m->m_refreshRate, sc<int>(m->m_position.x), sc<int>(m->m_position.y), m->m_shortDescription,
             m->m_output->make, m->m_output->model, sc<int>(m->m_output->physicalSize.x), sc<int>(m->m_output->physicalSize.y), m->m_output->serial, m->activeWorkspaceID(),


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Scale is a precise number that may be read back by certain tools via `hyprctl monitors -j` so it's important to not lose any precision to avoid non-integer pixel counts when scaling certain display sizes.

e.g.

    3840 / 1.33333 = 2880

    1.33333 -> 1.33

    3840 / 1.33 = 2887.22 (!!!)

Fixes: https://github.com/hyprwm/Hyprland/discussions/15151

With this change
```
frebib@frebib-PC ~> /tmp/hyprland.REKqAxZn/build/hyprctl/hyprctl monitors -j | jq '.[0].scale'
1.875
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope

#### Is it ready for merging, or does it need work?

Ready

