### PR TITLE
config/lua: validate toggle actions

### DIFF
--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -312,14 +312,14 @@ Math::eDirection Internal::parseDirectionStr(const std::string& str) {
     return Math::DIRECTION_DEFAULT;
 }
 
-CA::eTogglableAction Internal::parseToggleStr(const std::string& str) {
+Internal::ToggleActionResult Internal::parseToggleStr(const std::string& str) {
     if (str.empty() || str == "toggle")
         return CA::TOGGLE_ACTION_TOGGLE;
     if (str == "enable" || str == "on")
         return CA::TOGGLE_ACTION_ENABLE;
     if (str == "disable" || str == "off")
         return CA::TOGGLE_ACTION_DISABLE;
-    return CA::TOGGLE_ACTION_TOGGLE;
+    return std::unexpected(std::format("invalid toggle action \"{}\" (expected toggle/on/off/enable/disable)", str));
 }
 
 std::optional<PHLWINDOW> Internal::windowFromUpval(lua_State* L, int idx) {
@@ -454,9 +454,27 @@ CA::eTogglableAction Internal::tableToggleAction(lua_State* L, int idx, const ch
     if (!lua_istable(L, idx))
         return CA::TOGGLE_ACTION_TOGGLE;
 
-    if (const auto action = tableOptStr(L, idx, field); action.has_value())
-        return parseToggleStr(*action);
+    idx = lua_absindex(L, idx);
+    lua_getfield(L, idx, field);
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 1);
+        return CA::TOGGLE_ACTION_TOGGLE;
+    }
 
+    if (lua_type(L, -1) != LUA_TSTRING) {
+        lua_pop(L, 1);
+        configError(L, std::format("toggle action '{}' must be a string", field));
+        return CA::TOGGLE_ACTION_TOGGLE;
+    }
+
+    const std::string action = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    const auto parsed = parseToggleStr(action);
+    if (parsed)
+        return *parsed;
+
+    configError(L, parsed.error());
     return CA::TOGGLE_ACTION_TOGGLE;
 }
 

--- a/src/config/lua/bindings/LuaBindingsInternal.hpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.hpp
@@ -20,6 +20,7 @@
 #include "../../../managers/KeybindManager.hpp"
 #include "../../shared/actions/ConfigActions.hpp"
 
+#include <expected>
 #include <functional>
 #include <optional>
 #include <format>
@@ -37,6 +38,8 @@ namespace Desktop::Rule {
 }
 
 namespace Config::Lua::Bindings::Internal {
+
+    using ToggleActionResult = std::expected<Config::Actions::eTogglableAction, std::string>;
 
     struct SWindowRuleEffectDesc {
         const char* name;
@@ -132,7 +135,7 @@ namespace Config::Lua::Bindings::Internal {
     std::string                                        requireTableFieldWindowSelector(lua_State* L, int idx, const char* field, const char* fnName);
 
     Math::eDirection                                   parseDirectionStr(const std::string& str);
-    Config::Actions::eTogglableAction                  parseToggleStr(const std::string& str);
+    ToggleActionResult                                 parseToggleStr(const std::string& str);
 
     std::optional<PHLWINDOW>                           windowFromUpval(lua_State* L, int idx);
     void                                               pushWindowUpval(lua_State* L, int tableIdx);

--- a/tests/config/lua/LuaBindingsInternal.cpp
+++ b/tests/config/lua/LuaBindingsInternal.cpp
@@ -158,12 +158,16 @@ TEST(ConfigLuaBindingsInternal, parseDirectionAliases) {
 }
 
 TEST(ConfigLuaBindingsInternal, parseToggleAliases) {
-    EXPECT_EQ(Internal::parseToggleStr(""), Config::Actions::TOGGLE_ACTION_TOGGLE);
-    EXPECT_EQ(Internal::parseToggleStr("toggle"), Config::Actions::TOGGLE_ACTION_TOGGLE);
-    EXPECT_EQ(Internal::parseToggleStr("enable"), Config::Actions::TOGGLE_ACTION_ENABLE);
-    EXPECT_EQ(Internal::parseToggleStr("on"), Config::Actions::TOGGLE_ACTION_ENABLE);
-    EXPECT_EQ(Internal::parseToggleStr("disable"), Config::Actions::TOGGLE_ACTION_DISABLE);
-    EXPECT_EQ(Internal::parseToggleStr("off"), Config::Actions::TOGGLE_ACTION_DISABLE);
+    EXPECT_EQ(Internal::parseToggleStr("").value(), Config::Actions::TOGGLE_ACTION_TOGGLE);
+    EXPECT_EQ(Internal::parseToggleStr("toggle").value(), Config::Actions::TOGGLE_ACTION_TOGGLE);
+    EXPECT_EQ(Internal::parseToggleStr("enable").value(), Config::Actions::TOGGLE_ACTION_ENABLE);
+    EXPECT_EQ(Internal::parseToggleStr("on").value(), Config::Actions::TOGGLE_ACTION_ENABLE);
+    EXPECT_EQ(Internal::parseToggleStr("disable").value(), Config::Actions::TOGGLE_ACTION_DISABLE);
+    EXPECT_EQ(Internal::parseToggleStr("off").value(), Config::Actions::TOGGLE_ACTION_DISABLE);
+
+    const auto invalid = Internal::parseToggleStr("enabel");
+    ASSERT_FALSE(invalid);
+    EXPECT_EQ(invalid.error(), "invalid toggle action \"enabel\" (expected toggle/on/off/enable/disable)");
 }
 
 TEST(ConfigLuaBindingsInternal, argStrConvertsStringsAndNumbers) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Invalid Lua toggle actions currently fall back to `toggle`, so `--verify-config` says `config ok` for typos like `action = "enabel"`. This reports invalid values and non-string actions as config errors instead.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The focused source and test objects compile, and the changed files pass clang-format. The full local test link hit an unrelated GCC/libstdc++ error in `std::ranges::starts_with`, so I left that to CI.

#### Is it ready for merging, or does it need work?

The change is ready; leaving the PR as a draft for CI and review.