### PR TITLE
screenshare: fix toplevel capture missing software cursor

### DIFF
--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -353,7 +353,7 @@ void CScreenshareFrame::renderWindow() {
 
     CRegion fakeDamage = {0, 0, INT16_MAX, INT16_MAX};
     Pointer::mgr()->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), NOW, fakeDamage,
-                                             g_pInputManager->getMouseCoordsInternal() - PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT), true);
+                                             g_pInputManager->getMouseCoordsInternal() - PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT), true, true);
 }
 
 void CScreenshareFrame::render() {

--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -638,7 +638,8 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
     return buf;
 }
 
-void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage, std::optional<Vector2D> overridePos, bool forceRender) {
+void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage, std::optional<Vector2D> overridePos, bool forceRender,
+                                               bool actuallyForceRender) {
     if (!hasCursor())
         return;
 
@@ -652,7 +653,8 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
 
     // don't render cursor if forced but we are already using sw cursors for the monitor
     // otherwise we draw the cursor again for screencopy when using sw cursors
-    if (forceRender && (state->hardwareFailed || state->softwareLocks != 0))
+    // unless this is toplevel capture and we *actually* have to force render cursors
+    if (forceRender && !actuallyForceRender && (state->hardwareFailed || state->softwareLocks != 0))
         return;
 
     auto box = state->box.copy();

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -56,7 +56,7 @@ namespace Pointer {
         bool hasVisibleHWCursor(PHLMONITOR pMonitor);
 
         void renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage /* logical */, std::optional<Vector2D> overridePos = {} /* monitor-local */,
-                                      bool forceRender = false);
+                                      bool forceRender = false, bool actuallyForceRender = false);
 
         // this is needed e.g. during screensharing where
         // the software cursors aren't locked during the cursor move, but they


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes software cursors missing from toplevel capture. The function that was supposed to be *forced* to draw cursors still failed when it thought forcing was unnecessary. It thought wrong, drawing cursor on toplevel capture is always necessary.

#15604

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It's kinda silly, but someone designed the first force flag to not always work, and I think they also have a point, what can you do...

#### Is it ready for merging, or does it need work?

Ready.
