### PR TITLE
Ensure input method popups are rendered above overlay layers

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1236,15 +1236,15 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     }
     renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
-    // Render IME popups
-    for (auto const& imep : g_pInputManager->m_relay.m_inputMethodPopups) {
-        renderIMEPopup(imep.get(), pMonitor, time);
-    }
-
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
         renderLayer(ls.lock(), pMonitor, time);
     }
     renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
+
+    // Render IME popups
+    for (auto const& imep : g_pInputManager->m_relay.m_inputMethodPopups) {
+        renderIMEPopup(imep.get(), pMonitor, time);
+    }
 
     for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
         for (auto const& ls : lsl) {


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Input method popups (such as candidate lists and preedit UI) are currently rendered below the `overlay` layer.

This causes incorrect behavior when an overlay layer surface is present. For example, desktop shells or other overlay-based UI components may cover the input method popup, making it impossible for users to see candidates or interact with the input method normally.

Input method popups are part of the text input interaction flow and should remain visible above UI elements that do not represent application content. Rendering them below the overlay layer breaks the expected behavior of Wayland input methods.

This change ensures that input method popups are always rendered above overlay layers.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

related:

https://github.com/noctalia-dev/noctalia/pull/3689

before:
<img width="1296" height="298" alt="20260729_114351" src="https://github.com/user-attachments/assets/6b04f050-5a8f-4946-85e6-72d518b069f6" />

after:
<img width="1328" height="352" alt="20260729_114421" src="https://github.com/user-attachments/assets/e45214c7-bb88-434d-b485-e06c7b33f6fb" />

#### Is it ready for merging, or does it need work?

ready
