### PR TITLE
ci: add MiniMax provider to the AI translation check workflow

### DIFF
--- a/.github/workflows/translation-ai-check.yml
+++ b/.github/workflows/translation-ai-check.yml
@@ -19,7 +19,12 @@ jobs:
     if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.pull_request != null && github.event.comment.user.login == 'vaxerski' && github.event.comment.body == 'ai, please recheck' ) }}
     runs-on: ubuntu-latest
     env:
-      OPENAI_MODEL: gpt-5-mini
+      # Chat completions base URL for the MiniMax provider. Defaults to the
+      # global endpoint; set the MINIMAX_BASE_URL repository variable to
+      # https://api.minimaxi.com/v1 to run the review through the CN region.
+      MINIMAX_BASE_URL: ${{ vars.MINIMAX_BASE_URL || 'https://api.minimax.io/v1' }}
+      # Review model. Defaults to MiniMax-M3; MiniMax-M2.7 is also supported.
+      MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL || 'MiniMax-M3' }}
       SYSTEM_PROMPT: |
         You are a programmer and a translator. Your job is to review the attached patch for adding translation to a piece of software and make sure the submitted translation is not malicious, and that it makes sense. If the translation is not malicious, and doesn't contain obvious grammatical mistakes, say "Translation check OK". Otherwise, say "Translation check not ok" and list bad entries.
         Examples of bad translations include obvious trolling (slurs, etc) or nonsense sentences. Meaningful improvements may be suggested, but if there are only minor improvements, just reply with "Translation check OK". Do not provide anything but the result and (if applicable) the bad entries or improvements.
@@ -88,19 +93,20 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
             --data @body.json
 
-      - name: Query OpenAI and post review
+      - name: Query the translation reviewer and post review
         if: steps.get_diff.outputs.too_long == 'false'
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ env.OPENAI_MODEL }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          MINIMAX_BASE_URL: ${{ env.MINIMAX_BASE_URL }}
+          MINIMAX_MODEL: ${{ env.MINIMAX_MODEL }}
           SYSTEM_PROMPT: ${{ env.SYSTEM_PROMPT }}
           AI_PROMPT: ${{ env.AI_PROMPT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          # Prepare OpenAI chat request payload (embed diff safely)
+          # Prepare the chat completion request payload (embed diff safely)
           jq -n \
-            --arg model "$OPENAI_MODEL" \
+            --arg model "$MINIMAX_MODEL" \
             --arg sys "$SYSTEM_PROMPT" \
             --arg prompt "$AI_PROMPT" \
             --rawfile diff pr.diff \
@@ -111,9 +117,9 @@ jobs:
               ]
             }' > payload.json
 
-          # Call OpenAI
-          curl -sS https://api.openai.com/v1/chat/completions \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
+          # Call the MiniMax chat completions endpoint
+          curl -sS "$MINIMAX_BASE_URL/chat/completions" \
+            -H "Authorization: Bearer $MINIMAX_API_KEY" \
             -H "Content-Type: application/json" \
             -d @payload.json > response.json
 


### PR DESCRIPTION
Reason: The AI translation check workflow had a hard-coded chat completions endpoint, model, and API key secret, so the MiniMax provider could not run the review through its global or CN endpoint.

## What changed

Added the MiniMax provider to `.github/workflows/translation-ai-check.yml`:

- The chat completions base URL is now configurable through the `MINIMAX_BASE_URL` repository variable. It defaults to the global endpoint `https://api.minimax.io/v1`; set it to `https://api.minimaxi.com/v1` to run the review through the CN region.
- The review model is configurable through the `MINIMAX_MODEL` repository variable, defaulting to `MiniMax-M3`. `MiniMax-M2.7` is also supported.
- The review step now authenticates with the `MINIMAX_API_KEY` secret and posts the request to `${MINIMAX_BASE_URL}/chat/completions`.

The request payload and the `.choices[0].message.content` response parsing are unchanged, so the existing `src/i18n/**` change gating, diff size guard, and PR comment posting keep working as before.

## Checks

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/translation-ai-check.yml'))"` — workflow YAML parses.
