### PR TITLE
opengl: invalidate depth too

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -849,7 +849,7 @@ void CHyprOpenGLImpl::end() {
         g_pHyprRenderer->m_renderData.pMonitor->resources()->forEachUnusedFB(
             [](const auto& fb) {
                 fb->bind();
-                GLFB(fb)->invalidate({GL_STENCIL_ATTACHMENT, GL_COLOR_ATTACHMENT0});
+                GLFB(fb)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT, GL_COLOR_ATTACHMENT0});
             },
             false);
     }
@@ -2133,7 +2133,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                               .primarySurfaceUVBottomRight = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight,
                           });
 
-    GLFB(g_pHyprRenderer->m_renderData.currentFB)->invalidate({GL_STENCIL_ATTACHMENT});
+    GLFB(g_pHyprRenderer->m_renderData.currentFB)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT});
     scissor(nullptr);
 }
 


### PR DESCRIPTION
previously we tried using stencil only GL_STENCIL_INDEX8 but some drivers just simply sucks and gave us incomplete framebuffers. so we are actually creating GL_DEPTH24_STENCIL8 but disabling the depth with glDisable(GL_DEPTH_TEST);

but this means we need to invalidate the depth too, even if we really didnt use it.

see : https://github.com/hyprwm/Hyprland/pull/13067


