### PR TITLE
desktop/rules: fix gaps_out rule overriding float_gaps

### DIFF
--- a/hyprtester/src/tests/main/workspaces.cpp
+++ b/hyprtester/src/tests/main/workspaces.cpp
@@ -1007,3 +1007,14 @@ TEST_CASE(luaGetWorkspace) {
     ASSERT(getFromSocket("r/repl hl.get_workspace('r+1')"), "nil");
     ASSERT(getFromSocket("r/repl hl.get_workspace(42)"), "nil");
 }
+
+TEST_CASE(workspacesDistinctTiledAndFloatGaps) {
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'name:workspacesDistinctTiledAndFloatGaps', gaps_out = 200, float_gaps = 10, no_border = true })"));
+    OK(getFromSocket("/eval hl.window_rule({ match = { workspace = 'name:workspacesDistinctTiledAndFloatGaps', class = 'workspacesDistinctTiledAndFloatGaps' }, float = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:workspacesDistinctTiledAndFloatGaps' })"));
+    ASSERT(!!Tests::spawnKitty(), true);
+    ASSERT(getFromSocket("r/repl hl.get_active_window().at.x == 200"), "true");
+    ASSERT(!!Tests::spawnKitty("workspacesDistinctTiledAndFloatGaps"), true);
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ direction = 'l' })"));
+    ASSERT(getFromSocket("r/repl hl.get_active_window().at.x == 10"), "true");
+}

--- a/src/config/shared/workspace/WorkspaceRule.hpp
+++ b/src/config/shared/workspace/WorkspaceRule.hpp
@@ -32,7 +32,7 @@ namespace Config {
         std::optional<bool>                m_isPersistent;
         std::optional<CCssGapData>         m_gapsIn;
         std::optional<CCssGapData>         m_gapsOut;
-        std::optional<CCssGapData>         m_floatGaps = m_gapsOut;
+        std::optional<CCssGapData>         m_floatGaps;
         std::optional<int64_t>             m_borderSize;
         std::optional<bool>                m_decorate;
         std::optional<bool>                m_noRounding;

--- a/src/layout/space/Space.cpp
+++ b/src/layout/space/Space.cpp
@@ -92,7 +92,7 @@ void CSpace::recheckWorkArea() {
         PFLOATGAPS = PGAPSOUT;
 
     auto                   gapsOut   = WORKSPACERULE.m_gapsOut.value_or(*PGAPSOUT);
-    auto                   gapsFloat = WORKSPACERULE.m_gapsOut.value_or(*PFLOATGAPS);
+    auto                   gapsFloat = WORKSPACERULE.m_floatGaps.value_or(*PFLOATGAPS);
 
     Desktop::CReservedArea reservedGaps{gapsOut.m_top, gapsOut.m_right, gapsOut.m_bottom, gapsOut.m_left};
     Desktop::CReservedArea reservedFloatGaps{gapsFloat.m_top, gapsFloat.m_right, gapsFloat.m_bottom, gapsFloat.m_left};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes `gaps_out` workspace rule also overriding `float_gaps` setting and workspace rule. This made it impossible to move *floating* windows outside *tiled* workarea, with keybinds or when using `float_force_onscreen`. And I guess fixes float_gaps rule in general...

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Clearly float_gaps is supposed to be a separate thing and gaps_out should not affect it.

#### Is it ready for merging, or does it need work?

Ready

