### PR TITLE
hyprctl(repl): support multiline interactive input

### DIFF
--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -37,6 +37,12 @@ using namespace Hyprutils::Memory;
 #include <readline/readline.h>
 #include <readline/history.h>
 
+#define LUA_ERRSYNTAX 3
+#define LUA_EOFMARK "<eof>"
+
+#define xstr(a) str(a)
+#define str(a) #a
+
 std::string instanceSignature;
 bool        quiet = false;
 
@@ -196,7 +202,7 @@ int rollingRead(const int socket) {
     return 0;
 }
 
-int request(std::string_view arg, int minArgs = 0, bool needRoll = false) {
+int request(std::string_view arg, int minArgs = 0, bool needRoll = false, bool isRepl = false) {
     const auto SERVERSOCKET = socket(AF_UNIX, SOCK_STREAM, 0);
 
     if (SERVERSOCKET < 0) {
@@ -270,7 +276,11 @@ int request(std::string_view arg, int minArgs = 0, bool needRoll = false) {
 
     close(SERVERSOCKET);
 
-    log(reply);
+    // lua interactive REPL: check for incomplete-line error
+    if (isRepl && reply.starts_with("error: " xstr(LUA_ERRSYNTAX) " ") && reply.ends_with(LUA_EOFMARK))
+        return 8;
+    else
+        log(reply);
 
     if (reply.starts_with("error:"))
         return 7;
@@ -563,11 +573,24 @@ int main(int argc, char** argv) {
         } else {
             // interactive REPL mode
             char* input = nullptr;
-            while ((input = readline("> ")) != nullptr) {
-                std::string line(input);
+            bool continuing = false;
+            std::string line;
+            while ((input = readline(continuing ? ">> " : "> ")) != nullptr) {
+                // extend line if incomplete, replace otherwise
+                if (continuing) {
+                    line.append("\n");
+                    line.append(input);
+                } else
+                    line.assign(input);
                 if (!line.empty()) {
-                    exitStatus = request(std::format("/repl {}", line));
-                    add_history(input);
+                    exitStatus = request(std::format("/repl {}", line), 0, false, true);
+                    // check for incomplete-line error, retry
+                    if (exitStatus == 8)
+                        continuing = true;
+                    else {
+                        continuing = false;
+                        add_history(input);
+                    }
                 }
                 free(input);
             }

--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -582,6 +582,7 @@ int main(int argc, char** argv) {
                     line.append(input);
                 } else
                     line.assign(input);
+                free(input);
                 if (!line.empty()) {
                     exitStatus = request(std::format("/repl {}", line), 0, false, true);
                     // check for incomplete-line error, retry
@@ -589,10 +590,9 @@ int main(int argc, char** argv) {
                         continuing = true;
                     else {
                         continuing = false;
-                        add_history(input);
+                        add_history(line.c_str());
                     }
                 }
-                free(input);
             }
         }
     } else {

--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -38,10 +38,10 @@ using namespace Hyprutils::Memory;
 #include <readline/history.h>
 
 #define LUA_ERRSYNTAX 3
-#define LUA_EOFMARK "<eof>"
+#define LUA_EOFMARK   "<eof>"
 
 #define xstr(a) str(a)
-#define str(a) #a
+#define str(a)  #a
 
 std::string instanceSignature;
 bool        quiet = false;
@@ -572,8 +572,8 @@ int main(int argc, char** argv) {
             exitStatus = request(fullRequest, 1);
         } else {
             // interactive REPL mode
-            char* input = nullptr;
-            bool continuing = false;
+            char*       input      = nullptr;
+            bool        continuing = false;
             std::string line;
             while ((input = readline(continuing ? ">> " : "> ")) != nullptr) {
                 // extend line if incomplete, replace otherwise

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -893,7 +893,8 @@ std::optional<std::string> CConfigManager::eval(const std::string& code, bool re
         m_isEvaluating = false;
         m_isREPL       = false;
     });
-    const auto errCode = luaL_loadstring(m_lua, code.starts_with("return") ? code.c_str() : std::format("return {};", code).c_str());
+
+    const auto                    errCode = luaL_loadstring(m_lua, code.starts_with("return") ? code.c_str() : std::format("return {};", code).c_str());
     if (errCode != LUA_OK) {
         lua_pop(m_lua, 1);
         if (luaL_loadstring(m_lua, code.c_str()) != LUA_OK) {

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -893,12 +893,13 @@ std::optional<std::string> CConfigManager::eval(const std::string& code, bool re
         m_isEvaluating = false;
         m_isREPL       = false;
     });
-    if (luaL_loadstring(m_lua, code.starts_with("return") ? code.c_str() : std::format("return {};", code).c_str()) != LUA_OK) {
+    const auto errCode = luaL_loadstring(m_lua, code.starts_with("return") ? code.c_str() : std::format("return {};", code).c_str());
+    if (errCode != LUA_OK) {
         lua_pop(m_lua, 1);
         if (luaL_loadstring(m_lua, code.c_str()) != LUA_OK) {
             std::string err = lua_tostring(m_lua, -1);
             lua_pop(m_lua, 1);
-            return std::format("error: {}", err);
+            return std::format("error: {} {}", errCode, err);
         }
     }
 

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -610,7 +610,7 @@ void CConfigManager::reinitLuaState() {
                 lua_pushvalue(L, lua_upvalueindex(1));
                 lua_insert(L, 1);
                 lua_call(L, nstack, LUA_MULTRET);
-            } else {
+            } else if (nstack > 0) {
                 std::string out;
                 for (int i = 1; i <= nstack; ++i) {
                     out += std::format("{}\t", luaL_tolstring(L, i, nullptr));


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
repl with a simple command (i.e. Lua code provided as a `hyprctl` arg) handles multiline input just fine already, but interactive mode doesn't. This PR uses the [Lua repl's own approach](https://github.com/lua/lua/blob/7579fc9d7ed90240487251dfb69168f8e64e9294/lua.c#L569-L582) of trying to execute, then letting the user continue if the exec attempt returns an "unexpected EOF"-type syntax error. It's a little clunky, but if it's fine for them, it should be fine for us.

This required changing the Lua config manager's `eval()` output format slightly. For example, if you try to evaluate `print(`:
```diff
-error: [string "print("]:1: unexpected symbol near <eof>
+error: 3 [string "print("]:1: unexpected symbol near <eof>
```

With the 3 there being the Lua error code for syntax. `hyprctl repl` checks for that, as well as the `<eof>` marker, which is the same logic as linked above.

In practice, this looks like:
```sh
$ build/hyprctl/hyprctl repl
> print(
>> "asdf"
>> )
asdf
>
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
That change to the eval error response could in theory break stuff that depends on parsing it, but I'd imagine very few tools do that. Also, if they have logic like "find closing bracket and parse after that," this change won't affect them.

No tests for this, but repl isn't really tested anywhere at the moment. How much do we care about that?

#### Is it ready for merging, or does it need work?
Ready