### PR TITLE
input-capture: implement the session destroy request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,7 @@ function(protocolnew protoPath protoName external)
            ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp
     COMMAND hyprwayland-scanner ${path}/${protoName}.xml
             ${CMAKE_SOURCE_DIR}/protocols/
+    DEPENDS ${path}/${protoName}.xml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(hyprland_lib PRIVATE protocols/${protoName}.cpp
                                   protocols/${protoName}.hpp)
@@ -521,6 +522,7 @@ function(protocolWayland)
     COMMAND
       hyprwayland-scanner --wayland-enums
       ${WAYLAND_SCANNER_PKGDATA_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
+    DEPENDS ${WAYLAND_SCANNER_PKGDATA_DIR}/wayland.xml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(hyprland_lib PRIVATE protocols/wayland.cpp protocols/wayland.hpp)
   target_sources(generate-protocol-headers
@@ -538,7 +540,7 @@ else()
   target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GLES3 glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV Threads::Threads)
 endif()
 
-pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.7.0)
+pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.8.0)
 if(hyprland_protocols_dep_FOUND)
   pkg_get_variable(HYPRLAND_PROTOCOLS hyprland-protocols pkgdatadir)
   message(STATUS "hyprland-protocols dependency set to ${HYPRLAND_PROTOCOLS}")

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -208,7 +208,7 @@ CProtocolManager::CProtocolManager() {
     PROTO::singlePixel         = makeUnique<CSinglePixelProtocol>(&wp_single_pixel_buffer_manager_v1_interface, 1, "SinglePixel");
     PROTO::securityContext     = makeUnique<CSecurityContextProtocol>(&wp_security_context_manager_v1_interface, 1, "SecurityContext");
     PROTO::ctm                 = makeUnique<CHyprlandCTMControlProtocol>(&hyprland_ctm_control_manager_v1_interface, 2, "CTMControl");
-    PROTO::inputCapture        = makeUnique<CInputCaptureProtocol>(&hyprland_input_capture_manager_v1_interface, 1, "InputCapture");
+    PROTO::inputCapture        = makeUnique<CInputCaptureProtocol>(&hyprland_input_capture_manager_v1_interface, 2, "InputCapture");
     PROTO::hyprlandSurface     = makeUnique<CHyprlandSurfaceProtocol>(&hyprland_surface_manager_v1_interface, 2, "HyprlandSurface");
     PROTO::contentType         = makeUnique<CContentTypeProtocol>(&wp_content_type_manager_v1_interface, 1, "ContentType");
     PROTO::xdgTag              = makeUnique<CXDGToplevelTagProtocol>(&xdg_toplevel_tag_manager_v1_interface, 1, "XDGTag");

--- a/src/protocols/InputCapture.cpp
+++ b/src/protocols/InputCapture.cpp
@@ -33,6 +33,7 @@ CInputCaptureResource::CInputCaptureResource(SP<CHyprlandInputCaptureV1> resourc
     Log::logger->log(Log::INFO, "[input-capture]({}) new session", m_sessionId.c_str());
 
     m_resource->setOnDestroy([this](CHyprlandInputCaptureV1* r) { PROTO::inputCapture->destroyResource(this); }); //Remove & free this session
+    m_resource->setDestroy([this](CHyprlandInputCaptureV1* r) { PROTO::inputCapture->destroyResource(this); });
 
     m_resource->setEnable([this](CHyprlandInputCaptureV1* r) { onEnable(); });
     m_resource->setAddBarrier(
@@ -80,9 +81,6 @@ CInputCaptureResource::~CInputCaptureResource() {
         g_pEventLoopManager->removeTimer(m_keyRepeatTimer);
         m_keyRepeatTimer.reset();
     }
-
-    if (m_status == CLIENT_STATUS_ACTIVATED)
-        PROTO::inputCapture->forceRelease();
 
     Log::logger->log(Log::INFO, "[input-capture]({}) session destroyed", m_sessionId.c_str());
     PROTO::inputCapture->clearBarriers(m_sessionId);
@@ -358,7 +356,11 @@ void CInputCaptureProtocol::onCreateSession(CHyprlandInputCaptureManagerV1* pMgr
 }
 
 void CInputCaptureProtocol::destroyResource(CInputCaptureResource* resource) {
-    std::erase_if(m_Sessions, [resource](const auto& other) { return other->m_sessionId == resource->m_sessionId; });
+    //`active` holds a strong ref, so the erase alone would not destroy the session
+    if (active && active.get() == resource)
+        forceRelease();
+
+    std::erase_if(m_Sessions, [resource](const auto& other) { return other.get() == resource; });
 }
 
 bool CInputCaptureProtocol::isCaptured() {
@@ -417,6 +419,7 @@ void CInputCaptureProtocol::forceRelease() {
         auto cpy = active; //Because deactivate will put active to nullptr
         cpy->deactivate();
         cpy->disable();
+        g_pHyprRenderer->ensureCursorRenderingMode();
     }
     release();
 }


### PR DESCRIPTION
This implements a destroy lifecycle on the compositor's InputCapture sessions.

Part 3 of 3 needed for hyprwm/xdg-desktop-portal-hyprland#419, leaking file descriptors
from InputCapture.
Needs hyprland-protocols ≥ 0.8.0 (<protocols PR link>).

Not visible in the diff:

- `active` is a strong `SP<>`, so the erase never dropped the last reference and
  `~CInputCaptureResource` couldn't run. Releasing first also fixes the pre-existing
  disconnect-while-capturing case.
- Doesn't fix the residual `+1.00/session`. Not the EIS client connection. It leaks the
  same with `ConnectToEIS` never called. Suspect is `eis_backend_fd_add_client()`'s fd
  never being closed after `sendEisFd()`, but ownership after send isn't clear to me.
  Can file separately.

Second commit makes `protocolnew()` depend on the XML it generates from; without it a
stale build tree keeps the old glue after a protocols bump and fails to build. Happy to
split out.

### Validation

`hyprland_gtests` 271/271. Built clean and installed all 3 PRs in an Arch VM as well as the latest main/master and then verified the leaking flow from hyprwm/xdg-desktop-portal-hyprland#419.

| | before | after |
|---|---|---|
| `eis-*.lock` | one per session, never freed | stays at 0 |
| compositor fds | +6/session | +1/session |
| teardown traffic | `disable` only | `destroy` only |
| protocol errors | none | none |

Object IDs get reused afterwards, so the resources are freed.

### Disclosure

Agent implemented and verified in VM, with oversight and review from me before publishing.
