### PR TITLE
layout/scrolling/fullscreen: minor improvements ontop of 15660

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -25,6 +25,7 @@
 #include <hyprutils/string/VarList.hpp>
 #include <hyprutils/string/ConstVarList.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
+#include <optional>
 
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
@@ -492,7 +493,7 @@ void SScrollingData::recalculate(bool forceInstant) {
         const auto& COL = columns[i];
         // Not necessarily covering
         const bool COL_HAS_FS_TARGET = COL->targetDatas.size() == 1 && COL->targetDatas.at(0)->target &&
-            algorithm->m_scrollingFullscreenHandler->getFullscreenModes(COL->targetDatas.at(0)->target.lock()).internal != Fullscreen::FSMODE_NONE;
+            algorithm->m_scrollingFullscreenHandler->isFullscreen(COL->targetDatas.at(0)->target.lock(), std::nullopt, std::nullopt);
 
         for (size_t j = 0; j < COL->targetDatas.size(); ++j) {
             const auto TDATA                      = COL->targetDatas[j];

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -25,7 +25,6 @@
 #include <hyprutils/string/VarList.hpp>
 #include <hyprutils/string/ConstVarList.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
-#include <optional>
 
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -475,7 +475,7 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
 
         const auto TARGET_FS_MODES = getFullscreenModes(TARGET);
 
-        if (TARGET_FS_MODES.internal == FSMODE_NONE && TARGET_FS_MODES.client == FSMODE_NONE) {
+        if (isFullscreen(TARGET, std::nullopt, std::nullopt) && TARGET_FS_MODES.client == FSMODE_NONE) {
             const auto NEXT = std::next(it);
             removeFsTarget(TARGET, true);
             it = NEXT;
@@ -487,11 +487,13 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
             const auto STDATA = m_scrollingAlgorithm->dataFor(TARGET, true);
             if (STDATA) {
                 const auto COL_DATA = m_scrollingAlgorithm->dataFor(TARGET, true)->column;
-                if (COL_DATA && TARGET_FS_MODES.internal != FSMODE_NONE && COL_DATA->targetDatas.size() != 1) {
+                if (COL_DATA && isFullscreen(TARGET, std::nullopt, std::nullopt) && COL_DATA->targetDatas.size() != 1) {
+                    // Empty the list now so the unFS operation has an updated tracked FS target list it can check
                     for (const auto& e : toInsert) {
                         m_fsTargets.emplace(e.first, e.second);
                     }
                     toInsert.clear();
+
                     controller()->setFullscreenMode(TARGET_WINDOW, FSMODE_NONE, std::nullopt, true);
                     if (getFullscreenModes(TARGET).internal != FSMODE_NONE)
                         removeFsTarget(TARGET, true);
@@ -514,7 +516,7 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
             continue;
         }
 
-        if (TARGET_FS_MODES.internal != FSMODE_NONE) {
+        if (isFullscreen(TARGET, std::nullopt, std::nullopt)) {
             m_scrollingAlgorithm->dataFor(TARGET, true)->column->setColumnWidth((TARGET_FS_MODES.internal == FSMODE_FULLSCREEN ? fullscreenColumnWidth() : 1.F));
             ++it;
             continue;

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -475,7 +475,7 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
 
         const auto TARGET_FS_MODES = getFullscreenModes(TARGET);
 
-        if (isFullscreen(TARGET, std::nullopt, std::nullopt) && TARGET_FS_MODES.client == FSMODE_NONE) {
+        if (!isFullscreen(TARGET, std::nullopt, std::nullopt) && TARGET_FS_MODES.client == FSMODE_NONE) {
             const auto NEXT = std::next(it);
             removeFsTarget(TARGET, true);
             it = NEXT;

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -487,7 +487,8 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
             const auto STDATA = m_scrollingAlgorithm->dataFor(TARGET, true);
             if (STDATA) {
                 const auto COL_DATA = m_scrollingAlgorithm->dataFor(TARGET, true)->column;
-                if (COL_DATA && isFullscreen(TARGET, std::nullopt, std::nullopt) && COL_DATA->targetDatas.size() != 1) {
+                // use TARGET_FS_MODES.internal != FSMODE_NONE here because isFullscreen() would catch that target isn't alone in col and return false
+                if (COL_DATA && TARGET_FS_MODES.internal != FSMODE_NONE && COL_DATA->targetDatas.size() != 1) {
                     // Empty the list now so the unFS operation has an updated tracked FS target list it can check
                     for (const auto& e : toInsert) {
                         m_fsTargets.emplace(e.first, e.second);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

These are very minor changes ontop of https://github.com/hyprwm/Hyprland/pull/15660

`isFullscreen()` includes additional checks specific to scrolling's def of FS target so it's better to use that instead of `getModes()` since while controller's `getModes()` includes `isFullscreen()` check if internal mode comes out as non `FSMODE_NONE`, handlers' `getModes()` is pure

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready

