### PR TITLE
popup: make popup snapshot render their own size

### DIFF
--- a/src/desktop/state/PopupFadeout.cpp
+++ b/src/desktop/state/PopupFadeout.cpp
@@ -21,15 +21,10 @@ static bool shouldBlurPopup() {
     return *PBLURPOPUPS && *PBLUR;
 }
 
-static void damageFadeoutMonitor(PHLMONITORREF monitor) {
-    if (const auto MONITOR = monitor.lock(); MONITOR)
-        g_pHyprRenderer->damageMonitor(MONITOR);
-}
-
-template <typename T>
-static void damageWeakFadeout(WP<T> fadeout) {
+// the snapshot is baked at the popup's global coords and doesn't move, so only its own box needs damage
+static void damageWeakFadeout(WP<CPopupFadeout> fadeout) {
     if (const auto FADEOUT = fadeout.lock(); FADEOUT)
-        damageFadeoutMonitor(FADEOUT->monitor());
+        g_pHyprRenderer->damageBox(FADEOUT->damageBox());
 }
 
 SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffer> snapshot, float sourceAlpha) {
@@ -40,9 +35,15 @@ SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffe
     if (!MONITOR)
         return nullptr;
 
-    auto fadeout           = SP<CPopupFadeout>(new CPopupFadeout());
+    const auto EXTENDS = popup->wlSurface()->resource()->extends();
+    const auto ORIGIN  = popup->coordsGlobal() + EXTENDS.pos();
+
+    auto       fadeout     = SP<CPopupFadeout>(new CPopupFadeout());
     fadeout->m_monitor     = MONITOR;
     fadeout->m_framebuffer = snapshot;
+    fadeout->m_damageBox   = CBox{ORIGIN, EXTENDS.size()}.expand(4);
+    // take the size from the FB so the snapshot maps 1:1 and doesn't get rescaled mid-fade
+    fadeout->m_renderBox = CBox{((ORIGIN - MONITOR->m_position) * MONITOR->m_scale).round(), snapshot->m_size};
 
     static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
     if (shouldBlurPopup()) {
@@ -81,8 +82,7 @@ int CPopupFadeout::zIndex() const {
 }
 
 CBox CPopupFadeout::renderBox() const {
-    const auto MONITOR = m_monitor.lock();
-    return MONITOR ? CBox{{}, MONITOR->m_transformedSize} : CBox{};
+    return m_renderBox;
 }
 
 float CPopupFadeout::alpha() const {
@@ -91,6 +91,10 @@ float CPopupFadeout::alpha() const {
 
 bool CPopupFadeout::done() const {
     return m_alpha->value() == 0.F && !m_alpha->isBeingAnimated();
+}
+
+const CBox& CPopupFadeout::damageBox() const {
+    return m_damageBox;
 }
 
 SFadeoutRenderEffects CPopupFadeout::effects() const {

--- a/src/desktop/state/PopupFadeout.hpp
+++ b/src/desktop/state/PopupFadeout.hpp
@@ -15,11 +15,15 @@ namespace Desktop {
         virtual bool                  done() const override;
         virtual SFadeoutRenderEffects effects() const override;
 
+        const CBox&                   damageBox() const;
+
       private:
         CPopupFadeout() = default;
 
         PHLMONITORREF     m_monitor;
         int               m_zIndex = 0;
         PHLANIMVAR<float> m_alpha;
+        CBox              m_damageBox;
+        CBox              m_renderBox;
     };
 }

--- a/src/helpers/math/Math.cpp
+++ b/src/helpers/math/Math.cpp
@@ -41,6 +41,10 @@ wl_output_transform Math::invertTransform(wl_output_transform tr) {
     return tr;
 }
 
+Vector2D Math::transformedSize(wl_output_transform tr, const Vector2D& size) {
+    return tr % 2 == 1 ? Vector2D{size.y, size.x} : size;
+}
+
 static bool matEq(const Mat3x3& a, const Mat3x3& b) {
     for (size_t i = 0; i < 9; ++i) {
         const float Δ = std::fabs(a.getMatrix()[i] - b.getMatrix()[i]);

--- a/src/helpers/math/Math.hpp
+++ b/src/helpers/math/Math.hpp
@@ -15,4 +15,5 @@ namespace Math {
     eTransform               wlTransformToHyprutils(wl_output_transform t);
     wl_output_transform      invertTransform(wl_output_transform tr);
     eTransform               composeTransform(eTransform a, eTransform b);
+    Vector2D                 transformedSize(wl_output_transform tr, const Vector2D& size);
 }

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -697,7 +697,7 @@ bool CMonitor::applyMonitorRuleSoft(Config::CMonitorRule&& pMonitorRule) {
         }
     }
 
-    Vector2D xfmd     = m_transform % 2 == 1 ? Vector2D{m_pixelSize.y, m_pixelSize.x} : m_pixelSize;
+    Vector2D xfmd     = Math::transformedSize(m_transform, m_pixelSize);
     m_size            = (xfmd / m_scale).round();
     m_transformedSize = xfmd;
 
@@ -1056,7 +1056,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule) {
     if (!m_state.commit())
         Log::logger->log(Log::ERR, "Couldn't commit output named {}", m_name);
 
-    Vector2D xfmd     = m_transform % 2 == 1 ? Vector2D{m_pixelSize.y, m_pixelSize.x} : m_pixelSize;
+    Vector2D xfmd     = Math::transformedSize(m_transform, m_pixelSize);
     m_size            = (xfmd / m_scale).round();
     m_transformedSize = xfmd;
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -153,7 +153,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
                 }
             }
 
-            Vector2D tfs   = m_pending.transform % 2 == 1 ? Vector2D{m_pending.bufferSize.y, m_pending.bufferSize.x} : m_pending.bufferSize;
+            Vector2D tfs   = Math::transformedSize(m_pending.transform, m_pending.bufferSize);
             m_pending.size = tfs / m_pending.scale;
         }
 

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -13,7 +13,7 @@ Vector2D SSurfaceState::sourceSize() {
     if UNLIKELY (viewport.hasSource)
         return viewport.source.size();
 
-    Vector2D trc = transform % 2 == 1 ? Vector2D{bufferSize.y, bufferSize.x} : bufferSize;
+    Vector2D trc = Math::transformedSize(transform, bufferSize);
     return trc / scale;
 }
 
@@ -32,7 +32,7 @@ CRegion SSurfaceState::accumulateBufferDamage() {
         if (viewport.hasSource)
             surfaceDamage.translate(viewport.source.pos());
 
-        Vector2D trc = transform % 2 == 1 ? Vector2D{bufferSize.y, bufferSize.x} : bufferSize;
+        Vector2D trc = Math::transformedSize(transform, bufferSize);
 
         bufferDamage = surfaceDamage.scale(scale).transform(Math::wlTransformToHyprutils(Math::invertTransform(transform)), trc.x, trc.y).add(bufferDamage);
         damage.clear();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1791,7 +1791,7 @@ static Mat3x3 getFBProjection(PHLMONITORREF pMonitor, const Vector2D& size) {
     if (pMonitor->m_transform == WL_OUTPUT_TRANSFORM_NORMAL)
         return Mat3x3::identity();
 
-    const Vector2D tfmd = pMonitor->m_transform % 2 == 1 ? Vector2D{size.y, size.x} : size;
+    const Vector2D tfmd = Math::transformedSize(pMonitor->m_transform, size);
     return Mat3x3::identity().translate(size / 2.0).transform(Math::wlTransformToHyprutils(pMonitor->m_transform)).translate(-tfmd / 2.0);
 }
 
@@ -3151,13 +3151,22 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
 
     Log::logger->log(Log::DEBUG, "renderer: making a snapshot of {:x}", rc<uintptr_t>(popup.get()));
 
-    CRegion    fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
+    // snapshot the popup's own extents, not the whole monitor
+    const auto SURFACE     = popup->wlSurface()->resource();
+    const auto EXTENDS     = SURFACE->extends();
+    const auto CONTENTSIZE = (EXTENDS.size() * PMONITOR->m_scale).round();
+
+    if (CONTENTSIZE.x < 1 || CONTENTSIZE.y < 1)
+        return nullptr;
+
+    CRegion    fakeDamage{0, 0, CONTENTSIZE.x, CONTENTSIZE.y};
 
     const auto PFRAMEBUFFER = createFB("popup shapshot");
 
-    PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
+    PFRAMEBUFFER->alloc(CONTENTSIZE.x, CONTENTSIZE.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
+    // beginFullFakeRender projects through the FB's own size, so the popup lands 1:1 in it
     beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
 
     m_bRenderingSnapshot = true;
@@ -3165,7 +3174,8 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
 
     CSurfacePassElement::SRenderData renderdata;
-    renderdata.pos             = popup->coordsGlobal();
+    // getTexBox adds -monitor pos, so this lands the extents origin at 0,0 in the FB
+    renderdata.pos             = PMONITOR->m_position - EXTENDS.pos();
     renderdata.alpha           = 1.F;
     renderdata.dontRound       = true; // don't round popups
     renderdata.pMonitor        = PMONITOR;
@@ -3173,7 +3183,7 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     renderdata.popup           = true;
     renderdata.blur            = false;
 
-    popup->wlSurface()->resource()->breadthfirst(
+    SURFACE->breadthfirst(
         [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;


### PR DESCRIPTION
instead of fullscreen snapshots and essentially full monitor blits on dual gpu setups, make snapshots snapshot their own size, and damage their own size. but this means we have to consider transformed monitors.

add a Math::transformedSize and replace all "PMONITOR->m_transform % 2 == 0 ?" uses with it.


