### PR TITLE
config: fix duplicate config value crash

### DIFF
--- a/src/config/ConfigValue.cpp
+++ b/src/config/ConfigValue.cpp
@@ -40,7 +40,6 @@ void CConfigValueBase::populateFromName() {
 
 void CConfigValueBase::bindInternal(const std::string& val) {
     m_valueName = val;
-    registry().push_back(this);
     populateFromName();
 }
 


### PR DESCRIPTION
the constructor, and destructor already add and remove from the registry() so bindInternal's push_back added duplicates, also invalidating the iterators causing a crash on hyprctl reload full-reset

fixes: https://github.com/hyprwm/Hyprland/discussions/15704


