### PR TITLE
protocols: relax vicinae-hotkey-v1 binding policy

### DIFF
--- a/protocols/vicinae-hotkey-v1.xml
+++ b/protocols/vicinae-hotkey-v1.xml
@@ -59,11 +59,20 @@
 
     A global hotkey lets an unfocused client observe that a specific key
     combination was pressed. Compositors are the security boundary and SHOULD
-    apply policy when deciding whether to accept a request. In particular,
-    implementations SHOULD reject combinations that do not include at least one
-    non-latching modifier among Ctrl, Alt or Super, unless the trigger is a
-    function key, because unmodified (and Shift-only) keys carry ordinary text
-    entry and grabbing them turns this protocol into a keylogger.
+    apply policy when deciding whether to accept a request. As a default, we
+    suggest the following pseudo-code:
+
+    fn acceptable(keysym, modifiers) {
+      if modifiers contains any of {ctrl, alt, super}:
+        return true   # modified combinations are always acceptable
+      if keysym is a keypad key:
+        return true   # commonly a dedicated macro cluster
+      if keysym is a dead key:
+        return false  # no character mapping, but composes text
+      if keysym has a character mapping:
+        return false  # letters, digits, punctuation, space, Enter, Tab, ...
+      return true     # purely functional: function, media, navigation keys, ...
+    }
 
     The protocol's one hard guarantee is containment: a compositor MUST NOT
     deliver events for a combination the client did not successfully bind, and
@@ -148,8 +157,9 @@
         that needs a trustworthy identity SHOULD obtain it through the
         security-context mechanism rather than relying on this string.
 
-        description is a human-readable, localized description of what the hotkey
-		  does (e.g. "Toggle the launcher"), for display in compositor UI or even in this protocol error messages.
+        description is a human-readable, localized description of what the
+        hotkey does (e.g. "Toggle the launcher"), for display in compositor UI
+        or even in this protocol's error messages.
       </description>
       <arg name="id" type="new_id" interface="vicinae_hotkey_v1"
            summary="the new hotkey object"/>

--- a/src/ipc/s1/Commands.cpp
+++ b/src/ipc/s1/Commands.cpp
@@ -39,6 +39,7 @@ using namespace Hyprutils::String;
 #include "../../devices/ITouch.hpp"
 #include "../../devices/Tablet.hpp"
 #include "../../protocols/GlobalShortcuts.hpp"
+#include "../../protocols/Hotkey.hpp"
 #include "../../config/ConfigManager.hpp"
 #include "../../helpers/MiscFunctions.hpp"
 #include "../../helpers/SystemInfo.hpp"
@@ -978,9 +979,13 @@ static std::string rollinglogRequest(eHyprCtlOutputFormat format, std::string re
 static std::string globalShortcutsRequest(eHyprCtlOutputFormat format, std::string request) {
     std::string ret       = "";
     const auto  SHORTCUTS = PROTO::globalShortcuts->getAllShortcuts();
+    const auto  HOTKEYS   = PROTO::hotkey->getAllHotkeys();
     if (format == eHyprCtlOutputFormat::FORMAT_NORMAL) {
         for (auto const& sh : SHORTCUTS) {
             ret += std::format("{}:{} -> {}\n", sh.appid, sh.id, sh.description);
+        }
+        for (auto const& hk : HOTKEYS) {
+            ret += std::format("{}:{} -> {}{}\n", hk.appid, hk.trigger, hk.description, hk.bound ? "" : " (inactive)");
         }
         if (ret.empty())
             ret = "none";
@@ -993,6 +998,18 @@ static std::string globalShortcutsRequest(eHyprCtlOutputFormat format, std::stri
     "description": "{}"
 }},)#",
                                escapeJSONStrings(std::format("{}:{}", sh.appid, sh.id)), escapeJSONStrings(sh.description));
+        }
+        for (auto const& hk : HOTKEYS) {
+            ret += std::format(R"#(
+{{
+    "name": "{}",
+    "description": "{}",
+    "appid": "{}",
+    "trigger": "{}",
+    "bound": {}
+}},)#",
+                               escapeJSONStrings(std::format("{}:{}", hk.appid, hk.trigger)), escapeJSONStrings(hk.description), escapeJSONStrings(hk.appid),
+                               escapeJSONStrings(hk.trigger), hk.bound ? "true" : "false");
         }
         trimTrailingComma(ret);
         ret += "]\n";

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -181,32 +181,6 @@ uint32_t CKeybindManager::keycodeToModifier(xkb_keycode_t keycode) {
     }
 }
 
-SP<SKeybind> CKeybindManager::findConflictingKeybind(xkb_keysym_t keysym, uint32_t modmask) {
-    if (keysym == XKB_KEY_NoSymbol)
-        return nullptr;
-
-    for (const auto& k : m_keybinds) {
-        if (!k->enabled || k->mouse)
-            continue;
-        if (!k->submap.name.empty())
-            continue;
-        if (k->modmask != modmask)
-            continue;
-
-        xkb_keysym_t bindSym = XKB_KEY_NoSymbol;
-        if (!k->key.empty())
-            bindSym = xkb_keysym_from_name(k->key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
-        else if (k->keycode != 0 && m_xkbTranslationState)
-            // "code:NN" binds store the xkb keycode
-            bindSym = xkb_state_key_get_one_sym(m_xkbTranslationState, k->keycode);
-
-        if (bindSym != XKB_KEY_NoSymbol && bindSym == keysym)
-            return k;
-    }
-
-    return nullptr;
-}
-
 void CKeybindManager::updateXKBTranslationState() {
     if (m_xkbTranslationState) {
         xkb_state_unref(m_xkbTranslationState);
@@ -300,8 +274,9 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
 
     const auto MODS = g_pInputManager->getModsFromAllKBs();
 
-    if (PROTO::hotkey && PROTO::hotkey->onKey(keysym, MODS, KEYCODE, e.state == WL_KEYBOARD_KEY_STATE_PRESSED, e.timeMs))
-        return false;
+    // hotkeys are not exclusive: compositor keybinds and every hotkey bound to the
+    // combination all fire, but a matched key never reaches the focused client
+    const bool hotkeyMatched = PROTO::hotkey && PROTO::hotkey->onKey(keysym, MODS, KEYCODE, e.state == WL_KEYBOARD_KEY_STATE_PRESSED, e.timeMs);
 
     Config::Actions::state()->m_timeLastMs    = e.timeMs;
     Config::Actions::state()->m_lastCode      = KEYCODE;
@@ -332,6 +307,8 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
         if (suppressEvent)
             shadowKeybinds(keysym, KEYCODE);
 
+        suppressEvent |= hotkeyMatched;
+
         m_pressedKeys.back().sent = !suppressEvent;
     } else { // key release
 
@@ -361,7 +338,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
         }
     }
 
-    return !suppressEvent && !mouseBindWasActive;
+    return !suppressEvent && !mouseBindWasActive && !hotkeyMatched;
 }
 
 bool CKeybindManager::onAxisEvent(const IPointer::SAxisEvent& e, SP<IPointer> pointer) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -274,8 +274,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
 
     const auto MODS = g_pInputManager->getModsFromAllKBs();
 
-    // hotkeys are not exclusive: compositor keybinds and every hotkey bound to the
-    // combination all fire, but a matched key never reaches the focused client
+    // non-exclusive: keybinds still run after a hotkey match, only the focused client is skipped
     const bool hotkeyMatched = PROTO::hotkey && PROTO::hotkey->onKey(keysym, MODS, KEYCODE, e.state == WL_KEYBOARD_KEY_STATE_PRESSED, e.timeMs);
 
     Config::Actions::state()->m_timeLastMs    = e.timeMs;

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -125,7 +125,6 @@ class CKeybindManager {
     void                      removeKeybind(const std::string& displayKeys);
     uint32_t                  stringToModMask(std::string);
     uint32_t                  keycodeToModifier(xkb_keycode_t);
-    SP<SKeybind>              findConflictingKeybind(xkb_keysym_t keysym, uint32_t modmask);
     void                      clearKeybinds();
     void                      shadowKeybinds(const xkb_keysym_t& doesntHave = 0, const uint32_t doesntHaveCode = 0);
     SSubmap                   getCurrentSubmap();

--- a/src/protocols/Hotkey.cpp
+++ b/src/protocols/Hotkey.cpp
@@ -1,8 +1,6 @@
 #include "Hotkey.hpp"
 #include "../Compositor.hpp"
 #include "../devices/IKeyboard.hpp"
-#include "../managers/KeybindManager.hpp"
-#include "../event/EventBus.hpp"
 
 #include <xkbcommon/xkbcommon-keysyms.h>
 #include <array>
@@ -53,14 +51,6 @@ static std::string triggerString(xkb_keysym_t sym, uint32_t modmask) {
     return out;
 }
 
-static std::string keybindLabel(const SP<SKeybind>& k) {
-    if (!k->description.empty())
-        return k->description;
-    if (!k->arg.empty())
-        return std::format("{}, {}", k->handler, k->arg);
-    return k->handler;
-}
-
 CVicinaeHotkeyManager::CVicinaeHotkeyManager(SP<CVicinaeHotkeyManagerV1> resource_) : m_resource(resource_) {
     if UNLIKELY (!good())
         return;
@@ -77,7 +67,7 @@ bool CVicinaeHotkeyManager::good() {
 }
 
 CHotkeyProtocol::CHotkeyProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
-    m_reloadListener = Event::bus()->m_events.config.reloaded.listen([this] { revokeConflicting(); });
+    ;
 }
 
 void CHotkeyProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
@@ -93,14 +83,6 @@ void CHotkeyProtocol::bindManager(wl_client* client, void* data, uint32_t ver, u
 void CHotkeyProtocol::destroyManager(CVicinaeHotkeyManager* mgr) {
     // hotkeys outlive their manager
     std::erase_if(m_managers, [&](const auto& other) { return other.get() == mgr; });
-}
-
-bool CHotkeyProtocol::comboTakenByHotkey(xkb_keysym_t keysym, uint32_t modmask) {
-    for (const auto& hk : m_hotkeys) {
-        if (hk->bound && hk->keysym == keysym && hk->modmask == modmask)
-            return true;
-    }
-    return false;
 }
 
 void CHotkeyProtocol::onBind(SP<CVicinaeHotkeyManagerV1> mgr, uint32_t id, xkb_keysym_t keysym, uint32_t protoMods, const char* appid, const char* description) {
@@ -130,17 +112,6 @@ void CHotkeyProtocol::onBind(SP<CVicinaeHotkeyManagerV1> mgr, uint32_t id, xkb_k
 
     if (!isValidTrigger(keysym, hk->modmask)) {
         hk->resource->sendDenied(VICINAE_HOTKEY_V1_DENY_REASON_NOT_PERMITTED, "a non-latching modifier (Ctrl, Alt or Super) is required unless the trigger is a function key");
-        return;
-    }
-
-    if (comboTakenByHotkey(keysym, hk->modmask)) {
-        hk->resource->sendDenied(VICINAE_HOTKEY_V1_DENY_REASON_ALREADY_BOUND, "the combination is already bound by another hotkey");
-        return;
-    }
-
-    if (const auto CONFLICT = g_pKeybindManager->findConflictingKeybind(keysym, hk->modmask)) {
-        hk->resource->sendDenied(VICINAE_HOTKEY_V1_DENY_REASON_ALREADY_BOUND,
-                                 std::format("the combination is reserved by a compositor keybind ({})", keybindLabel(CONFLICT)).c_str());
         return;
     }
 
@@ -193,20 +164,4 @@ std::vector<CHotkeyProtocol::SHotkeyInfo> CHotkeyProtocol::getAllHotkeys() {
         });
     }
     return out;
-}
-
-void CHotkeyProtocol::revokeConflicting() {
-    for (const auto& hk : m_hotkeys) {
-        if (!hk->bound)
-            continue;
-        const auto CONFLICT = g_pKeybindManager->findConflictingKeybind(hk->keysym, hk->modmask);
-        if (!CONFLICT)
-            continue;
-
-        hk->bound    = false;
-        hk->held     = false;
-        hk->heldCode = 0;
-        hk->resource->sendRevoked(VICINAE_HOTKEY_V1_REVOKE_REASON_SUPERSEDED,
-                                  std::format("the combination is now reserved by a compositor keybind ({})", keybindLabel(CONFLICT)).c_str());
-    }
 }

--- a/src/protocols/Hotkey.cpp
+++ b/src/protocols/Hotkey.cpp
@@ -21,14 +21,43 @@ static uint32_t           protoModsToHL(uint32_t mods) {
     return out;
 }
 
-static bool isFunctionKey(xkb_keysym_t sym) {
-    return sym >= XKB_KEY_F1 && sym <= XKB_KEY_F35;
+static bool isKeypadKey(xkb_keysym_t sym) {
+    return sym >= XKB_KEY_KP_Space && sym <= XKB_KEY_KP_Equal;
 }
 
+static bool isDeadKey(xkb_keysym_t sym) {
+    return sym >= XKB_KEY_dead_grave && sym <= XKB_KEY_dead_longsolidusoverlay;
+}
+
+static xkb_keysym_t normalizeKeypad(xkb_keysym_t sym) {
+    switch (sym) {
+        case XKB_KEY_KP_Insert: return XKB_KEY_KP_0;
+        case XKB_KEY_KP_End: return XKB_KEY_KP_1;
+        case XKB_KEY_KP_Down: return XKB_KEY_KP_2;
+        case XKB_KEY_KP_Next: return XKB_KEY_KP_3;
+        case XKB_KEY_KP_Left: return XKB_KEY_KP_4;
+        case XKB_KEY_KP_Begin: return XKB_KEY_KP_5;
+        case XKB_KEY_KP_Right: return XKB_KEY_KP_6;
+        case XKB_KEY_KP_Home: return XKB_KEY_KP_7;
+        case XKB_KEY_KP_Up: return XKB_KEY_KP_8;
+        case XKB_KEY_KP_Prior: return XKB_KEY_KP_9;
+        case XKB_KEY_KP_Delete: return XKB_KEY_KP_Decimal;
+        default: return sym;
+    }
+}
+
+// see the suggested acceptance policy in the protocol's security considerations
 static bool isValidTrigger(xkb_keysym_t sym, uint32_t modmask) {
-    if (isFunctionKey(sym))
+    if (modmask & (HL_MODIFIER_CTRL | HL_MODIFIER_ALT | HL_MODIFIER_META))
         return true;
-    return modmask & (HL_MODIFIER_CTRL | HL_MODIFIER_ALT | HL_MODIFIER_META);
+
+    if (isKeypadKey(sym))
+        return true;
+
+    if (isDeadKey(sym))
+        return false;
+
+    return xkb_keysym_to_utf32(sym) == 0;
 }
 
 static std::string triggerString(xkb_keysym_t sym, uint32_t modmask) {
@@ -111,7 +140,7 @@ void CHotkeyProtocol::onBind(SP<CVicinaeHotkeyManagerV1> mgr, uint32_t id, xkb_k
     }
 
     if (!isValidTrigger(keysym, hk->modmask)) {
-        hk->resource->sendDenied(VICINAE_HOTKEY_V1_DENY_REASON_NOT_PERMITTED, "a non-latching modifier (Ctrl, Alt or Super) is required unless the trigger is a function key");
+        hk->resource->sendDenied(VICINAE_HOTKEY_V1_DENY_REASON_NOT_PERMITTED, "a non-latching modifier (Ctrl, Alt or Super) is required when the trigger key carries text entry");
         return;
     }
 
@@ -127,7 +156,7 @@ bool CHotkeyProtocol::onKey(xkb_keysym_t keysym, uint32_t modmask, uint32_t keyc
         for (const auto& hk : m_hotkeys) {
             if (!hk->bound || hk->held)
                 continue;
-            if (hk->keysym != keysym || hk->modmask != mods)
+            if (normalizeKeypad(hk->keysym) != normalizeKeypad(keysym) || hk->modmask != mods)
                 continue;
 
             hk->held              = true;

--- a/src/protocols/Hotkey.cpp
+++ b/src/protocols/Hotkey.cpp
@@ -5,6 +5,7 @@
 #include "../event/EventBus.hpp"
 
 #include <xkbcommon/xkbcommon-keysyms.h>
+#include <array>
 #include <format>
 
 static constexpr uint32_t RELEVANT_MODS = HL_MODIFIER_SHIFT | HL_MODIFIER_CTRL | HL_MODIFIER_ALT | HL_MODIFIER_META;
@@ -30,6 +31,26 @@ static bool isValidTrigger(xkb_keysym_t sym, uint32_t modmask) {
     if (isFunctionKey(sym))
         return true;
     return modmask & (HL_MODIFIER_CTRL | HL_MODIFIER_ALT | HL_MODIFIER_META);
+}
+
+static std::string triggerString(xkb_keysym_t sym, uint32_t modmask) {
+    std::string out;
+    if (modmask & HL_MODIFIER_META)
+        out += "SUPER+";
+    if (modmask & HL_MODIFIER_CTRL)
+        out += "CTRL+";
+    if (modmask & HL_MODIFIER_ALT)
+        out += "ALT+";
+    if (modmask & HL_MODIFIER_SHIFT)
+        out += "SHIFT+";
+
+    std::array<char, 64> buf{};
+    if (xkb_keysym_get_name(sym, buf.data(), buf.size()) > 0)
+        out += buf.data();
+    else
+        out += std::format("keysym:{:#x}", sc<uint32_t>(sym));
+
+    return out;
 }
 
 static std::string keybindLabel(const SP<SKeybind>& k) {
@@ -158,6 +179,20 @@ bool CHotkeyProtocol::onKey(xkb_keysym_t keysym, uint32_t modmask, uint32_t keyc
     }
 
     return consumed;
+}
+
+std::vector<CHotkeyProtocol::SHotkeyInfo> CHotkeyProtocol::getAllHotkeys() {
+    std::vector<SHotkeyInfo> out;
+    out.reserve(m_hotkeys.size());
+    for (const auto& hk : m_hotkeys) {
+        out.emplace_back(SHotkeyInfo{
+            .appid       = hk->appid,
+            .description = hk->description,
+            .trigger     = triggerString(hk->keysym, hk->modmask),
+            .bound       = hk->bound,
+        });
+    }
+    return out;
 }
 
 void CHotkeyProtocol::revokeConflicting() {

--- a/src/protocols/Hotkey.hpp
+++ b/src/protocols/Hotkey.hpp
@@ -3,7 +3,6 @@
 #include "../defines.hpp"
 #include "vicinae-hotkey-v1.hpp"
 #include "./WaylandProtocol.hpp"
-#include "../helpers/signal/Signal.hpp"
 
 #include <vector>
 #include <string>
@@ -38,8 +37,6 @@ class CHotkeyProtocol : public IWaylandProtocol {
     // returns true if a bound hotkey consumed the key
     bool                     onKey(xkb_keysym_t keysym, uint32_t modmask, uint32_t keycode, bool pressed, uint32_t timeMs);
 
-    void                     revokeConflicting();
-
     std::vector<SHotkeyInfo> getAllHotkeys();
 
   private:
@@ -56,12 +53,9 @@ class CHotkeyProtocol : public IWaylandProtocol {
 
     void onBind(SP<CVicinaeHotkeyManagerV1> mgr, uint32_t id, xkb_keysym_t keysym, uint32_t protoMods, const char* appid, const char* description);
     void destroyManager(CVicinaeHotkeyManager* mgr);
-    bool comboTakenByHotkey(xkb_keysym_t keysym, uint32_t modmask);
 
     std::vector<SP<CVicinaeHotkeyManager>> m_managers;
     std::vector<SP<SBoundHotkey>>          m_hotkeys;
-
-    CHyprSignalListener                    m_reloadListener;
 
     friend class CVicinaeHotkeyManager;
 };

--- a/src/protocols/Hotkey.hpp
+++ b/src/protocols/Hotkey.hpp
@@ -26,12 +26,21 @@ class CHotkeyProtocol : public IWaylandProtocol {
   public:
     CHotkeyProtocol(const wl_interface* iface, const int& ver, const std::string& name);
 
+    struct SHotkeyInfo {
+        std::string appid;
+        std::string description;
+        std::string trigger; // human-readable combo, e.g. "SUPER+K"
+        bool        bound = false;
+    };
+
     void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) override;
 
     // returns true if a bound hotkey consumed the key
-    bool onKey(xkb_keysym_t keysym, uint32_t modmask, uint32_t keycode, bool pressed, uint32_t timeMs);
+    bool                     onKey(xkb_keysym_t keysym, uint32_t modmask, uint32_t keycode, bool pressed, uint32_t timeMs);
 
-    void revokeConflicting();
+    void                     revokeConflicting();
+
+    std::vector<SHotkeyInfo> getAllHotkeys();
 
   private:
     struct SBoundHotkey {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

After [further discussion](https://github.com/niri-wm/niri/pull/4145#issuecomment-5151787448) it appears that the default binding policy we apply is too restrictive:

- There are use cases in which many applications could want to bind the same key. For instance, to use the same shortcut to trigger a microphone mute across all running voip applications. The single binding policy prevents this which is annoying and probably over restricting. To fix this, we simply disable this rule.
- Bare numpad keys and other non printable keys such as `Insert`, `End`, `Page Up/Down`  can't be bound without a modifier, which often goes against what users want. We now allow these, and only require a modifier for "text" keys. 

In order to keep the user in control, it is important that they are able to audit what application is reserving what shortcut in order to debug any potential problem. To that end, `hyprctl globalshortcuts` now prints out all reserved shortcuts, from the portal and from the `vicinae-hotkey-v1` reservations.

This is the output of `hyprctl globalshortcuts -j` on my system, where OBS and vicinae are reserving shortcuts:

```json
[{
    "name": "vicinae:ALT+SHIFT+c",
    "description": "clipboard:history",
    "appid": "vicinae",
    "trigger": "ALT+SHIFT+c",
    "bound": true
},
{
    "name": "vicinae:SUPER+space",
    "description": "Toggle Vicinae",
    "appid": "vicinae",
    "trigger": "SUPER+space",
    "bound": true
},
{
    "name": "com.obsproject.Studio:CTRL+KP_Home",
    "description": "OBS Studio hotkey",
    "appid": "com.obsproject.Studio",
    "trigger": "CTRL+KP_Home",
    "bound": true
}]
```




#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The changes are only compositor policy, the protocol itself is unaffected

#### Is it ready for merging, or does it need work?

ready

