### PR TITLE
fix: popup event handling with keyboard exclusive layers

### DIFF
--- a/src/desktop/state/ViewHitTester.cpp
+++ b/src/desktop/state/ViewHitTester.cpp
@@ -326,6 +326,23 @@ SP<CWLSurfaceResource> CViewHitTester::layerPopupSurfaceAt(const Vector2D& pos, 
     return nullptr;
 }
 
+SP<CWLSurfaceResource> CViewHitTester::layerPopupSurfaceAt(const Vector2D& pos, const std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound) const {
+    for (auto const& ls : *layerSurfaces | std::views::reverse) {
+        if (!ls->aliveAndVisible())
+            continue;
+
+        auto SURFACEAT = ls->m_popupHead->at(pos, true);
+
+        if (SURFACEAT) {
+            *layerFound    = ls.lock();
+            *surfaceCoords = pos - SURFACEAT->coordsGlobal();
+            return SURFACEAT->wlSurface()->resource();
+        }
+    }
+
+    return nullptr;
+}
+
 SP<CWLSurfaceResource> CViewHitTester::layerSurfaceAt(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound,
                                                       bool aboveLockscreen) const {
     for (auto const& ls : *layerSurfaces | std::views::reverse) {

--- a/src/desktop/state/ViewHitTester.hpp
+++ b/src/desktop/state/ViewHitTester.hpp
@@ -23,6 +23,7 @@ namespace Desktop {
         SP<CWLSurfaceResource> windowSurfaceAt(const Vector2D& pos, PHLWINDOW window, Vector2D& surfaceLocal) const;
         Vector2D               surfaceLocalAt(const Vector2D& pos, PHLWINDOW window, SP<CWLSurfaceResource> surface) const;
         SP<CWLSurfaceResource> layerPopupSurfaceAt(const Vector2D& pos, PHLMONITOR monitor, Vector2D* surfaceCoords, PHLLS* layerFound) const;
+        SP<CWLSurfaceResource> layerPopupSurfaceAt(const Vector2D& pos, const std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound) const;
         SP<CWLSurfaceResource> layerSurfaceAt(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound,
                                               bool aboveLockscreen = false) const;
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -453,6 +453,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     // forced above all
     if (!g_pInputManager->m_exclusiveLSes.empty()) {
         if (!foundSurface)
+            foundSurface = Desktop::viewState()->hitTest().layerPopupSurfaceAt(mouseCoords, &g_pInputManager->m_exclusiveLSes, &surfaceCoords, &pFoundLayerSurface);
+
+        if (!foundSurface)
             foundSurface = Desktop::viewState()->hitTest().layerSurfaceAt(mouseCoords, &g_pInputManager->m_exclusiveLSes, &surfaceCoords, &pFoundLayerSurface);
 
         if (!foundSurface) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Native wayland popups attached to layers with keyboard interactivity set to exclusive didn't receive any mouse event, the layer was eating it all.

In practice this resulted in many popups outright closing on click, since very often, clicking outside of the popup makes the application close the popup.

#### Is it ready for merging, or does it need work?

ready
