### PR TITLE
protocols: ext-background-effect for native popups/subsurfaces

### DIFF
--- a/src/desktop/state/LayerFadeout.cpp
+++ b/src/desktop/state/LayerFadeout.cpp
@@ -29,9 +29,9 @@ static bool shouldBlurLayer(PHLLS layer) {
     if (!*PBLUR)
         return false;
 
-    auto surface = layer->wlSurface();
-    if (surface && surface->m_hasBackgroundEffect)
-        return !surface->m_blurRegion.empty();
+    const auto SURFACE = layer->wlSurface();
+    if (const auto EFFECT = SURFACE ? SURFACE->backgroundEffectBlur() : std::nullopt; EFFECT)
+        return *EFFECT;
 
     return layer->m_ruleApplicator->blur().valueOrDefault();
 }

--- a/src/desktop/state/PopupFadeout.cpp
+++ b/src/desktop/state/PopupFadeout.cpp
@@ -38,7 +38,7 @@ SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffe
     fadeout->m_framebuffer = snapshot;
 
     static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
-    if (g_pHyprRenderer->shouldBlur(popup)) {
+    if (popup->shouldBlur()) {
         fadeout->m_effects.textureBlur.enabled               = true;
         fadeout->m_effects.textureBlur.blockBlurOptimization = true;
 

--- a/src/desktop/state/PopupFadeout.cpp
+++ b/src/desktop/state/PopupFadeout.cpp
@@ -14,13 +14,6 @@
 using namespace Desktop;
 using namespace Desktop::View;
 
-static bool shouldBlurPopup() {
-    static CConfigValue PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
-    static CConfigValue PBLUR       = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
-
-    return *PBLURPOPUPS && *PBLUR;
-}
-
 static void damageFadeoutMonitor(PHLMONITORREF monitor) {
     if (const auto MONITOR = monitor.lock(); MONITOR)
         g_pHyprRenderer->damageMonitor(MONITOR);
@@ -45,7 +38,7 @@ SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffe
     fadeout->m_framebuffer = snapshot;
 
     static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
-    if (shouldBlurPopup()) {
+    if (g_pHyprRenderer->shouldBlur(popup)) {
         fadeout->m_effects.textureBlur.enabled               = true;
         fadeout->m_effects.textureBlur.blockBlurOptimization = true;
 

--- a/src/desktop/state/WindowFadeout.cpp
+++ b/src/desktop/state/WindowFadeout.cpp
@@ -30,9 +30,9 @@ static bool shouldBlurWindow(PHLWINDOW window) {
     if (window->m_ruleApplicator->noBlur().valueOrDefault() || window->m_ruleApplicator->RGBX().valueOrDefault() || window->opaque())
         return false;
 
-    auto surface = window->wlSurface();
-    if (surface && surface->m_hasBackgroundEffect)
-        return !surface->m_blurRegion.empty();
+    const auto SURFACE = window->wlSurface();
+    if (const auto EFFECT = SURFACE ? SURFACE->backgroundEffectBlur() : std::nullopt; EFFECT)
+        return *EFFECT;
 
     return true;
 }

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -711,3 +711,19 @@ std::optional<uint8_t> CPopup::alphaGenericToKey(eAlphaModifiableProp p) {
     static_assert(ALPHA_MODIFIABLE_LAST == 1);
     UNREACHABLE();
 }
+
+bool CPopup::shouldBlur() const {
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    auto surface = wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    if (const auto LAYER = layerOwner(); LAYER)
+        return LAYER->m_ruleApplicator->blurPopups().valueOrDefault();
+
+    static auto PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
+    return *PBLURPOPUPS;
+}

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -717,9 +717,9 @@ bool CPopup::shouldBlur() const {
     if (!*PBLUR)
         return false;
 
-    auto surface = wlSurface();
-    if (surface && surface->m_hasBackgroundEffect)
-        return !surface->m_blurRegion.empty();
+    const auto SURFACE = wlSurface();
+    if (const auto EFFECT = SURFACE ? SURFACE->backgroundEffectBlur() : std::nullopt; EFFECT)
+        return *EFFECT;
 
     if (const auto LAYER = layerOwner(); LAYER)
         return LAYER->m_ruleApplicator->blurPopups().valueOrDefault();

--- a/src/desktop/view/Popup.hpp
+++ b/src/desktop/view/Popup.hpp
@@ -63,6 +63,7 @@ namespace Desktop::View {
         void                                                onReposition();
 
         void                                                recheckTree();
+        bool                                                shouldBlur() const;
 
         bool                                                inert() const;
 

--- a/src/desktop/view/WLSurface.cpp
+++ b/src/desktop/view/WLSurface.cpp
@@ -191,6 +191,13 @@ SP<CPointerConstraint> CWLSurface::constraint() const {
     return m_constraint.lock();
 }
 
+std::optional<bool> CWLSurface::backgroundEffectBlur() const {
+    if (!m_hasBackgroundEffect)
+        return std::nullopt;
+
+    return !m_blurRegion.empty();
+}
+
 SP<Desktop::View::CWLSurface> CWLSurface::fromResource(SP<CWLSurfaceResource> pSurface) {
     if (!pSurface)
         return nullptr;

--- a/src/desktop/view/WLSurface.hpp
+++ b/src/desktop/view/WLSurface.hpp
@@ -49,6 +49,10 @@ namespace Desktop::View {
         void                   appendConstraint(WP<CPointerConstraint> constraint);
         SP<CPointerConstraint> constraint() const;
 
+        // ext-background-effect: nullopt if the client expressed no preference for this surface,
+        // otherwise whether it asked for its background to be blurred.
+        std::optional<bool> backgroundEffectBlur() const;
+
         // allow stretching. Useful for plugins.
         bool m_fillIgnoreSmall = false;
 

--- a/src/desktop/view/WLSurface.hpp
+++ b/src/desktop/view/WLSurface.hpp
@@ -49,8 +49,7 @@ namespace Desktop::View {
         void                   appendConstraint(WP<CPointerConstraint> constraint);
         SP<CPointerConstraint> constraint() const;
 
-        // ext-background-effect: nullopt if the client expressed no preference for this surface,
-        // otherwise whether it asked for its background to be blurred.
+        // nullopt if the client set no ext-background-effect on this surface
         std::optional<bool> backgroundEffectBlur() const;
 
         // allow stretching. Useful for plugins.

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -357,7 +357,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                         }),
                         surfaceDamage());
     } else {
-        if (BLUR && m_data.popup)
+        if (BLUR && (m_data.popup || m_data.blurOptIn))
             drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex                   = TEXTURE,
                             .box                   = windowBox,

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2153,7 +2153,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
         // handle ext-background-effect-v1 blur region if specified
         CRegion blurClipRegion = data.clipRegion;
         auto    PSURFACE       = Desktop::View::CWLSurface::fromResource(data.surface);
-        if (PSURFACE && PSURFACE->m_hasBackgroundEffect && !PSURFACE->m_blurRegion.empty()) {
+        if (PSURFACE && PSURFACE->backgroundEffectBlur().value_or(false)) {
             CRegion protocolBlur = PSURFACE->m_blurRegion.copy();
             protocolBlur.intersect(CBox{0, 0, box.width, box.height});
             protocolBlur.scale(m_renderData.pMonitor->m_scale);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -763,22 +763,26 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
 
-            renderdata.blur = shouldBlur(pWindow->m_popupHead);
-
-            if (renderdata.blur) {
-                renderdata.discardMode |= DISCARD_ALPHA;
-                renderdata.discardOpacity = *PBLURIGNOREA;
-            }
-
             if (pWindow->m_ruleApplicator->nearestNeighbor().valueOrDefault())
                 renderdata.useNearestNeighbor = true;
 
             renderdata.surfaceCounter = 0;
 
+            const auto DISCARDMODE    = renderdata.discardMode;
+            const auto DISCARDOPACITY = renderdata.discardOpacity;
+
             pWindow->m_popupHead->breadthfirst(
-                [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
+                [this, &renderdata, DISCARDMODE, DISCARDOPACITY](WP<Desktop::View::CPopup> popup, void* data) {
                     if (!popup->aliveAndVisible())
                         return;
+
+                    renderdata.blur           = shouldBlur(popup);
+                    renderdata.discardMode    = DISCARDMODE;
+                    renderdata.discardOpacity = DISCARDOPACITY;
+                    if (renderdata.blur) {
+                        renderdata.discardMode |= DISCARD_ALPHA;
+                        renderdata.discardOpacity = *PBLURIGNOREA;
+                    }
 
                     const auto     pos    = popup->coordsRelativeToParent();
                     const Vector2D oldPos = renderdata.pos;
@@ -995,19 +999,20 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
     renderdata.squishOversized = false; // don't squish popups
     renderdata.dontRound       = true;
     renderdata.popup           = true;
-    renderdata.blur            = pLayer->m_ruleApplicator->blurPopups().valueOrDefault();
-    renderdata.discardMode &= ~DISCARD_ALPHA;
-    renderdata.discardOpacity = 0.F;
-    if (renderdata.blur && pLayer->m_ruleApplicator->ignoreAlpha().hasValue()) {
-        renderdata.discardMode |= DISCARD_ALPHA;
-        renderdata.discardOpacity = pLayer->m_ruleApplicator->ignoreAlpha().valueOrDefault();
-    }
-    renderdata.surfaceCounter = 0;
+    renderdata.surfaceCounter  = 0;
     if (popups) {
         pLayer->m_popupHead->breadthfirst(
-            [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
+            [this, &renderdata, &pLayer](WP<Desktop::View::CPopup> popup, void* data) {
                 if (!popup->aliveAndVisible())
                     return;
+
+                renderdata.blur = shouldBlur(popup);
+                renderdata.discardMode &= ~DISCARD_ALPHA;
+                renderdata.discardOpacity = 0.F;
+                if (renderdata.blur && pLayer->m_ruleApplicator->ignoreAlpha().hasValue()) {
+                    renderdata.discardMode |= DISCARD_ALPHA;
+                    renderdata.discardOpacity = pLayer->m_ruleApplicator->ignoreAlpha().valueOrDefault();
+                }
 
                 const auto SURF = popup->wlSurface()->resource();
 
@@ -3328,6 +3333,13 @@ bool IHyprRenderer::shouldBlur(PHLWINDOW w) {
 bool IHyprRenderer::shouldBlur(WP<Desktop::View::CPopup> p) {
     static CConfigValue PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
     static CConfigValue PBLUR       = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+
+    const auto          SURFACE = p ? p->wlSurface() : nullptr;
+    if (SURFACE && SURFACE->m_hasBackgroundEffect)
+        return *PBLUR && !SURFACE->m_blurRegion.empty();
+
+    if (const auto LAYER = p ? p->layerOwner() : nullptr; LAYER)
+        return LAYER->m_ruleApplicator->blurPopups().valueOrDefault();
 
     return *PBLURPOPUPS && *PBLUR;
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -776,7 +776,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                     if (!popup->aliveAndVisible())
                         return;
 
-                    renderdata.blur           = shouldBlur(popup);
+                    renderdata.blur           = !m_bRenderingSnapshot && popup->shouldBlur();
                     renderdata.discardMode    = DISCARDMODE;
                     renderdata.discardOpacity = DISCARDOPACITY;
                     if (renderdata.blur) {
@@ -1006,7 +1006,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 if (!popup->aliveAndVisible())
                     return;
 
-                renderdata.blur = shouldBlur(popup);
+                renderdata.blur = popup->shouldBlur();
                 renderdata.discardMode &= ~DISCARD_ALPHA;
                 renderdata.discardOpacity = 0.F;
                 if (renderdata.blur && pLayer->m_ruleApplicator->ignoreAlpha().hasValue()) {
@@ -3328,20 +3328,6 @@ bool IHyprRenderer::shouldBlur(PHLWINDOW w) {
         return !surface->m_blurRegion.empty();
 
     return true;
-}
-
-bool IHyprRenderer::shouldBlur(WP<Desktop::View::CPopup> p) {
-    static CConfigValue PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
-    static CConfigValue PBLUR       = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
-
-    const auto          SURFACE = p ? p->wlSurface() : nullptr;
-    if (SURFACE && SURFACE->m_hasBackgroundEffect)
-        return *PBLUR && !SURFACE->m_blurRegion.empty();
-
-    if (const auto LAYER = p ? p->layerOwner() : nullptr; LAYER)
-        return LAYER->m_ruleApplicator->blurPopups().valueOrDefault();
-
-    return *PBLURPOPUPS && *PBLUR;
 }
 
 SP<ITexture> IHyprRenderer::renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth,

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -687,19 +687,29 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         }
 
         renderdata.surfaceCounter = 0;
+
+        const bool EFFECTBLURALLOWED = !standalone && blurPolicyAllows(pWindow);
+
         pWindow->wlSurface()->resource()->breadthfirst(
-            [this, &renderdata, &pWindow](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+            [this, &renderdata, &pWindow, EFFECTBLURALLOWED](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 if (!s->m_current.texture)
                     return;
 
                 if (s->m_current.size.x < 1 || s->m_current.size.y < 1)
                     return;
 
-                renderdata.localPos    = offset;
-                renderdata.texture     = s->m_current.texture;
-                renderdata.surface     = s;
-                renderdata.mainSurface = s == pWindow->wlSurface()->resource();
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                const auto HLSURFACE = Desktop::View::CWLSurface::fromResource(s);
+                const bool OWNEFFECT = EFFECTBLURALLOWED && HLSURFACE && HLSURFACE->backgroundEffectBlur().value_or(false);
+
+                auto       surfacedata = renderdata;
+                surfacedata.blur |= OWNEFFECT;
+                surfacedata.blockBlurOptimization |= OWNEFFECT;
+                surfacedata.blurOptIn   = OWNEFFECT;
+                surfacedata.localPos    = offset;
+                surfacedata.texture     = s->m_current.texture;
+                surfacedata.surface     = s;
+                surfacedata.mainSurface = s == pWindow->wlSurface()->resource();
+                addPassElement(makeUnique<CSurfacePassElement>(surfacedata));
                 renderdata.surfaceCounter++;
             },
             nullptr);
@@ -978,20 +988,29 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
         renderdata.discardOpacity = pLayer->m_ruleApplicator->ignoreAlpha().valueOrDefault();
     }
 
+    const bool EFFECTBLURALLOWED = blurPolicyAllows();
+
     if (!popups)
         pLayer->wlSurface()->resource()->breadthfirst(
-            [this, &renderdata, &pLayer](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+            [this, &renderdata, &pLayer, EFFECTBLURALLOWED](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 if (!s->m_current.texture)
                     return;
 
                 if (s->m_current.size.x < 1 || s->m_current.size.y < 1)
                     return;
 
-                renderdata.localPos    = offset;
-                renderdata.texture     = s->m_current.texture;
-                renderdata.surface     = s;
-                renderdata.mainSurface = s == pLayer->wlSurface()->resource();
-                m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                const auto HLSURFACE = Desktop::View::CWLSurface::fromResource(s);
+                const bool OWNEFFECT = EFFECTBLURALLOWED && HLSURFACE && HLSURFACE->backgroundEffectBlur().value_or(false);
+
+                auto       surfacedata = renderdata;
+                surfacedata.blur |= OWNEFFECT;
+                surfacedata.blockBlurOptimization |= OWNEFFECT;
+                surfacedata.blurOptIn   = OWNEFFECT;
+                surfacedata.localPos    = offset;
+                surfacedata.texture     = s->m_current.texture;
+                surfacedata.surface     = s;
+                surfacedata.mainSurface = s == pLayer->wlSurface()->resource();
+                m_renderPass.add(makeUnique<CSurfacePassElement>(surfacedata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -3296,12 +3315,20 @@ NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription() 
     return m_renderData.pMonitor->workBufferImageDescription();
 }
 
-bool IHyprRenderer::shouldBlur(PHLLS ls) {
+bool IHyprRenderer::blurPolicyAllows() {
     if (m_bRenderingSnapshot)
         return false;
 
     static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
-    if (!*PBLUR)
+    return *PBLUR;
+}
+
+bool IHyprRenderer::blurPolicyAllows(PHLWINDOW w) {
+    return blurPolicyAllows() && !w->m_ruleApplicator->noBlur().valueOrDefault() && !w->m_ruleApplicator->RGBX().valueOrDefault();
+}
+
+bool IHyprRenderer::shouldBlur(PHLLS ls) {
+    if (!blurPolicyAllows())
         return false;
 
     const auto SURFACE = ls->wlSurface();
@@ -3312,15 +3339,7 @@ bool IHyprRenderer::shouldBlur(PHLLS ls) {
 }
 
 bool IHyprRenderer::shouldBlur(PHLWINDOW w) {
-    if (m_bRenderingSnapshot)
-        return false;
-
-    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
-    if (!*PBLUR)
-        return false;
-
-    const bool DONT_BLUR = w->m_ruleApplicator->noBlur().valueOrDefault() || w->m_ruleApplicator->RGBX().valueOrDefault() || w->opaque();
-    if (DONT_BLUR)
+    if (!blurPolicyAllows(w) || w->opaque())
         return false;
 
     const auto SURFACE = w->wlSurface();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3304,9 +3304,9 @@ bool IHyprRenderer::shouldBlur(PHLLS ls) {
     if (!*PBLUR)
         return false;
 
-    auto surface = ls->wlSurface();
-    if (surface && surface->m_hasBackgroundEffect)
-        return !surface->m_blurRegion.empty();
+    const auto SURFACE = ls->wlSurface();
+    if (const auto EFFECT = SURFACE ? SURFACE->backgroundEffectBlur() : std::nullopt; EFFECT)
+        return *EFFECT;
 
     return ls->m_ruleApplicator->blur().valueOrDefault();
 }
@@ -3323,9 +3323,9 @@ bool IHyprRenderer::shouldBlur(PHLWINDOW w) {
     if (DONT_BLUR)
         return false;
 
-    auto surface = w->wlSurface();
-    if (surface && surface->m_hasBackgroundEffect)
-        return !surface->m_blurRegion.empty();
+    const auto SURFACE = w->wlSurface();
+    if (const auto EFFECT = SURFACE ? SURFACE->backgroundEffectBlur() : std::nullopt; EFFECT)
+        return *EFFECT;
 
     return true;
 }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -215,10 +215,6 @@ namespace Render {
         void                 clearCMSettingsCache();
         virtual bool         reloadShaders(const std::string& path = "") = 0;
 
-        bool                 shouldBlur(PHLLS ls);
-        bool                 shouldBlur(PHLWINDOW w);
-        bool                 shouldBlur(WP<Desktop::View::CPopup> p);
-
       protected:
         virtual void              renderOffToMain(SP<IFramebuffer> off)                                         = 0;
         virtual SP<IRenderbuffer> getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) = 0;
@@ -285,6 +281,9 @@ namespace Render {
         SP<ITexture>                      m_missingAssetTexture;
         ASP<Hyprgraphics::CImageResource> m_backgroundResource;
         bool                              m_backgroundResourceFailed = false;
+
+        bool                              shouldBlur(PHLLS ls);
+        bool                              shouldBlur(PHLWINDOW w);
 
         bool                              m_cursorHidden            = false;
         bool                              m_cursorHiddenByCondition = false;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -215,6 +215,10 @@ namespace Render {
         void                 clearCMSettingsCache();
         virtual bool         reloadShaders(const std::string& path = "") = 0;
 
+        bool                 shouldBlur(PHLLS ls);
+        bool                 shouldBlur(PHLWINDOW w);
+        bool                 shouldBlur(WP<Desktop::View::CPopup> p);
+
       protected:
         virtual void              renderOffToMain(SP<IFramebuffer> off)                                         = 0;
         virtual SP<IRenderbuffer> getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) = 0;
@@ -281,10 +285,6 @@ namespace Render {
         SP<ITexture>                      m_missingAssetTexture;
         ASP<Hyprgraphics::CImageResource> m_backgroundResource;
         bool                              m_backgroundResourceFailed = false;
-
-        bool                              shouldBlur(PHLLS ls);
-        bool                              shouldBlur(PHLWINDOW w);
-        bool                              shouldBlur(WP<Desktop::View::CPopup> p);
 
         bool                              m_cursorHidden            = false;
         bool                              m_cursorHiddenByCondition = false;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -282,6 +282,8 @@ namespace Render {
         ASP<Hyprgraphics::CImageResource> m_backgroundResource;
         bool                              m_backgroundResourceFailed = false;
 
+        bool                              blurPolicyAllows();
+        bool                              blurPolicyAllows(PHLWINDOW w);
         bool                              shouldBlur(PHLLS ls);
         bool                              shouldBlur(PHLWINDOW w);
 

--- a/src/render/pass/SurfacePassElement.hpp
+++ b/src/render/pass/SurfacePassElement.hpp
@@ -29,6 +29,7 @@ class CSurfacePassElement : public IPassElement {
         float                  alpha = 1.F, fadeAlpha = 1.F;
         bool                   blur                  = false;
         bool                   blockBlurOptimization = false;
+        bool                   blurOptIn             = false;
 
         uint8_t                wrapX = WRAP_CLAMP_TO_EDGE;
         uint8_t                wrapY = WRAP_CLAMP_TO_EDGE;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I forgot to add native popup support when I implemented ext-background-effect. This fixes it

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Obviously that's only applicable to native popups, Electron apps which emulate popups can't benefit from this.

#### Is it ready for merging, or does it need work?

ready


