### PR TITLE
hyprctl: fix wiki strings

### DIFF
--- a/hyprctl/src/Strings.hpp
+++ b/hyprctl/src/Strings.hpp
@@ -148,8 +148,7 @@ regex:
     Regular expression by which a window will be searched
 
 property:
-    See https://wiki.hypr.land/Configuring/Using-hyprctl/#setprop for list
-    of properties
+    See the wiki for a list of properties
 
 value:
     Property value
@@ -167,8 +166,7 @@ regex:
     Regular expression by which a window will be searched
 
 property:
-    See https://wiki.hypr.land/Configuring/Using-hyprctl/#setprop for list
-    of properties
+    See the wiki for a list of properties
 
 flags:
     See 'hyprctl --help')#";


### PR DESCRIPTION
do not keep raw URLs, those can change. Just direct the user.


