### PR TITLE
layout/monocle/fullscreen: Fix alpha and input being incorrectly set when a Maximised window is moved from a normal workspace w/o monocle to a special workspace with monocle

### DIFF
--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -483,7 +483,7 @@ static int dsp_moveToWorkspace(lua_State* L) {
         return Internal::dispatcherError(L, "Invalid workspace", ERR, C_INVARG);
 
     bool silent = lua_toboolean(L, lua_upvalueindex(2));
-    return Internal::checkResult(L, CA::moveToWorkspace(ws, silent, Internal::windowFromUpval(L, 3)));
+    return Internal::checkResult(L, CA::moveWindowToWorkspace(ws, silent, Internal::windowFromUpval(L, 3)));
 }
 
 static int dsp_moveToMonitor(lua_State* L) {
@@ -492,7 +492,7 @@ static int dsp_moveToMonitor(lua_State* L) {
         return Internal::dispatcherError(L, "Invalid monitor / monitor doesn't exist", ERR, C_INVARG);
 
     bool silent = lua_toboolean(L, lua_upvalueindex(2));
-    return Internal::checkResult(L, CA::moveToWorkspace(mon->m_activeWorkspace, silent, Internal::windowFromUpval(L, 3)));
+    return Internal::checkResult(L, CA::moveWindowToWorkspace(mon->m_activeWorkspace, silent, Internal::windowFromUpval(L, 3)));
 }
 
 static int dsp_closeWindow(lua_State* L) {

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -312,7 +312,7 @@ ActionResult Actions::fullscreenWindow(Fullscreen::eFullscreenMode internalMode,
     return {};
 }
 
-ActionResult Actions::moveToWorkspace(PHLWORKSPACE ws, bool silent, std::optional<PHLWINDOW> w) {
+ActionResult Actions::moveWindowToWorkspace(PHLWORKSPACE ws, bool silent, std::optional<PHLWINDOW> w) {
     auto window = xtract(w);
     if (!window)
         return {};

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -44,7 +44,7 @@ namespace Config::Actions {
     ActionResult fullscreenWindow(Fullscreen::eFullscreenMode mode, bool layoutAware, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult fullscreenWindow(Fullscreen::eFullscreenMode internalMode, Fullscreen::eFullscreenMode clientMode, bool layoutAware,
                                   std::optional<PHLWINDOW> window = std::nullopt /* Active */);
-    ActionResult moveToWorkspace(PHLWORKSPACE ws, bool silent, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
+    ActionResult moveWindowToWorkspace(PHLWORKSPACE ws, bool silent, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult moveFocus(Math::eDirection dir);
     ActionResult focus(PHLWINDOW window);
     ActionResult moveInDirection(Math::eDirection dir, std::optional<PHLWINDOW> window = std::nullopt /* Active */);

--- a/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
@@ -132,7 +132,10 @@ void CMonocleAlgorithm::recalculate(eRecalculateReason reason) {
         return;
 
     // Avoid further pos recalc if in fullscreen
-    if (Fullscreen::controller()->hasFullscreen(m_parent->space()->workspace(), true)) {
+    // Monocle has its own input blocking reason and uses WINDOW_ALPHA_LAYOUT so we need to handle this differently than other layouts
+    if (const auto COVERING_FS_WINDOW = Fullscreen::controller()->getFullscreenWindow(m_parent->space()->workspace(), true); COVERING_FS_WINDOW) {
+        COVERING_FS_WINDOW->setInputBlocked(Desktop::View::INPUT_BLOCK_MONOCLE_INACTIVE, false);
+        *COVERING_FS_WINDOW->alpha(Desktop::View::WINDOW_ALPHA_LAYOUT) = 1.F;
         m_defaultFullscreenHandler->syncTargetSizeAndPosition();
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

- Title.

- also renames `moveToWorkspace()` -> `moveWindowToWorkspace()` to be less confusing (moving to workspace may also mean you are switching to it, though that has its own function so it's confusing)

<details> <summary> Repo steps: </summary>

Normal Workspace: Dwindle
Special Workspace: Monocle

Already have a window in the special workspace

Maximise a window in the normal workspace, move it to special with `on_focus_under_fullscreen = 1` and `follow = true`

It'll be invisible.

</details>

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- If other layouts are to also use custom input blocking reasons and `WINDOW_ALPHA_LAYOUT`, the same exception also has to be made for them

Otherwise nothing

#### Is it ready for merging, or does it need work?

- [ ] Test

