### PR TITLE
animations: add focus flash and shrink effects

### DIFF
--- a/hyprtester/src/tests/main/focus_effect.cpp
+++ b/hyprtester/src/tests/main/focus_effect.cpp
@@ -1,0 +1,64 @@
+#include <chrono>
+#include <thread>
+
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include "tests.hpp"
+
+TEST_CASE(focusEffectConfig) {
+    NLog::log("{}Testing decoration:focus_effect config", Colors::GREEN);
+
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'none' } })"));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'flash' } })"));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'shrink' } })"));
+    NOK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'explode' } })"));
+
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_flash_opacity = 0.25 } })"));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_shrink_percentage = 0.6 } })"));
+    NOK(getFromSocket("/eval hl.config({ decoration = { focus_flash_opacity = 1.5 } })"));
+    NOK(getFromSocket("/eval hl.config({ decoration = { focus_shrink_percentage = 0.05 } })"));
+
+    // restore defaults
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'none' } })"));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_flash_opacity = 0.5 } })"));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_shrink_percentage = 0.8 } })"));
+}
+
+TEST_CASE(focusEffectAnimations) {
+    NLog::log("{}Testing focus effect animation nodes", Colors::GREEN);
+
+    auto str = getFromSocket("/animations");
+    ASSERT_CONTAINS(str, "\tname: focus\n");
+    ASSERT_CONTAINS(str, "\tname: focusFlash\n");
+    ASSERT_CONTAINS(str, "\tname: focusShrink\n");
+}
+
+TEST_CASE(focusEffectDispatcher) {
+    NLog::log("{}Testing hl.dsp.window.focus_effect", Colors::GREEN);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:focus_effect' })"));
+
+    if (!Tests::spawnKitty("focus_effect_a"))
+        FAIL_TEST("Could not spawn kitty");
+
+    if (!Tests::spawnKitty("focus_effect_b"))
+        FAIL_TEST("Could not spawn kitty");
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:focus_effect_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.focus_effect({ effect = 'flash' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.focus_effect({ effect = 'shrink' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.focus_effect({ effect = 'none' })"));
+    NOK(getFromSocket("/dispatch hl.dsp.window.focus_effect({ effect = 'explode' })"));
+
+    // Config-driven focus path should not error.
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'flash' } })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:focus_effect_b' })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'shrink' } })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:focus_effect_a' })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    OK(getFromSocket("/eval hl.config({ decoration = { focus_effect = 'none' } })"));
+
+    Tests::killAllWindows();
+}

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -658,6 +658,10 @@ static int dsp_setProp(lua_State* L) {
     return Internal::checkResult(L, CA::setProp(lua_tostring(L, lua_upvalueindex(1)), lua_tostring(L, lua_upvalueindex(2)), Internal::windowFromUpval(L, 3)));
 }
 
+static int dsp_focusEffect(lua_State* L) {
+    return Internal::checkResult(L, CA::focusEffect(lua_tostring(L, lua_upvalueindex(1)), Internal::windowFromUpval(L, 2)));
+}
+
 static int dsp_moveIntoGroup(lua_State* L) {
     return Internal::checkResult(L, CA::moveIntoGroup(sc<Math::eDirection>((int)lua_tonumber(L, lua_upvalueindex(1))), Internal::windowFromUpval(L, 2)));
 }
@@ -1043,6 +1047,17 @@ static int hlWindowAlterZOrder(lua_State* L) {
     return 1;
 }
 
+static int hlWindowFocusEffect(lua_State* L) {
+    if (!lua_istable(L, 1))
+        return Internal::configError(L, "hl.window.focus_effect: expected a table { effect, window? }");
+
+    const auto effect = Internal::requireTableFieldStr(L, 1, "effect", "hl.window.focus_effect");
+    lua_pushstring(L, effect.c_str());
+    Internal::pushWindowUpval(L, 1);
+    lua_pushcclosure(L, dsp_focusEffect, 2);
+    return 1;
+}
+
 static int hlWindowSetProp(lua_State* L) {
     if (!lua_istable(L, 1))
         return Internal::configError(L, "hl.window.set_prop: expected a table { prop, value, window? }");
@@ -1382,6 +1397,7 @@ void Internal::registerDispatcherBindings(lua_State* L) {
         Internal::setFn(L, "bring_to_top", hlWindowBringToTop);
         Internal::setFn(L, "alter_zorder", hlWindowAlterZOrder);
         Internal::setFn(L, "set_prop", hlWindowSetProp);
+        Internal::setFn(L, "focus_effect", hlWindowFocusEffect);
         Internal::setFn(L, "deny_from_group", hlWindowDenyFromGroup);
         Internal::setFn(L, "drag", hlWindowDrag);
         Internal::setFn(L, "resize", hlWindowResize);

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -878,6 +878,21 @@ ActionResult Actions::setProp(const std::string& PROP, const std::string& VAL, s
     return {};
 }
 
+ActionResult Actions::focusEffect(const std::string& effect, std::optional<PHLWINDOW> w) {
+    auto window = xtract(w);
+    if (!window)
+        return {};
+
+    if (effect != "flash" && effect != "shrink" && effect != "none")
+        return actionError("Invalid focus effect, expected flash, shrink, or none", eActionErrorLevel::ERROR, eActionErrorCode::INVALID_ARGUMENT);
+
+    if (effect == "none")
+        return {};
+
+    window->playFocusEffect(effect);
+    return {};
+}
+
 ActionResult Actions::toggleGroup(std::optional<PHLWINDOW> w) {
     auto window = xtract(w);
     if (!window)

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -65,6 +65,7 @@ namespace Config::Actions {
     ActionResult swapNext(const bool next, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult alterZOrder(const std::string& mode, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult setProp(const std::string& prop, const std::string& val, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
+    ActionResult focusEffect(const std::string& effect, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
 
     ActionResult toggleGroup(std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult changeGroupActive(bool forward = true, std::optional<PHLWINDOW> window = std::nullopt /* Active */);

--- a/src/config/shared/animation/AnimationTree.cpp
+++ b/src/config/shared/animation/AnimationTree.cpp
@@ -26,6 +26,7 @@ void CAnimationTreeController::reset() {
     m_animationTree.createNode("workspaces", "global");
     m_animationTree.createNode("zoomFactor", "global");
     m_animationTree.createNode("monitorAdded", "global");
+    m_animationTree.createNode("focus", "global");
 
     // layer
     m_animationTree.createNode("layersIn", "layers");
@@ -50,6 +51,10 @@ void CAnimationTreeController::reset() {
     m_animationTree.createNode("fadePopupsIn", "fadePopups");
     m_animationTree.createNode("fadePopupsOut", "fadePopups");
     m_animationTree.createNode("fadeDpms", "fade");
+
+    // focus
+    m_animationTree.createNode("focusFlash", "focus");
+    m_animationTree.createNode("focusShrink", "focus");
 
     // workspaces
     m_animationTree.createNode("workspacesIn", "workspaces");

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -228,6 +228,9 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Float>("decoration:dim_special", "how much to dim the rest of the screen by when a special workspace is open.", 0.2,
                   {.min = 0, .max = 1, .refresh = Supplementary::REFRESH_WINDOW_STATES}),
         MS<Float>("decoration:dim_around", "how much the dimaround window rule should dim by.", 0.4, {.min = 0, .max = 1, .refresh = Supplementary::REFRESH_WINDOW_STATES}),
+        MS<String>("decoration:focus_effect", "effect to play when a window gains focus. [none/flash/shrink]", "none", {.validator = strChoice({"none", "flash", "shrink"})}),
+        MS<Float>("decoration:focus_flash_opacity", "opacity to flash to when decoration:focus_effect is flash.", 0.5, {.min = 0, .max = 1}),
+        MS<Float>("decoration:focus_shrink_percentage", "scale to shrink to when decoration:focus_effect is shrink.", 0.8, {.min = 0.1, .max = 1}),
         MS<String>("decoration:screen_shader", "a path to a custom shader to be applied at the end of rendering.", STRVAL_EMPTY, {.refresh = Supplementary::REFRESH_SCREEN_SHADER}),
         MS<Bool>("decoration:border_part_of_window", "whether the border should be treated as a part of the window.", true),
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -121,6 +121,8 @@ PHLWINDOW CWindow::create(SP<CXWaylandSurface> surface) {
     Animation::mgr()->createAnimation(0.f, pWindow->m_glowFadeAnimationProgress, Config::animationTree()->getAnimationPropertyConfig("fadeGlow"), pWindow, AVARDAMAGE_GLOW);
     Animation::mgr()->createAnimation(0.f, pWindow->m_glowAngleAnimationProgress, Config::animationTree()->getAnimationPropertyConfig("glowangle"), pWindow, AVARDAMAGE_GLOW);
     Animation::mgr()->createAnimation(0.f, pWindow->m_dimPercent, Config::animationTree()->getAnimationPropertyConfig("fadeDim"), pWindow, AVARDAMAGE_ENTIRE);
+    Animation::mgr()->createAnimation(1.f, pWindow->m_focusFlash, Config::animationTree()->getAnimationPropertyConfig("focusFlash"), pWindow, AVARDAMAGE_ENTIRE);
+    Animation::mgr()->createAnimation(1.f, pWindow->m_focusScale, Config::animationTree()->getAnimationPropertyConfig("focusShrink"), pWindow, AVARDAMAGE_ENTIRE);
     Animation::mgr()->createAnimation(1.f, pWindow->alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE), Config::animationTree()->getAnimationPropertyConfig("fadeOut"), pWindow,
                                       AVARDAMAGE_ENTIRE);
     Animation::mgr()->createAnimation(1.f, pWindow->alpha(WINDOW_ALPHA_MOVE_FROM_WORKSPACE), Config::animationTree()->getAnimationPropertyConfig("fadeIn"), pWindow,
@@ -159,6 +161,8 @@ PHLWINDOW CWindow::create(SP<CXDGSurfaceResource> resource) {
     Animation::mgr()->createAnimation(0.f, pWindow->m_glowFadeAnimationProgress, Config::animationTree()->getAnimationPropertyConfig("fadeGlow"), pWindow, AVARDAMAGE_GLOW);
     Animation::mgr()->createAnimation(0.f, pWindow->m_glowAngleAnimationProgress, Config::animationTree()->getAnimationPropertyConfig("glowangle"), pWindow, AVARDAMAGE_GLOW);
     Animation::mgr()->createAnimation(0.f, pWindow->m_dimPercent, Config::animationTree()->getAnimationPropertyConfig("fadeDim"), pWindow, AVARDAMAGE_ENTIRE);
+    Animation::mgr()->createAnimation(1.f, pWindow->m_focusFlash, Config::animationTree()->getAnimationPropertyConfig("focusFlash"), pWindow, AVARDAMAGE_ENTIRE);
+    Animation::mgr()->createAnimation(1.f, pWindow->m_focusScale, Config::animationTree()->getAnimationPropertyConfig("focusShrink"), pWindow, AVARDAMAGE_ENTIRE);
     Animation::mgr()->createAnimation(1.f, pWindow->alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE), Config::animationTree()->getAnimationPropertyConfig("fadeOut"), pWindow,
                                       AVARDAMAGE_ENTIRE);
     Animation::mgr()->createAnimation(1.f, pWindow->alpha(WINDOW_ALPHA_MOVE_FROM_WORKSPACE), Config::animationTree()->getAnimationPropertyConfig("fadeIn"), pWindow,
@@ -800,11 +804,15 @@ void CWindow::onMap() {
     m_glowFadeAnimationProgress->resetAllCallbacks();
     m_glowAngleAnimationProgress->resetAllCallbacks();
     m_dimPercent->resetAllCallbacks();
+    m_focusFlash->resetAllCallbacks();
+    m_focusScale->resetAllCallbacks();
     alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE)->resetAllCallbacks();
     alpha(WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->resetAllCallbacks();
 
     alpha(WINDOW_ALPHA_MOVE_FROM_WORKSPACE)->setValueAndWarp(1.F);
     alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE)->setValueAndWarp(1.F);
+    m_focusFlash->setValueAndWarp(1.F);
+    m_focusScale->setValueAndWarp(1.F);
 
     resetMotionBlur();
     resetWobble();
@@ -1105,6 +1113,9 @@ bool CWindow::opaque() {
     if (alphaValue(WINDOW_ALPHA_FADE) != 1.f || alphaValue(WINDOW_ALPHA_FULLSCREEN) != 1.f || alphaValue(WINDOW_ALPHA_ACTIVE) != 1.f)
         return false;
 
+    if (m_focusFlash && m_focusFlash->value() != 1.f)
+        return false;
+
     const auto PWORKSPACE = m_workspace;
 
     if (m_wlSurface->small() && !m_wlSurface->m_fillIgnoreSmall)
@@ -1285,6 +1296,37 @@ void CWindow::onFocusAnimUpdate() {
     if (m_glowAngleAnimationProgress->enabled() && !m_glowAngleAnimationProgress->isBeingAnimated()) {
         m_glowAngleAnimationProgress->setValueAndWarp(0.f);
         *m_glowAngleAnimationProgress = 1.f;
+    }
+
+    playFocusEffect();
+}
+
+void CWindow::playFocusEffect(const std::string& effect) {
+    static auto PEFFECT = CConfigValue<std::string>("decoration:focus_effect");
+    static auto PFLASH  = CConfigValue<Config::FLOAT>("decoration:focus_flash_opacity");
+    static auto PSHRINK = CConfigValue<Config::FLOAT>("decoration:focus_shrink_percentage");
+
+    const auto  EFFECT = effect.empty() ? *PEFFECT : effect;
+
+    if (EFFECT == "flash") {
+        if (!m_focusFlash || !m_focusFlash->enabled())
+            return;
+
+        m_focusFlash->setValueAndWarp(*PFLASH);
+        *m_focusFlash = 1.f;
+        return;
+    }
+
+    if (EFFECT == "shrink") {
+        if (!m_focusScale || !m_focusScale->enabled())
+            return;
+
+        // Don't fight an in-progress size animation like a popin,
+        if (sizeAnimation()->isBeingAnimated())
+            return;
+
+        m_focusScale->setValueAndWarp(*PSHRINK);
+        *m_focusScale = 1.f;
     }
 }
 

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -259,6 +259,10 @@ namespace Desktop::View {
         // animated tint
         PHLANIMVAR<float> m_dimPercent;
 
+        // focus effects (flash opacity multiplier / shrink scale). 1 = identity.
+        PHLANIMVAR<float> m_focusFlash;
+        PHLANIMVAR<float> m_focusScale;
+
         // animate moving to an invisible workspace
         int m_monitorMovedFrom = -1; // -1 means not moving
 
@@ -396,6 +400,7 @@ namespace Desktop::View {
         void                              setAnimationsToMove();
         void                              onWorkspaceAnimUpdate();
         void                              onFocusAnimUpdate();
+        void                              playFocusEffect(const std::string& effect = "");
         std::optional<MotionBlur::SState> motionBlurState(bool allowStale = false) const;
         void                              damageMotionBlur(bool allowStale = false) const;
         void                              recordMotionBlur(const CBox& previous, const CBox& current);

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -185,8 +185,25 @@ void IElementRenderer::drawRect(WP<CRectPassElement> element, const CRegion& dam
 
 void IElementRenderer::drawHints(WP<CRendererHintsPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
-    if (m_data.renderModif.has_value())
-        g_pHyprRenderer->m_renderData.renderModif = *m_data.renderModif;
+
+    if (m_data.popCount > 0) {
+        auto& modifs = g_pHyprRenderer->m_renderData.renderModif.modifs;
+        if (modifs.size() >= m_data.popCount)
+            modifs.erase(modifs.end() - sc<long>(m_data.popCount), modifs.end());
+        return;
+    }
+
+    if (!m_data.renderModif.has_value())
+        return;
+
+    if (m_data.append) {
+        for (const auto& modif : m_data.renderModif->modifs) {
+            g_pHyprRenderer->m_renderData.renderModif.modifs.emplace_back(modif);
+        }
+        return;
+    }
+
+    g_pHyprRenderer->m_renderData.renderModif = *m_data.renderModif;
 }
 
 void IElementRenderer::drawPreBlur(WP<CPreBlurElement> element, const CRegion& damage) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -592,7 +592,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.fadeAlpha = pWindow->alphaValue(WINDOW_ALPHA_FADE) * pWindow->alphaValue(WINDOW_ALPHA_FULLSCREEN) * pWindow->alphaValue(WINDOW_ALPHA_LAYOUT) *
         (pWindow->m_pinned || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) : 1.F) * pWindow->alphaValue(WINDOW_ALPHA_MOVE_FROM_WORKSPACE);
-    renderdata.alpha         = pWindow->alphaValue(WINDOW_ALPHA_ACTIVE);
+    renderdata.alpha         = pWindow->alphaValue(WINDOW_ALPHA_ACTIVE) * (pWindow->m_focusFlash ? pWindow->m_focusFlash->value() : 1.f);
     renderdata.decorate      = decorate && !pWindow->m_X11DoesntWantBorders && Fullscreen::controller()->getFullscreenModes(pWindow).internal != Fullscreen::FSMODE_FULLSCREEN;
     renderdata.rounding      = standalone || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->m_scale;
     renderdata.roundingPower = standalone || renderdata.dontRound ? 2.0f : pWindow->roundingPower();
@@ -615,7 +615,28 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
 
-    const auto fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
+    // scale around the window center without mutating layout geometry.
+    SRenderModifData FOCUSSCALEMODIF;
+    size_t           focusScaleModifCount = 0;
+    if (!standalone && pWindow->m_focusScale) {
+        const float FOCUSSCALE = pWindow->m_focusScale->value();
+        if UNLIKELY (FOCUSSCALE != 1.f) {
+            const Vector2D CENTER = (pWindow->middle() + pWindow->m_floatingOffset - pMonitor->m_position) * pMonitor->m_scale;
+            FOCUSSCALEMODIF.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, -CENTER);
+            FOCUSSCALEMODIF.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, FOCUSSCALE);
+            FOCUSSCALEMODIF.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, CENTER);
+            focusScaleModifCount = FOCUSSCALEMODIF.modifs.size();
+            m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{.renderModif = FOCUSSCALEMODIF, .append = true}));
+        }
+    }
+
+    CScopeGuard focusScaleGuard([focusScaleModifCount] {
+        if (focusScaleModifCount == 0)
+            return;
+        g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{.popCount = focusScaleModifCount}));
+    });
+
+    const auto  fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
 
     if (*PDIMAROUND && pWindow->m_ruleApplicator->dimAround().valueOrDefault() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
         CBox                        monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};

--- a/src/render/pass/RendererHintsPassElement.hpp
+++ b/src/render/pass/RendererHintsPassElement.hpp
@@ -6,6 +6,9 @@ class CRendererHintsPassElement : public IPassElement {
   public:
     struct SData {
         std::optional<Render::SRenderModifData> renderModif;
+        bool                                    append = false;
+        // pop this many modifs from the current renderModif (ignores renderModif/append).
+        size_t popCount = 0;
     };
 
     CRendererHintsPassElement(const SData& data);


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Adds native focus animations similar to [hyprfocus](https://github.com/VortexCoyote/hyprfocus): when a window gains focus it can briefly flash (opacity) or shrink (scale), then return to normal

Config:
```lua
-- pick one: "flash" or "shrink" (or "none")
hl.config({
  decoration = {
    focus_effect = "shrink",
    focus_flash_opacity = 0.45,      -- used when focus_effect = "flash"
    focus_shrink_percentage = 0.85, -- used when focus_effect = "shrink"
  },
})

hl.animation({ leaf = "focusFlash", enabled = true, speed = 5, bezier = "default" })
hl.animation({ leaf = "focusShrink", enabled = true, speed = 4, bezier = "default" })
```
Also adds animation leaves `focusFlash` / `focusShrink`, and a dispatcher `hl.dsp.window.focus_effect` for one-shots. Uses dedicated anim vars so it doesn’t mess with layout geometry or active opacity.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- New config options will need a wiki update
- Was tested manually and confirmed to work
- hyprtester covers config/animations/dispatcher; full suite had a few unrelated flakes on my machine

#### Is it ready for merging, or does it need work?
Ready for review. Wiki docs still need a follow-up PR.