### PR TITLE
monitor: fix UB reading Config::INTEGER from bool

### DIFF
--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -2495,7 +2495,7 @@ NColorManagement::SImageDescription::SPCMasteringLuminances CMonitor::getMasteri
 }
 
 uint32_t CMonitor::getPreferredReadFormat() {
-    static const auto PFORCE8BIT = CConfigValue<Config::INTEGER>("misc:screencopy_force_8b");
+    static const auto PFORCE8BIT = CConfigValue<Config::BOOL>("misc:screencopy_force_8b");
 
     auto              monFmt = m_output->state->state().drmFormat;
 


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

`misc:screencopy_force_8b` is declared `MS<Bool>` and then read as `Config::INTEGER`, which is UB at least two ways.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think the option is inert as is, since `true` is default. THe option is likely always surrounded by nonzero bytes making the truthiness of the option guaranteed-ish when it reads 8 bytes from a pointer to bool. Most captures probably break if screencopies aren't 8 bit.

#### Is it ready for merging, or does it need work?

ready, 1-liner
