### PR TITLE
frame time scheduling

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -580,7 +580,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("render:send_content_type", "Report content type to allow monitor profile autoswitch", true),
         MS<Int>("render:cm_auto_hdr", "Auto-switch to hdr mode when fullscreen app is in hdr", 1,
                 {.min = 0, .max = 2, .map = OptionMap{{"disable", 0}, {"hdr", 1}, {"hdredid", 2}}}),
-        MS<Bool>("render:new_render_scheduling", "enable new render scheduling, which should improve FPS on underpowered devices.", false),
+        MS<Bool>("render:new_render_scheduling", "Use new render scheduling, which should reduce latency and stutters.", true),
         MS<Int>("render:non_shader_cm", "Enable CM without shader.", 3, {.min = 0, .max = 3, .map = OptionMap{{"disable", 0}, {"always", 1}, {"ondemand", 2}, {"ignore", 3}}}),
         MS<String>("render:cm_sdr_eotf", "Default transfer function for displaying SDR apps.", "default"),
         MS<Bool>("render:commit_timing_enabled", "Enable commit timing proto. Requires restart", true),

--- a/src/helpers/Drm.cpp
+++ b/src/helpers/Drm.cpp
@@ -5,7 +5,9 @@
 #include <optional>
 #include <sys/stat.h>
 #include <hyprutils/os/FileDescriptor.hpp>
+#include <hyprutils/memory/Casts.hpp>
 #include <string>
+#include <vector>
 #include <algorithm>
 #include "Drm.hpp"
 #include <sys/ioctl.h>
@@ -26,6 +28,7 @@ struct sync_merge_data {
 #endif
 
 using namespace Hyprutils::OS;
+using namespace Hyprutils::Memory;
 
 namespace {
     using SDRMNodePair = std::array<dev_t, 2>;
@@ -96,6 +99,41 @@ int DRM::doIoctl(int fd, unsigned long request, void* arg) {
         ret = ioctl(fd, request, arg);
     } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
     return ret;
+}
+
+// https://www.kernel.org/doc/html/latest/driver-api/sync_file.html
+// when the fence signalled, which is not the same as when we got around to noticing it - the
+// readable notification only arrives on the next event loop wakeup.
+std::optional<Time::steady_tp> DRM::fenceSignalTime(int fd) {
+    if (fd < 0)
+        return std::nullopt;
+
+#ifdef __linux__
+    sync_file_info info{};
+
+    // num_fences 0 asks the kernel how many there are.
+    if (doIoctl(fd, SYNC_IOC_FILE_INFO, &info) != 0 || info.num_fences == 0)
+        return std::nullopt;
+
+    std::vector<sync_fence_info> fences(info.num_fences);
+    info.sync_fence_info = rc<uintptr_t>(fences.data());
+
+    if (doIoctl(fd, SYNC_IOC_FILE_INFO, &info) != 0)
+        return std::nullopt;
+
+    // the sync file is done when all of its fences are, so the last one to change status is the time we want.
+    __u64 latest = 0;
+    for (const auto& FENCE : fences) {
+        if (FENCE.status != 1)
+            return std::nullopt; // still pending, no completion time to report.
+
+        latest = std::max(latest, FENCE.timestamp_ns);
+    }
+
+    return Time::steady_tp{std::chrono::nanoseconds{sc<Time::steady_dur::rep>(latest)}};
+#else
+    return std::nullopt;
+#endif
 }
 
 // https://www.kernel.org/doc/html/latest/driver-api/dma-buf.html#c.dma_buf_export_sync_file

--- a/src/helpers/Drm.hpp
+++ b/src/helpers/Drm.hpp
@@ -3,11 +3,13 @@
 #include <optional>
 #include <sys/types.h>
 #include <hyprutils/os/FileDescriptor.hpp>
+#include "time/Time.hpp"
 
 namespace DRM {
     std::optional<dev_t>           devIDFromFD(int fd);
     bool                           sameGpu(int fd1, int fd2);
     int                            doIoctl(int fd, unsigned long request, void* arg);
+    std::optional<Time::steady_tp> fenceSignalTime(int fd);
     Hyprutils::OS::CFileDescriptor exportFence(int fd);
     Hyprutils::OS::CFileDescriptor mergeFence(const Hyprutils::OS::CFileDescriptor& fd1, const Hyprutils::OS::CFileDescriptor& fd2);
 }

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -139,6 +139,15 @@ void CEventLoopManager::enterLoop() {
     Log::logger->log(Log::DEBUG, "Kicked off the event loop! :(");
 }
 
+void CEventLoopManager::flushClients() {
+    wl_client* client = nullptr;
+    wl_client_for_each(client, wl_display_get_client_list(m_wayland.display)) {
+        // flushes every clients connection. wl_display_flush_clients destroys
+        // a client on a failed flush, wl_client_flush does not.
+        wl_client_flush(client);
+    }
+}
+
 void CEventLoopManager::onTimerFire() {
     const auto CPY = m_timers.timers;
     for (auto const& t : CPY) {

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -50,6 +50,7 @@ class CEventLoopManager {
     ~CEventLoopManager();
 
     void enterLoop();
+    void flushClients();
 
     // Note: will remove the timer if the ptr is lost.
     void addTimer(SP<CEventLoopTimer> timer);

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -159,6 +159,12 @@ void CMonitor::onConnect(bool noRule) {
             flags &= ~Aquamarine::IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK;
         }
 
+        // without a hardware clock the timestamp is sampled when we dispatched the flip event, so it
+        // carries our own event loop latency. clients feeding it back into commit-timing deadlines
+        // lose that much of their margin. filter it before anything downstream sees it.
+        if (!(flags & Aquamarine::IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK) && !m_vrrActive && !m_tearingState.activelyTearing)
+            ts = Time::toTimespec(m_presentationTimeFilter.filter(Time::fromTimespec(&ts), std::chrono::nanoseconds(event.refresh)));
+
         PROTO::presentation->onPresented(m_self.lock(), ts, event.refresh, event.seq, flags);
 
         if (m_zoomAnimFrameCounter < 5) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -185,18 +185,18 @@ void CMonitor::onConnect(bool noRule) {
         // if the monitor has no pending frames, we wont hit the no damage send frame callback path in rendermonitor
         // this becomes really noticeable in new render scheduling. causing firefox to simply wait for a new frame callback.
         // when nothing is scheduling new frames.
-        auto mon = m_self.lock();
+        auto       mon  = m_self.lock();
+        auto const WHEN = Time::fromTimespec(&ts);
         if (!isMirror() && !g_pHyprRenderer->shouldRenderMonitor(mon)) {
-            auto const NOW = Time::steadyNow();
             if (m_activeWorkspace)
-                g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeWorkspace, NOW);
+                g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeWorkspace, WHEN);
             if (m_activeSpecialWorkspace)
-                g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeSpecialWorkspace, NOW);
+                g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeSpecialWorkspace, WHEN);
         }
 
-        m_frameScheduler->onPresented();
+        m_events.presented.emit(WHEN);
 
-        m_events.presented.emit(Time::fromTimespec(&ts));
+        m_frameScheduler->onPresented(WHEN, event.refresh);
     });
 
     m_listeners.destroy = m_output->events.destroy.listen([this] {
@@ -1134,6 +1134,12 @@ void CMonitor::scheduleFrame(Aquamarine::IOutput::scheduleFrameReason reason) {
 
     if (m_renderingActive)
         m_pendingFrame = true;
+
+    if (m_frameScheduler && m_frameScheduler->renderPending()) {
+        m_output->needsFrame = true;
+        m_pendingFrame       = true;
+        return;
+    }
 
     m_output->scheduleFrame(reason);
 }

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -197,6 +197,11 @@ void CMonitor::onConnect(bool noRule) {
         m_events.presented.emit(WHEN);
 
         m_frameScheduler->onPresented(WHEN, event.refresh);
+
+        // presentation, fifo and commit-timing all send off the emits above. get them out now, or they
+        // sit in the connection buffer until the loop flushes, which is after the frame we're about to render.
+        if (m_frameScheduler->newSchedulingEnabled())
+            g_pEventLoopManager->flushClients();
     });
 
     m_listeners.destroy = m_output->events.destroy.listen([this] {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -2237,8 +2237,10 @@ bool CMonitor::attemptDirectScanout() {
             m_inFence.reset();
             m_output->state->resetExplicitFences(); // good luck.
         }
-    } else
+    } else {
+        m_inFence.reset();
         m_output->state->resetExplicitFences();
+    }
 
     // no need to do explicit sync here as surface current can only ever be ready to read
 

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -19,6 +19,7 @@
 #include "../render/Texture.hpp"
 #include "../render/Framebuffer.hpp"
 #include "MonitorResources.hpp"
+#include "PresentationTimeFilter.hpp"
 #include "../helpers/time/Timer.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../desktop/reserved/ReservedArea.hpp"
@@ -136,6 +137,7 @@ namespace Monitor {
         PHLMONITORREF                  m_self;
 
         UP<CMonitorFrameScheduler>     m_frameScheduler;
+        CPresentationTimeFilter        m_presentationTimeFilter;
 
         // mirroring
         PHLMONITORREF              m_mirrorOf;

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -11,77 +11,38 @@ CMonitorFrameScheduler::CMonitorFrameScheduler(PHLMONITOR m) : m_monitor(m) {
     ;
 }
 
+CMonitorFrameScheduler::~CMonitorFrameScheduler() {
+    if (g_pEventLoopManager && m_renderTimer) {
+        m_renderTimer->cancel();
+        g_pEventLoopManager->removeTimer(m_renderTimer);
+    }
+}
+
 bool CMonitorFrameScheduler::newSchedulingEnabled() {
     static auto PENABLENEW = CConfigValue<Config::INTEGER>("render:new_render_scheduling");
 
-    return *PENABLENEW && g_pHyprRenderer->explicitSyncSupported() && m_monitor && !m_monitor->m_directScanoutIsActive;
+    //#TODO: figure out if this can be done on vrr/tearing
+    return *PENABLENEW && g_pHyprRenderer->explicitSyncSupported() && m_monitor && !m_monitor->m_tearingState.activelyTearing && !m_monitor->m_vrrActive;
 }
 
-void CMonitorFrameScheduler::onSyncFired() {
+void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when, int refreshNs) {
     const auto PMONITOR = m_monitor.lock();
     if (!PMONITOR || !newSchedulingEnabled())
         return;
 
-    // Sync fired: reset submitted state, set as rendered. Check the last render time. If we are running
-    // late, we will instantly render here.
+    // drm hands us the period in ns, but its 0 if the connector has no refresh.
+    const float HZ  = PMONITOR->m_refreshRate > 0.F ? PMONITOR->m_refreshRate : 60.F;
+    m_refreshPeriod = refreshNs > 0 ? std::chrono::nanoseconds(refreshNs) : std::chrono::nanoseconds(static_cast<int64_t>(1'000'000'000.0 / HZ));
 
-    if (std::chrono::duration_cast<std::chrono::microseconds>(hrc::now() - m_lastRenderBegun).count() / 1000.F < 1000.F / PMONITOR->m_refreshRate) {
-        // we are in. Frame is valid. We can just render as normal.
-        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, didn't miss.", PMONITOR->m_name);
-        m_renderAtFrame = true;
-        return;
-    }
-
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, missed.", PMONITOR->m_name);
-
-    // we are out. The frame is taking too long to render. Begin rendering immediately, but don't commit yet.
-    m_pendingThird  = true;
-    m_renderAtFrame = false; // block frame rendering, we already scheduled
-
-    m_lastRenderBegun = hrc::now();
-
-    // get a ref to ourselves. renderMonitor can destroy this scheduler if it decides to perform a monitor reload
-    // FIXME: this is horrible. "renderMonitor" should not be able to do that.
-    auto self = m_self;
-
-    g_pHyprRenderer->renderMonitor(PMONITOR, false);
-
-    if (!self)
-        return;
-
-    onFinishRender();
-}
-
-void CMonitorFrameScheduler::onPresented() {
-    const auto PMONITOR = m_monitor.lock();
-    if (!PMONITOR || !newSchedulingEnabled())
-        return;
-
-    if (!m_pendingThird)
-        return;
-
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending.", PMONITOR->m_name);
-
-    m_pendingThird = false;
-
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending at the earliest convenience.", PMONITOR->m_name);
-
-    g_pEventLoopManager->doLater([m = PHLMONITORREF{PMONITOR}] {
-        if (!m || !m->m_output)
-            return;
-
-        auto ml = m.lock();
-
-        g_pHyprRenderer->commitPendingAndDoExplicitSync(ml); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
-
-        // schedule a frame: we might have some missed damage, which got cleared due to the above commit.
-        // TODO: this is not always necessary, but doesn't hurt in general. We likely won't hit this if nothing's happening anyways.
-        if (ml->m_damage.hasChanged())
-            ml->scheduleFrame();
-    });
+    m_earliestNextFlip = when + m_refreshPeriod;
+    m_delayNextFrame   = true; // this comes with the assumption next frame from AQ actually comes from the pageflip, the AQ currently does.
 }
 
 void CMonitorFrameScheduler::onFrame() {
+    // whatever we do below, the arming from onPresented belongs to this frame only.
+    const auto EARLIEST_FLIP = std::exchange(m_earliestNextFlip, {});
+    const bool DELAY         = std::exchange(m_delayNextFrame, false);
+
     const auto PMONITOR = m_monitor.lock();
     if (!PMONITOR || !canRender())
         return;
@@ -100,47 +61,55 @@ void CMonitorFrameScheduler::onFrame() {
     }
 
     if (!newSchedulingEnabled()) {
-        PMONITOR->m_lastPresentationTimer.reset();
+        // config change might still have this armed.
+        if (!m_renderTimer || (m_renderTimer && !m_renderTimer->armed()))
+            renderNow();
 
-        g_pHyprRenderer->renderMonitor(PMONITOR);
         return;
     }
 
-    if (!m_renderAtFrame) {
-        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, but m_renderAtFrame = false.", PMONITOR->m_name);
-        return;
+    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, scheduling a render on the event loop.", PMONITOR->m_name);
+
+    if (!m_renderTimer) {
+        m_renderTimer = makeShared<CEventLoopTimer>(
+            std::nullopt,
+            [this, self = m_self](SP<CEventLoopTimer>, void*) {
+                if (self.expired())
+                    return;
+
+                renderNow();
+            },
+            nullptr);
+
+        g_pEventLoopManager->addTimer(m_renderTimer);
     }
 
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, render = true, rendering normally.", PMONITOR->m_name);
+    if (DELAY && m_refreshPeriod > Time::steady_dur::zero() && !m_renderTimer->armed()) /*pageflip emitted .frame()*/ {
+        //const auto NOW    = Time::steadyNow();
+        //const auto TARGET = EARLIEST_FLIP - estimatedRenderCost();
+        //m_renderTimer->updateTimeout(TARGET > NOW ? TARGET - NOW : std::chrono::nanoseconds(50));
 
-    m_lastRenderBegun = hrc::now();
+        //#TODO: until rendermonitor rewrite happends, we cant measure rendercost reliably.
+        m_renderTimer->updateTimeout(std::chrono::nanoseconds(50));
+    } else if (!m_renderTimer->armed())                             // idle frame callback emitted .frame()
+        m_renderTimer->updateTimeout(std::chrono::nanoseconds(50)); // just add a tiny delay, since the wl_event_loop has no order guarantee, but delaying it means should be last.
+}
+
+bool CMonitorFrameScheduler::renderPending() {
+    return m_renderTimer && m_renderTimer->armed();
+}
+
+void CMonitorFrameScheduler::renderNow() {
+    const auto PMONITOR = m_monitor.lock();
+    if (!PMONITOR || !canRender())
+        return;
+
+    PMONITOR->m_lastPresentationTimer.reset();
 
     // get a ref to ourselves. renderMonitor can destroy this scheduler if it decides to perform a monitor reload
     // FIXME: this is horrible. "renderMonitor" should not be able to do that.
     auto self = m_self;
-
     g_pHyprRenderer->renderMonitor(PMONITOR);
-
-    if (!self)
-        return;
-
-    onFinishRender();
-}
-
-void CMonitorFrameScheduler::onFinishRender() {
-    m_sync = g_pHyprRenderer->createSyncFDManager(); // this destroys the old sync
-    if (!m_sync || !m_sync->isValid()) {
-        Log::logger->log(Log::ERR, "CMonitorFrameScheduler: explicit sync failed, falling back to frame events");
-        m_sync.reset();
-        m_renderAtFrame = true;
-        return;
-    }
-
-    g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this, self = m_self] {
-        if (!self) // might've gotten destroyed
-            return;
-        onSyncFired();
-    });
 }
 
 bool CMonitorFrameScheduler::canRender() {

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -35,17 +35,14 @@ void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when, int refres
     if (!PMONITOR || !newSchedulingEnabled())
         return;
 
-    // drm hands us the period in ns, but its 0 if the connector has no refresh.
-    const float HZ  = PMONITOR->m_refreshRate > 0.F ? PMONITOR->m_refreshRate : 60.F;
-    m_refreshPeriod = refreshNs > 0 ? std::chrono::nanoseconds(refreshNs) : std::chrono::nanoseconds(static_cast<int64_t>(1'000'000'000.0 / HZ));
+    m_frameTimes.setRefreshPeriod(refreshNs, PMONITOR->m_refreshRate);
 
     // did the frame we timed actually make the flip it aimed at?
-    const auto LATE = when - AIMED_AT;
-    if (AIMED_AT.time_since_epoch() > Time::steady_dur::zero() && LATE > m_refreshPeriod / 2 && LATE < m_refreshPeriod * 4)
+    if (const auto LATE = m_frameTimes.flipMiss(when, AIMED_AT); LATE)
         Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> missed the flip we aimed at by {:.3f}ms", PMONITOR->m_name,
-                         std::chrono::duration<float, std::milli>(LATE).count());
+                         std::chrono::duration<float, std::milli>(*LATE).count());
 
-    m_earliestNextFlip = when + m_refreshPeriod;
+    m_earliestNextFlip = when + m_frameTimes.refreshPeriod();
     m_delayNextFrame   = true; // this comes with the assumption next frame from AQ actually comes from the pageflip, the AQ currently does.
 }
 
@@ -101,7 +98,7 @@ void CMonitorFrameScheduler::onFrame() {
                 if (!PMONITOR)
                     return;
 
-                if (PMONITOR->m_inFence.isValid() && PMONITOR->output()->pendingPageFlip() && DEADLINE > START && m_refreshPeriod > Time::steady_dur::zero()) {
+                if (PMONITOR->m_inFence.isValid() && PMONITOR->output()->pendingPageFlip() && DEADLINE > START && m_frameTimes.hasRefreshPeriod()) {
                     m_inFlightDeadline = DEADLINE; // we committed, so a presentation for this deadline is coming.
 
                     auto fence = makeShared<CFileDescriptor>(PMONITOR->m_inFence.duplicate());
@@ -122,26 +119,18 @@ void CMonitorFrameScheduler::onFrame() {
         g_pEventLoopManager->addTimer(m_renderTimer);
     }
 
-    if (DELAY && m_refreshPeriod > Time::steady_dur::zero() && !m_renderTimer->armed()) /*pageflip emitted .frame()*/ {
-        const auto NOW      = Time::steadyNow();
-        const auto COST     = m_frameTimes.estimatedRenderCost();
-        const auto DEADLINE = std::min(EARLIEST_FLIP, NOW + m_refreshPeriod);
-        const auto TARGET   = DEADLINE - COST;
+    if (!m_renderTimer->armed()) {
+        // DELAY means a pageflip emitted .frame(), so there is a vblank to aim at. otherwise it came from an idle
+        // frame callback and nextArm just gets us behind the rest of this loop iteration.
+        const auto TARGET = m_frameTimes.nextTarget(Time::steadyNow(), DELAY ? EARLIEST_FLIP : Time::steady_tp{});
 
-        // only delay if the estimate says we can still make this flip.
-        const bool CAN_DELAY = m_frameTimes.hasSamples() && COST < m_refreshPeriod && TARGET > NOW;
-        const auto ARM_IN    = CAN_DELAY ? TARGET - NOW : FRAME_IDLE_DELAY;
+        m_pendingDeadline = TARGET.deadline;
 
-        m_pendingDeadline = DEADLINE;
+        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, period {:.3f}ms, est. cost {:.3f}ms, arming in {:.3f}ms", PMONITOR->m_name,
+                         std::chrono::duration<float, std::milli>(m_frameTimes.refreshPeriod()).count(),
+                         std::chrono::duration<float, std::milli>(m_frameTimes.estimatedRenderCost()).count(), std::chrono::duration<float, std::milli>(TARGET.target).count());
 
-        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, period {:.3f}ms, target in {:.3f}ms, est. cost {:.3f}ms, arming in {:.3f}ms", PMONITOR->m_name,
-                         std::chrono::duration<float, std::milli>(m_refreshPeriod).count(), std::chrono::duration<float, std::milli>(TARGET - NOW).count(),
-                         std::chrono::duration<float, std::milli>(COST).count(), std::chrono::duration<float, std::milli>(ARM_IN).count());
-
-        m_renderTimer->updateTimeout(ARM_IN);
-    } else if (!m_renderTimer->armed()) { // idle frame callback emitted .frame()
-        m_pendingDeadline = {};
-        m_renderTimer->updateTimeout(FRAME_IDLE_DELAY); // just add a tiny delay, since the wl_event_loop has no order guarantee
+        m_renderTimer->updateTimeout(TARGET.target);
     }
 }
 

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -3,9 +3,11 @@
 #include "../Compositor.hpp"
 #include "../render/Renderer.hpp"
 #include "../managers/eventLoop/EventLoopManager.hpp"
+#include "../helpers/Drm.hpp"
 
 using namespace Render::GL;
 using namespace Monitor;
+using namespace Hyprutils::OS;
 
 CMonitorFrameScheduler::CMonitorFrameScheduler(PHLMONITOR m) : m_monitor(m) {
     ;
@@ -26,6 +28,9 @@ bool CMonitorFrameScheduler::newSchedulingEnabled() {
 }
 
 void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when, int refreshNs) {
+    // if we bail below, the deadline must not outlive this presentation.
+    const auto AIMED_AT = std::exchange(m_inFlightDeadline, {});
+
     const auto PMONITOR = m_monitor.lock();
     if (!PMONITOR || !newSchedulingEnabled())
         return;
@@ -33,6 +38,12 @@ void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when, int refres
     // drm hands us the period in ns, but its 0 if the connector has no refresh.
     const float HZ  = PMONITOR->m_refreshRate > 0.F ? PMONITOR->m_refreshRate : 60.F;
     m_refreshPeriod = refreshNs > 0 ? std::chrono::nanoseconds(refreshNs) : std::chrono::nanoseconds(static_cast<int64_t>(1'000'000'000.0 / HZ));
+
+    // did the frame we timed actually make the flip it aimed at?
+    const auto LATE = when - AIMED_AT;
+    if (AIMED_AT.time_since_epoch() > Time::steady_dur::zero() && LATE > m_refreshPeriod / 2 && LATE < m_refreshPeriod * 4)
+        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> missed the flip we aimed at by {:.3f}ms", PMONITOR->m_name,
+                         std::chrono::duration<float, std::milli>(LATE).count());
 
     m_earliestNextFlip = when + m_refreshPeriod;
     m_delayNextFrame   = true; // this comes with the assumption next frame from AQ actually comes from the pageflip, the AQ currently does.
@@ -77,7 +88,34 @@ void CMonitorFrameScheduler::onFrame() {
                 if (self.expired())
                     return;
 
+                const auto START    = Time::steadyNow();
+                const auto DEADLINE = std::exchange(m_pendingDeadline, {});
+
                 renderNow();
+
+                // renderNow -> renderMonitor can destroy us on a monitor reload.
+                if (self.expired())
+                    return;
+
+                const auto PMONITOR = m_monitor.lock();
+                if (!PMONITOR)
+                    return;
+
+                if (PMONITOR->m_inFence.isValid() && PMONITOR->output()->pendingPageFlip() && DEADLINE > START && m_refreshPeriod > Time::steady_dur::zero()) {
+                    m_inFlightDeadline = DEADLINE; // we committed, so a presentation for this deadline is coming.
+
+                    auto fence = makeShared<CFileDescriptor>(PMONITOR->m_inFence.duplicate());
+                    g_pEventLoopManager->doOnReadable(PMONITOR->m_inFence.duplicate(), [this, self, START, fence]() {
+                        if (self.expired())
+                            return;
+
+                        const auto SIGNALLED = DRM::fenceSignalTime(fence->get());
+                        if (!SIGNALLED)
+                            return;
+
+                        m_frameTimes.addRenderCost(START, *SIGNALLED);
+                    });
+                }
             },
             nullptr);
 
@@ -85,14 +123,26 @@ void CMonitorFrameScheduler::onFrame() {
     }
 
     if (DELAY && m_refreshPeriod > Time::steady_dur::zero() && !m_renderTimer->armed()) /*pageflip emitted .frame()*/ {
-        //const auto NOW    = Time::steadyNow();
-        //const auto TARGET = EARLIEST_FLIP - estimatedRenderCost();
-        //m_renderTimer->updateTimeout(TARGET > NOW ? TARGET - NOW : std::chrono::nanoseconds(50));
+        const auto NOW      = Time::steadyNow();
+        const auto COST     = m_frameTimes.estimatedRenderCost();
+        const auto DEADLINE = std::min(EARLIEST_FLIP, NOW + m_refreshPeriod);
+        const auto TARGET   = DEADLINE - COST;
 
-        //#TODO: until rendermonitor rewrite happends, we cant measure rendercost reliably.
-        m_renderTimer->updateTimeout(std::chrono::nanoseconds(50));
-    } else if (!m_renderTimer->armed())                             // idle frame callback emitted .frame()
-        m_renderTimer->updateTimeout(std::chrono::nanoseconds(50)); // just add a tiny delay, since the wl_event_loop has no order guarantee, but delaying it means should be last.
+        // only delay if the estimate says we can still make this flip.
+        const bool CAN_DELAY = m_frameTimes.hasSamples() && COST < m_refreshPeriod && TARGET > NOW;
+        const auto ARM_IN    = CAN_DELAY ? TARGET - NOW : FRAME_IDLE_DELAY;
+
+        m_pendingDeadline = DEADLINE;
+
+        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, period {:.3f}ms, target in {:.3f}ms, est. cost {:.3f}ms, arming in {:.3f}ms", PMONITOR->m_name,
+                         std::chrono::duration<float, std::milli>(m_refreshPeriod).count(), std::chrono::duration<float, std::milli>(TARGET - NOW).count(),
+                         std::chrono::duration<float, std::milli>(COST).count(), std::chrono::duration<float, std::milli>(ARM_IN).count());
+
+        m_renderTimer->updateTimeout(ARM_IN);
+    } else if (!m_renderTimer->armed()) { // idle frame callback emitted .frame()
+        m_pendingDeadline = {};
+        m_renderTimer->updateTimeout(FRAME_IDLE_DELAY); // just add a tiny delay, since the wl_event_loop has no order guarantee
+    }
 }
 
 bool CMonitorFrameScheduler::renderPending() {

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -36,6 +36,7 @@ void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when, int refres
         return;
 
     m_frameTimes.setRefreshPeriod(refreshNs, PMONITOR->m_refreshRate);
+    m_frameTimes.notePresentation(when);
 
     // did the frame we timed actually make the flip it aimed at?
     if (const auto LATE = m_frameTimes.flipMiss(when, AIMED_AT); LATE)
@@ -125,13 +126,14 @@ void CMonitorFrameScheduler::onFrame() {
         // m_vrrActive can be set on a panel that cannot do vrr, and that one still runs on a fixed grid.
         const bool VRR         = PMONITOR->m_vrrActive && PMONITOR->output()->vrrCapable;
         const bool AIM_AT_FLIP = DELAY && !VRR;
-        const auto TARGET      = m_frameTimes.nextTarget(Time::steadyNow(), AIM_AT_FLIP ? EARLIEST_FLIP : Time::steady_tp{}, PMONITOR->m_directScanoutIsActive);
+        const auto NOW         = Time::steadyNow();
+        const auto TARGET      = m_frameTimes.nextTarget(NOW, AIM_AT_FLIP ? EARLIEST_FLIP : Time::steady_tp{}, PMONITOR->m_directScanoutIsActive);
 
         m_pendingDeadline = TARGET.deadline;
 
         Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, period {:.3f}ms, est. cost {:.3f}ms, arming in {:.3f}ms", PMONITOR->m_name,
                          std::chrono::duration<float, std::milli>(m_frameTimes.refreshPeriod()).count(),
-                         std::chrono::duration<float, std::milli>(m_frameTimes.estimatedRenderCost()).count(), std::chrono::duration<float, std::milli>(TARGET.target).count());
+                         std::chrono::duration<float, std::milli>(m_frameTimes.estimatedRenderCost(NOW)).count(), std::chrono::duration<float, std::milli>(TARGET.target).count());
 
         m_renderTimer->updateTimeout(TARGET.target);
     }

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -121,8 +121,8 @@ void CMonitorFrameScheduler::onFrame() {
 
     if (!m_renderTimer->armed()) {
         // DELAY means a pageflip emitted .frame(), so there is a vblank to aim at. an idle frame callback has none,
-        // and neither does vrr - its vblank moves with us. both fall back to rendering right after this loop iteration.
-        const bool AIM_AT_FLIP = DELAY && !PMONITOR->m_vrrActive;
+        // vrr moves its vblank with us, and direct scanout has no render to pay for. all fall back to FRAME_IDLE_DELAY.
+        const bool AIM_AT_FLIP = DELAY && !PMONITOR->m_vrrActive && !PMONITOR->m_directScanoutIsActive;
         const auto TARGET      = m_frameTimes.nextTarget(Time::steadyNow(), AIM_AT_FLIP ? EARLIEST_FLIP : Time::steady_tp{});
 
         m_pendingDeadline = TARGET.deadline;

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -23,8 +23,8 @@ CMonitorFrameScheduler::~CMonitorFrameScheduler() {
 bool CMonitorFrameScheduler::newSchedulingEnabled() {
     static auto PENABLENEW = CConfigValue<Config::INTEGER>("render:new_render_scheduling");
 
-    //#TODO: figure out if this can be done on vrr/tearing
-    return *PENABLENEW && g_pHyprRenderer->explicitSyncSupported() && m_monitor && !m_monitor->m_tearingState.activelyTearing && !m_monitor->m_vrrActive;
+    //#TODO: figure out if this can be done on tearing
+    return *PENABLENEW && g_pHyprRenderer->explicitSyncSupported() && m_monitor && !m_monitor->m_tearingState.activelyTearing;
 }
 
 void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when, int refreshNs) {
@@ -120,9 +120,10 @@ void CMonitorFrameScheduler::onFrame() {
     }
 
     if (!m_renderTimer->armed()) {
-        // DELAY means a pageflip emitted .frame(), so there is a vblank to aim at. otherwise it came from an idle
-        // frame callback and nextArm just gets us behind the rest of this loop iteration.
-        const auto TARGET = m_frameTimes.nextTarget(Time::steadyNow(), DELAY ? EARLIEST_FLIP : Time::steady_tp{});
+        // DELAY means a pageflip emitted .frame(), so there is a vblank to aim at. an idle frame callback has none,
+        // and neither does vrr - its vblank moves with us. both fall back to rendering right after this loop iteration.
+        const bool AIM_AT_FLIP = DELAY && !PMONITOR->m_vrrActive;
+        const auto TARGET      = m_frameTimes.nextTarget(Time::steadyNow(), AIM_AT_FLIP ? EARLIEST_FLIP : Time::steady_tp{});
 
         m_pendingDeadline = TARGET.deadline;
 

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -120,10 +120,12 @@ void CMonitorFrameScheduler::onFrame() {
     }
 
     if (!m_renderTimer->armed()) {
-        // DELAY means a pageflip emitted .frame(), so there is a vblank to aim at. an idle frame callback has none,
-        // vrr moves its vblank with us, and direct scanout has no render to pay for. all fall back to FRAME_IDLE_DELAY.
-        const bool AIM_AT_FLIP = DELAY && !PMONITOR->m_vrrActive && !PMONITOR->m_directScanoutIsActive;
-        const auto TARGET      = m_frameTimes.nextTarget(Time::steadyNow(), AIM_AT_FLIP ? EARLIEST_FLIP : Time::steady_tp{});
+        // DELAY means a pageflip emitted .frame(), so there is a vblank to aim at. an idle frame callback has none, and
+        // neither does vrr - its vblank moves with us. direct scanout has one, it just has no render to pay for.
+        // m_vrrActive can be set on a panel that cannot do vrr, and that one still runs on a fixed grid.
+        const bool VRR         = PMONITOR->m_vrrActive && PMONITOR->output()->vrrCapable;
+        const bool AIM_AT_FLIP = DELAY && !VRR;
+        const auto TARGET      = m_frameTimes.nextTarget(Time::steadyNow(), AIM_AT_FLIP ? EARLIEST_FLIP : Time::steady_tp{}, PMONITOR->m_directScanoutIsActive);
 
         m_pendingDeadline = TARGET.deadline;
 

--- a/src/output/MonitorFrameScheduler.hpp
+++ b/src/output/MonitorFrameScheduler.hpp
@@ -1,40 +1,34 @@
 #pragma once
 
 #include "Monitor.hpp"
-#include "../render/SyncFDManager.hpp"
-
-#include <chrono>
+#include "../managers/eventLoop/EventLoopTimer.hpp"
 
 namespace Monitor {
     class CMonitorFrameScheduler {
       public:
-        using hrc = std::chrono::high_resolution_clock;
-
         CMonitorFrameScheduler(PHLMONITOR m);
+        ~CMonitorFrameScheduler();
 
         CMonitorFrameScheduler(const CMonitorFrameScheduler&)            = delete;
         CMonitorFrameScheduler(CMonitorFrameScheduler&&)                 = delete;
         CMonitorFrameScheduler& operator=(const CMonitorFrameScheduler&) = delete;
         CMonitorFrameScheduler& operator=(CMonitorFrameScheduler&&)      = delete;
 
-        void                    onSyncFired();
-        void                    onPresented();
+        void                    onPresented(const Time::steady_tp& when, int refreshNs);
         void                    onFrame();
+        bool                    renderPending();
 
       private:
+        void                       renderNow();
         bool                       canRender();
-        void                       onFinishRender();
         bool                       newSchedulingEnabled();
 
-        bool                       m_renderAtFrame = true;
-        bool                       m_pendingThird  = false;
-        hrc::time_point            m_lastRenderBegun;
-
         PHLMONITORREF              m_monitor;
-
-        UP<Render::ISyncFDManager> m_sync;
-
         WP<CMonitorFrameScheduler> m_self;
+        SP<CEventLoopTimer>        m_renderTimer;
+        Time::steady_tp            m_earliestNextFlip;
+        Time::steady_dur           m_refreshPeriod{};
+        bool                       m_delayNextFrame = false;
 
         friend class CMonitor;
     };

--- a/src/output/MonitorFrameScheduler.hpp
+++ b/src/output/MonitorFrameScheduler.hpp
@@ -31,7 +31,6 @@ namespace Monitor {
         Time::steady_tp            m_earliestNextFlip;
         Time::steady_tp            m_pendingDeadline;  // deadline of the frame the render timer is currently armed for
         Time::steady_tp            m_inFlightDeadline; // deadline of the frame that committed and is waiting on its flip
-        Time::steady_dur           m_refreshPeriod{};
         bool                       m_delayNextFrame = false;
 
         friend class CMonitor;

--- a/src/output/MonitorFrameScheduler.hpp
+++ b/src/output/MonitorFrameScheduler.hpp
@@ -2,6 +2,7 @@
 
 #include "Monitor.hpp"
 #include "../managers/eventLoop/EventLoopTimer.hpp"
+#include "MonitorFrameTimer.hpp"
 
 namespace Monitor {
     class CMonitorFrameScheduler {
@@ -26,7 +27,10 @@ namespace Monitor {
         PHLMONITORREF              m_monitor;
         WP<CMonitorFrameScheduler> m_self;
         SP<CEventLoopTimer>        m_renderTimer;
+        CMonitorFrameTimer         m_frameTimes;
         Time::steady_tp            m_earliestNextFlip;
+        Time::steady_tp            m_pendingDeadline;  // deadline of the frame the render timer is currently armed for
+        Time::steady_tp            m_inFlightDeadline; // deadline of the frame that committed and is waiting on its flip
         Time::steady_dur           m_refreshPeriod{};
         bool                       m_delayNextFrame = false;
 

--- a/src/output/MonitorFrameTimer.cpp
+++ b/src/output/MonitorFrameTimer.cpp
@@ -35,6 +35,9 @@ Time::steady_dur CMonitorFrameTimer::estimatedRenderCost() const {
 
     const auto WORST = std::ranges::max(m_renderTimes | std::views::transform([](const SRenderTimes& t) { return t.end - t.start; }));
 
+    // 15 previous samples, take the slowest and assume the next can be that slow + 25% + the safety margin.
+    // spikes pull the estimate up and stay for the whole window. until frames are more
+    // stable and we have proper early outs, we cant be more precise.
     return WORST + WORST / 4 + FRAME_SAFETY_MARGIN;
 }
 

--- a/src/output/MonitorFrameTimer.cpp
+++ b/src/output/MonitorFrameTimer.cpp
@@ -4,6 +4,11 @@
 
 using namespace Monitor;
 
+// everything after we stop measuring - the commit, the atomic ioctl, the flip itself - plus timer wakeup jitter.
+constexpr Time::steady_dur FRAME_SAFETY_MARGIN = std::chrono::microseconds(800);
+// with no pageflip behind the frame event we have no vblank to aim at, so there is no margin use. render now.
+constexpr Time::steady_dur FRAME_IDLE_DELAY = std::chrono::microseconds(1);
+
 CMonitorFrameTimer::CMonitorFrameTimer() {
     ;
 }
@@ -24,11 +29,56 @@ bool CMonitorFrameTimer::hasSamples() const {
     return !m_renderTimes.empty();
 }
 
-Time::steady_dur CMonitorFrameTimer::estimatedRenderCost() {
+Time::steady_dur CMonitorFrameTimer::estimatedRenderCost() const {
     if (m_renderTimes.empty())
         return Time::steady_dur::zero();
 
     const auto WORST = std::ranges::max(m_renderTimes | std::views::transform([](const SRenderTimes& t) { return t.end - t.start; }));
 
     return WORST + WORST / 4 + FRAME_SAFETY_MARGIN;
+}
+
+void CMonitorFrameTimer::setRefreshPeriod(int refreshNs, float fallbackHz) {
+    // drm hands us the period in ns, but its 0 if the connector has no refresh.
+    if (refreshNs > 0) {
+        m_refreshPeriod = std::chrono::nanoseconds(refreshNs);
+        return;
+    }
+
+    const float HZ  = fallbackHz > 0.F ? fallbackHz : 60.F;
+    m_refreshPeriod = std::chrono::nanoseconds(static_cast<int64_t>(1'000'000'000.0 / HZ));
+}
+
+Time::steady_dur CMonitorFrameTimer::refreshPeriod() const {
+    return m_refreshPeriod;
+}
+
+bool CMonitorFrameTimer::hasRefreshPeriod() const {
+    return m_refreshPeriod > Time::steady_dur::zero();
+}
+
+std::optional<Time::steady_dur> CMonitorFrameTimer::flipMiss(const Time::steady_tp& when, const Time::steady_tp& aimedAt) const {
+    if (aimedAt.time_since_epoch() <= Time::steady_dur::zero() || !hasRefreshPeriod())
+        return std::nullopt;
+
+    // under half a period we made the flip, over a few periods the two aren't the same frame anymore.
+    const auto LATE = when - aimedAt;
+    if (LATE <= m_refreshPeriod / 2 || LATE >= m_refreshPeriod * 4)
+        return std::nullopt;
+
+    return LATE;
+}
+
+CMonitorFrameTimer::SFrameTarget CMonitorFrameTimer::nextTarget(const Time::steady_tp& now, const Time::steady_tp& earliestFlip) const {
+    if (earliestFlip.time_since_epoch() <= Time::steady_dur::zero() || !hasRefreshPeriod())
+        return {.deadline = {}, .target = FRAME_IDLE_DELAY};
+
+    const auto DEADLINE = std::min(earliestFlip, now + m_refreshPeriod);
+    const auto COST     = estimatedRenderCost();
+    const auto TARGET   = DEADLINE - COST;
+
+    // only delay if the estimate says we can still make this flip.
+    const bool CAN_DELAY = hasSamples() && COST < m_refreshPeriod && TARGET > now;
+
+    return {.deadline = DEADLINE, .target = CAN_DELAY ? TARGET - now : FRAME_IDLE_DELAY};
 }

--- a/src/output/MonitorFrameTimer.cpp
+++ b/src/output/MonitorFrameTimer.cpp
@@ -72,16 +72,17 @@ std::optional<Time::steady_dur> CMonitorFrameTimer::flipMiss(const Time::steady_
     return LATE;
 }
 
-CMonitorFrameTimer::SFrameTarget CMonitorFrameTimer::nextTarget(const Time::steady_tp& now, const Time::steady_tp& earliestFlip) const {
+CMonitorFrameTimer::SFrameTarget CMonitorFrameTimer::nextTarget(const Time::steady_tp& now, const Time::steady_tp& earliestFlip, bool noRenderCost) const {
     if (earliestFlip.time_since_epoch() <= Time::steady_dur::zero() || !hasRefreshPeriod())
         return {.deadline = {}, .target = FRAME_IDLE_DELAY};
 
     const auto DEADLINE = std::min(earliestFlip, now + m_refreshPeriod);
-    const auto COST     = estimatedRenderCost();
-    const auto TARGET   = DEADLINE - COST;
+    // nothing to render still costs us the commit, the ioctl and the timer wakeup - that is what the margin is for.
+    const auto COST   = noRenderCost ? FRAME_SAFETY_MARGIN : estimatedRenderCost();
+    const auto TARGET = DEADLINE - COST;
 
-    // only delay if the estimate says we can still make this flip.
-    const bool CAN_DELAY = hasSamples() && COST < m_refreshPeriod && TARGET > now;
+    // only delay if the estimate says we can still make this flip. with no render there is nothing to estimate.
+    const bool CAN_DELAY = (noRenderCost || hasSamples()) && COST < m_refreshPeriod && TARGET > now;
 
     return {.deadline = DEADLINE, .target = CAN_DELAY ? TARGET - now : FRAME_IDLE_DELAY};
 }

--- a/src/output/MonitorFrameTimer.cpp
+++ b/src/output/MonitorFrameTimer.cpp
@@ -1,6 +1,6 @@
 #include "MonitorFrameTimer.hpp"
 #include <algorithm>
-#include <ranges>
+#include <utility>
 
 using namespace Monitor;
 
@@ -8,6 +8,10 @@ using namespace Monitor;
 constexpr Time::steady_dur FRAME_SAFETY_MARGIN = std::chrono::microseconds(800);
 // with no pageflip behind the frame event we have no vblank to aim at, so there is no margin use. render now.
 constexpr Time::steady_dur FRAME_IDLE_DELAY = std::chrono::microseconds(1);
+// a sample older than this was taken at a gpu clock we are probably no longer running at.
+constexpr Time::steady_dur FRAME_SAMPLE_MAX_AGE = std::chrono::milliseconds(300);
+// frames to keep rendering immediately after idle
+constexpr int FRAME_COLD_AFTER_WAKE = 2;
 
 CMonitorFrameTimer::CMonitorFrameTimer() {
     ;
@@ -25,20 +29,28 @@ void CMonitorFrameTimer::addRenderCost(const Time::steady_tp& start, const Time:
         m_renderTimes.pop_front();
 }
 
-bool CMonitorFrameTimer::hasSamples() const {
-    return !m_renderTimes.empty();
+bool CMonitorFrameTimer::hasFreshSamples(const Time::steady_tp& now) const {
+    return std::ranges::any_of(m_renderTimes, [&now](const SRenderTimes& t) { return now - t.end <= FRAME_SAMPLE_MAX_AGE; });
 }
 
-Time::steady_dur CMonitorFrameTimer::estimatedRenderCost() const {
-    if (m_renderTimes.empty())
+Time::steady_dur CMonitorFrameTimer::estimatedRenderCost(const Time::steady_tp& now) const {
+    Time::steady_dur worst = Time::steady_dur::zero();
+
+    for (const auto& SAMPLE : m_renderTimes) {
+        // a sample from before an idle period
+        if (now - SAMPLE.end > FRAME_SAMPLE_MAX_AGE)
+            continue;
+
+        worst = std::max(worst, SAMPLE.end - SAMPLE.start);
+    }
+
+    if (worst == Time::steady_dur::zero())
         return Time::steady_dur::zero();
 
-    const auto WORST = std::ranges::max(m_renderTimes | std::views::transform([](const SRenderTimes& t) { return t.end - t.start; }));
-
-    // 15 previous samples, take the slowest and assume the next can be that slow + 25% + the safety margin.
+    // up to 15 recent samples, take the slowest and assume the next can be that slow + 25% + the safety margin.
     // spikes pull the estimate up and stay for the whole window. until frames are more
     // stable and we have proper early outs, we cant be more precise.
-    return WORST + WORST / 4 + FRAME_SAFETY_MARGIN;
+    return worst + worst / 4 + FRAME_SAFETY_MARGIN;
 }
 
 void CMonitorFrameTimer::setRefreshPeriod(int refreshNs, float fallbackHz) {
@@ -60,6 +72,22 @@ bool CMonitorFrameTimer::hasRefreshPeriod() const {
     return m_refreshPeriod > Time::steady_dur::zero();
 }
 
+void CMonitorFrameTimer::notePresentation(const Time::steady_tp& when) {
+    const auto PREV = std::exchange(m_lastPresentation, when);
+
+    if (PREV.time_since_epoch() <= Time::steady_dur::zero())
+        return;
+
+    if (when - PREV > FRAME_SAMPLE_MAX_AGE)
+        m_coldFrames = FRAME_COLD_AFTER_WAKE;
+    else if (m_coldFrames > 0)
+        m_coldFrames--;
+}
+
+bool CMonitorFrameTimer::frameFromIdle() const {
+    return m_coldFrames > 0;
+}
+
 std::optional<Time::steady_dur> CMonitorFrameTimer::flipMiss(const Time::steady_tp& when, const Time::steady_tp& aimedAt) const {
     if (aimedAt.time_since_epoch() <= Time::steady_dur::zero() || !hasRefreshPeriod())
         return std::nullopt;
@@ -78,11 +106,12 @@ CMonitorFrameTimer::SFrameTarget CMonitorFrameTimer::nextTarget(const Time::stea
 
     const auto DEADLINE = std::min(earliestFlip, now + m_refreshPeriod);
     // nothing to render still costs us the commit, the ioctl and the timer wakeup - that is what the margin is for.
-    const auto COST   = noRenderCost ? FRAME_SAFETY_MARGIN : estimatedRenderCost();
+    const auto COST   = noRenderCost ? FRAME_SAFETY_MARGIN : estimatedRenderCost(now);
     const auto TARGET = DEADLINE - COST;
 
-    // only delay if the estimate says we can still make this flip. with no render there is nothing to estimate.
-    const bool CAN_DELAY = (noRenderCost || hasSamples()) && COST < m_refreshPeriod && TARGET > now;
+    // only delay if the estimate says we can still make this flip. with no render there is nothing to estimate,
+    // but a idle gpu is slow at the commit too, starting early is the best we can do when we cannot predict what the frame will cost.
+    const bool CAN_DELAY = !frameFromIdle() && (noRenderCost || hasFreshSamples(now)) && COST < m_refreshPeriod && TARGET > now;
 
     return {.deadline = DEADLINE, .target = CAN_DELAY ? TARGET - now : FRAME_IDLE_DELAY};
 }

--- a/src/output/MonitorFrameTimer.cpp
+++ b/src/output/MonitorFrameTimer.cpp
@@ -1,0 +1,34 @@
+#include "MonitorFrameTimer.hpp"
+#include <algorithm>
+#include <ranges>
+
+using namespace Monitor;
+
+CMonitorFrameTimer::CMonitorFrameTimer() {
+    ;
+}
+
+void CMonitorFrameTimer::addRenderCost(const Time::steady_tp& start, const Time::steady_tp& end) {
+    // a fence that signalled before we started rendering is a stale one, left over from a frame that
+    // didn't redraw. it measures nothing.
+    if (end <= start)
+        return;
+
+    m_renderTimes.emplace_back(SRenderTimes{.start = start, .end = end});
+
+    if (m_renderTimes.size() > 15)
+        m_renderTimes.pop_front();
+}
+
+bool CMonitorFrameTimer::hasSamples() const {
+    return !m_renderTimes.empty();
+}
+
+Time::steady_dur CMonitorFrameTimer::estimatedRenderCost() {
+    if (m_renderTimes.empty())
+        return Time::steady_dur::zero();
+
+    const auto WORST = std::ranges::max(m_renderTimes | std::views::transform([](const SRenderTimes& t) { return t.end - t.start; }));
+
+    return WORST + WORST / 4 + FRAME_SAFETY_MARGIN;
+}

--- a/src/output/MonitorFrameTimer.hpp
+++ b/src/output/MonitorFrameTimer.hpp
@@ -24,7 +24,7 @@ namespace Monitor {
         // how late we were for the flip we aimed at, or nullopt if we made it
         std::optional<Time::steady_dur> flipMiss(const Time::steady_tp& when, const Time::steady_tp& aimedAt) const;
         // when to render for the flip at earliestFlip.
-        SFrameTarget nextTarget(const Time::steady_tp& now, const Time::steady_tp& earliestFlip) const;
+        SFrameTarget nextTarget(const Time::steady_tp& now, const Time::steady_tp& earliestFlip, bool noRenderCost = false) const;
 
       private:
         struct SRenderTimes {

--- a/src/output/MonitorFrameTimer.hpp
+++ b/src/output/MonitorFrameTimer.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "../helpers/time/Time.hpp"
+#include <deque>
+
+namespace Monitor {
+    // everything after we stop measuring - the commit, the atomic ioctl, the flip itself - plus timer wakeup jitter.
+    inline constexpr Time::steady_dur FRAME_SAFETY_MARGIN = std::chrono::microseconds(800);
+
+    // with no pageflip behind the frame event we have no vblank to aim at, so there is no margin to keep - we only
+    // want the render to land after the rest of this loop iteration. the timer wheel counts in µs, so this is the
+    // smallest delay that still goes through it instead of being picked first.
+    inline constexpr Time::steady_dur FRAME_IDLE_DELAY = std::chrono::microseconds(1);
+
+    class CMonitorFrameTimer {
+      public:
+        CMonitorFrameTimer();
+        void             addRenderCost(const Time::steady_tp& start, const Time::steady_tp& end);
+        Time::steady_dur estimatedRenderCost();
+        bool             hasSamples() const;
+
+      private:
+        struct SRenderTimes {
+            Time::steady_tp start;
+            Time::steady_tp end;
+        };
+
+        std::deque<SRenderTimes> m_renderTimes;
+    };
+}

--- a/src/output/MonitorFrameTimer.hpp
+++ b/src/output/MonitorFrameTimer.hpp
@@ -14,12 +14,17 @@ namespace Monitor {
         };
 
         void             addRenderCost(const Time::steady_tp& start, const Time::steady_tp& end);
-        Time::steady_dur estimatedRenderCost() const;
-        bool             hasSamples() const;
+        Time::steady_dur estimatedRenderCost(const Time::steady_tp& now) const;
+        bool             hasFreshSamples(const Time::steady_tp& now) const;
 
         void             setRefreshPeriod(int refreshNs, float fallbackHz);
         Time::steady_dur refreshPeriod() const;
         bool             hasRefreshPeriod() const;
+
+        // record a presentation. a long gap between two of them is how we spot an idle wake.
+        void notePresentation(const Time::steady_tp& when);
+        // are we still on the cold frames right after such a wake?
+        bool frameFromIdle() const;
 
         // how late we were for the flip we aimed at, or nullopt if we made it
         std::optional<Time::steady_dur> flipMiss(const Time::steady_tp& when, const Time::steady_tp& aimedAt) const;
@@ -34,5 +39,7 @@ namespace Monitor {
 
         std::deque<SRenderTimes> m_renderTimes;
         Time::steady_dur         m_refreshPeriod{};
+        Time::steady_tp          m_lastPresentation{};
+        int                      m_coldFrames = 0;
     };
 }

--- a/src/output/MonitorFrameTimer.hpp
+++ b/src/output/MonitorFrameTimer.hpp
@@ -1,22 +1,30 @@
 #pragma once
 #include "../helpers/time/Time.hpp"
 #include <deque>
+#include <optional>
 
 namespace Monitor {
-    // everything after we stop measuring - the commit, the atomic ioctl, the flip itself - plus timer wakeup jitter.
-    inline constexpr Time::steady_dur FRAME_SAFETY_MARGIN = std::chrono::microseconds(800);
-
-    // with no pageflip behind the frame event we have no vblank to aim at, so there is no margin to keep - we only
-    // want the render to land after the rest of this loop iteration. the timer wheel counts in µs, so this is the
-    // smallest delay that still goes through it instead of being picked first.
-    inline constexpr Time::steady_dur FRAME_IDLE_DELAY = std::chrono::microseconds(1);
-
     class CMonitorFrameTimer {
       public:
         CMonitorFrameTimer();
+
+        struct SFrameTarget {
+            Time::steady_tp  deadline;
+            Time::steady_dur target;
+        };
+
         void             addRenderCost(const Time::steady_tp& start, const Time::steady_tp& end);
-        Time::steady_dur estimatedRenderCost();
+        Time::steady_dur estimatedRenderCost() const;
         bool             hasSamples() const;
+
+        void             setRefreshPeriod(int refreshNs, float fallbackHz);
+        Time::steady_dur refreshPeriod() const;
+        bool             hasRefreshPeriod() const;
+
+        // how late we were for the flip we aimed at, or nullopt if we made it
+        std::optional<Time::steady_dur> flipMiss(const Time::steady_tp& when, const Time::steady_tp& aimedAt) const;
+        // when to render for the flip at earliestFlip.
+        SFrameTarget nextTarget(const Time::steady_tp& now, const Time::steady_tp& earliestFlip) const;
 
       private:
         struct SRenderTimes {
@@ -25,5 +33,6 @@ namespace Monitor {
         };
 
         std::deque<SRenderTimes> m_renderTimes;
+        Time::steady_dur         m_refreshPeriod{};
     };
 }

--- a/src/output/PresentationTimeFilter.cpp
+++ b/src/output/PresentationTimeFilter.cpp
@@ -1,0 +1,30 @@
+#include "PresentationTimeFilter.hpp"
+
+using namespace Monitor;
+
+Time::steady_tp CPresentationTimeFilter::filter(const Time::steady_tp& raw, Time::steady_dur period) {
+    // we have no calculated vblank periods, just use the raw wrong timestamps.
+    if (period <= Time::steady_dur::zero()) {
+        m_previousTimeSample.reset();
+        return raw;
+    }
+
+    // no previous samples yet
+    if (!m_previousTimeSample) {
+        m_previousTimeSample = raw;
+        return raw;
+    }
+
+    const auto EXPECTED = *m_previousTimeSample + period;
+    const auto JITTER   = raw - EXPECTED;
+
+    // missed vblank / idleframe. reset.
+    if (JITTER > period / 2 || JITTER < -period / 2) {
+        m_previousTimeSample = raw;
+        return raw;
+    }
+
+    m_previousTimeSample = EXPECTED;
+
+    return EXPECTED;
+}

--- a/src/output/PresentationTimeFilter.hpp
+++ b/src/output/PresentationTimeFilter.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../helpers/time/Time.hpp"
+
+namespace Monitor {
+    // this filters out jitter from timestamps coming from software clocks. ktime_get returns a timestamp
+    // from when the event was sent, not when the pageflip actually occured. that means the timestamp we see
+    // includes any jitter from our own code + eventloop delay, so it fluctuates +-0.02 ms on best case, or more
+    // in worse.
+    // this is a workaround, not the fix. reconstructing a vblank we never observed can only ever
+    // be guessed. the real fix is a hardware clock where the kernel registers a vblank counter where
+    // the flip event carries a true hardware timestamp and a usable sequence number.
+    class CPresentationTimeFilter {
+      public:
+        // raw = timestamp we got, period = AQ calculated time between vblanks
+        Time::steady_tp filter(const Time::steady_tp& raw, Time::steady_dur period);
+
+      private:
+        std::optional<Time::steady_tp> m_previousTimeSample;
+    };
+}


### PR DESCRIPTION
the start of frame time scheduling, removes the old triple buffer logic that is sound in theory but we dont have the code to do it, yet. so currently its broken anyways.

lets make new_render_scheduling do something useful instead.

we also filter out render jitter from software clock garbage drivers.

