### PR TITLE
desktop/view: fix special workspace hiding on window unmap fallback

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2692,6 +2692,9 @@ void CWindow::unmapWindow() {
             }
         }
 
+        if (candidate && PMONITOR && PMONITOR->m_activeSpecialWorkspace && candidate->m_workspace != PMONITOR->m_activeSpecialWorkspace)
+            candidate = nullptr;
+
         Log::logger->log(Log::DEBUG, "On closed window, new focused candidate is {}", candidate);
 
         if (candidate != Desktop::focusState()->window() && candidate) {
@@ -2705,7 +2708,7 @@ void CWindow::unmapWindow() {
                 Fullscreen::controller()->setFullscreenMode(candidate, CURRENT_WINDOW_FS_MODES.internal, std::nullopt, CURRENT_FS_LAYOUT_HANDLED);
         }
 
-        if (!candidate && m_workspace && m_workspace->getWindowCount() == 0)
+        if (!candidate && m_workspace && (m_workspace->getWindowCount() == 0 || PMONITOR->m_activeSpecialWorkspace))
             g_pInputManager->refocus();
 
         g_pInputManager->sendMotionEventsToFocused();


### PR DESCRIPTION
#### What does it fix/add?
This fixes the bug where an active special workspace hides when you close a pinned floating window (like a PiP video) inside it.
 
in depth explanation at: https://github.com/hyprwm/Hyprland/discussions/15691


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
 (this part was updated after first review)
 Refactored to use native refocusing. If a special workspace is active and a fallback candidate from a different workspace is selected, we now explicitly reject it (`candidate = nullptr`). This automatically triggers `g_pInputManager->refocus()` to find the correct window, preventing the special workspace from incorrectly hiding.
##### Pre-Patch

https://github.com/user-attachments/assets/3b576381-fb1c-466c-8dad-c7cfa04c69c5

##### Post-Patch

https://github.com/user-attachments/assets/d228c1e9-18ed-431b-842e-ecf6eb4bb84c



#### Is it ready for merging, or does it need work?
Ready for merging.