### PR TITLE
seat: don't block pointer focus for when no mouse is attached

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -301,11 +301,6 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
         return;
     }
 
-    if (!m_mouse) {
-        Log::logger->log(Log::ERR, "BUG THIS: setPointerFocus without a valid mouse set");
-        return;
-    }
-
     m_listeners.pointerSurfaceDestroy.reset();
 
     for (auto const& p : PROTO::seat->m_pointers) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Stylus and touchscreen are libinput devices who don't register as IPointer. On tablets a typecover or some external pointer would be the only device in the system that could expose an IPointer. This makes it so that detaching TypeCover empties m_pointers, so setMouse(nullptr) runs and m_mouse becomes null. From that point, every setPointerFocus() call initiated from touch or tablet-tool proximity is no-op'ed by the guard.
This causes proximity_in, motion, pressure, and down events to not be delivered to clients. This PR removes the guard.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Shouldn't cause regressions or unintended side-effects. 


#### Is it ready for merging, or does it need work?
326/326 gtests passed