### PR TITLE
hyprctl: random Lua-adjacent fixes

### DIFF
--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -566,8 +566,8 @@ int main(int argc, char** argv) {
         std::println("{}", USAGE);
     else if (fullRequest.contains("/rollinglog") && needRoll)
         exitStatus = request(fullRequest, 0, true);
-    else if (fullRequest.contains("/repl")) {
-        if (ARGS.size() > 1) {
+    else if (auto pos = fullRequest.find("/repl"); pos != std::string::npos) {
+        if (fullRequest.length() > pos + 5) {
             // single command with output
             exitStatus = request(fullRequest, 1);
         } else {

--- a/hyprtester/src/tests/main/hyprctl.cpp
+++ b/hyprtester/src/tests/main/hyprctl.cpp
@@ -208,3 +208,16 @@ TEST_CASE(hyprctlREPL) {
     EXPECT(getCommandStdOut("hyprctl repl 'print(type(hl))'"), "table");
     EXPECT(getCommandStdOut("hyprctl eval 'print(type(hl))'"), "ok");
 }
+
+TEST_CASE(hyprctlBatch) {
+    const auto command  = R"([[BATCH]] activewindow; repl local i = 42\; print(i, "hello\\nworld ]"); clients)";
+    const auto expected = R"(Invalid
+
+
+42	hello
+world ]
+
+
+no open windows)";
+    EXPECT(getFromSocket(command), expected);
+}

--- a/src/ipc/s1/S1.cpp
+++ b/src/ipc/s1/S1.cpp
@@ -142,9 +142,9 @@ SResponse CSocket1::dispatchBatch(std::string request, pid_t pid) {
         }
 
         if (request[i] == '\\') {
-            if (i < request.size() && (request[i + 1] == '\\' || request[i + 1] == ';')) {
+            if (i < request.size() && (request[i + 1] == '\\' || request[i + 1] == ';'))
                 ++i;
-            } else
+            else
                 Log::logger->log(Log::ERR, "Malformed socket1 request: invalid escape sequence {} at position {}, using it verbatim", request.subview(i, 2), i);
         }
         parsedCommand << request[i];

--- a/src/ipc/s1/S1.cpp
+++ b/src/ipc/s1/S1.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <optional>
 #include <ranges>
+#include <sstream>
 #include <hyprutils/string/String.hpp>
 
 using namespace IPC::Socket1;
@@ -129,25 +130,24 @@ SResponse CSocket1::dispatchBatch(std::string request, pid_t pid) {
     request = request.substr(BATCH_TOKEN.size());
 
     std::vector<std::string> commands;
-    size_t                   commandStart = 0;
-    int                      bracketDepth = 0;
+    std::stringstream        parsedCommand("");
 
     for (size_t i = 0; i <= request.size(); ++i) {
         const bool atEnd = i == request.size();
-
-        if (!atEnd) {
-            if (request[i] == '[')
-                ++bracketDepth;
-            else if (request[i] == ']')
-                --bracketDepth;
+        if (atEnd || request[i] == ';') {
+            commands.emplace_back(Hyprutils::String::trim(parsedCommand.str()));
+            parsedCommand.str("");
+            parsedCommand.clear();
+            continue;
         }
 
-        if (!atEnd && (request[i] != ';' || bracketDepth != 0))
-            continue;
-
-        if (commandStart < i)
-            commands.emplace_back(Hyprutils::String::trim(request.substr(commandStart, i - commandStart)));
-        commandStart = i + 1;
+        if (request[i] == '\\') {
+            if (i < request.size() && (request[i + 1] == '\\' || request[i + 1] == ';')) {
+                ++i;
+            } else
+                Log::logger->log(Log::ERR, "Malformed socket1 request: invalid escape sequence {} at position {}, using it verbatim", request.subview(i, 2), i);
+        }
+        parsedCommand << request[i];
     }
 
     std::vector<SResponse> responses;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Two separate things:
- Fixes `hyprctl repl`'s interactive-mode detection, so it triggers properly even when a specific instance is selected (`-i 1` or whatever)
- Updates the S1 socket's batch-command parsing, to require escaping for all semicolons inside of batched commands
  - This also eliminates some square-bracket matching that was intended to avoid needing escapes, but just makes things worse now that we have Lua and the user might need to include arbitrary strings

Some IPC batch examples, before and after this change:
```diff
-[[BATCH]][float;pin] kitty;activewindow
+[[BATCH]][float\;pin] kitty;activewindow

-[[BATCH]]repl local v = "asdf"; print(v);activewindow  // would over-split into 3 commands
+[[BATCH]]repl local v = "asdf"\; print(v);activewindow

-[[BATCH]]repl print("DEBUG]");activewindow  // wouldn't be split into 2 commands
+[[BATCH]]repl print("DEBUG]");activewindow
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This changes the IPC format *specifically for batch execution*, so minor things relying on that might break. The main change is for the old-style `[rule;rule] command` exec-with-rules syntax; the semicolons between rules in there will now have to be escaped as shown above. Escaping is also needed for any backslashes (e.g. in Lua code that might `print("\n")`).

#### Is it ready for merging, or does it need work?
Probably ready? The only other change I thought about that'd be neat is modifying `hyprctl --batch` to treat each arg as a separate command, and then having it do the escaping and semicolon-joining *for* the user. The logic for that is kinda very incompatible with how hyprctl currently parses arguments, though, so I haven't done it and probably won't unless we decide it's important.