### PR TITLE
Don't advertise the headless FALLBACK placeholder as an output manage…

### DIFF
--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -52,6 +52,9 @@ void COutputManager::makeAndSendNewHead(PHLMONITOR pMonitor) {
     if UNLIKELY (m_stopped)
         return;
 
+    if (pMonitor && pMonitor->m_isUnsafeFallback)
+        return;
+
     const auto RESOURCE =
         PROTO::outputManagement->m_heads.emplace_back(makeShared<COutputHead>(makeShared<CZwlrOutputHeadV1>(m_resource->client(), m_resource->version(), 0), pMonitor));
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a regression where hyprland is advertising fallback as an output management head 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
relevant discussion: https://github.com/hyprwm/Hyprland/discussions/15774

#### Is it ready for merging, or does it need work?
yes

