### PR TITLE
Session: add disable-able systemd session target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,9 @@ else()
   message(STATUS "SYSTEMD support is requested (NO_SYSTEMD not defined)...")
   add_compile_definitions(USES_SYSTEMD)
 
+  install(FILES ${CMAKE_SOURCE_DIR}/systemd/hyprland-session.target
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
+
   # session file -uwsm
   if(NO_UWSM)
     message(STATUS "UWSM support is disabled...")

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -543,7 +543,7 @@ void CCompositor::cleanEnvironment() {
 
     if (m_aqBackend->hasSession() && !Env::envEnabled("HYPRLAND_NO_SD_VARS") && !getenv("MANAGERPID")) {
 #ifdef USES_SYSTEMD
-        if (!Env::envEnabled("HYPRLAND_NO_SD_TARGET"))
+        if (m_sdSessionTarget)
             // stopping hyprland-session doesn't wait for dependent services; this does
             Config::Supplementary::executor()->spawn("systemctl --user stop graphical-session.target");
 #endif
@@ -804,8 +804,10 @@ void CCompositor::startCompositor() {
             "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS";
         Config::Supplementary::executor()->spawn(CMD);
 #ifdef USES_SYSTEMD
-        if (!Env::envEnabled("HYPRLAND_NO_SD_TARGET"))
+        if (!Env::envEnabled("HYPRLAND_NO_SD_TARGET")) {
+            m_sdSessionTarget = true;
             Config::Supplementary::executor()->spawn("systemctl --user start hyprland-session.target");
+        }
 #endif
     }
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -541,7 +541,7 @@ void CCompositor::cleanEnvironment() {
     if (m_desktopEnvSet)
         unsetenv("XDG_CURRENT_DESKTOP");
 
-    if (m_aqBackend->hasSession() && !Env::envEnabled("HYPRLAND_NO_SD_VARS")) {
+    if (m_aqBackend->hasSession() && !Env::envEnabled("HYPRLAND_NO_SD_VARS") && !getenv("MANAGERPID")) {
 #ifdef USES_SYSTEMD
         if (!Env::envEnabled("HYPRLAND_NO_SD_TARGET"))
             // stopping hyprland-session doesn't wait for dependent services; this does
@@ -793,7 +793,9 @@ void CCompositor::startCompositor() {
         /* Session-less Hyprland usually means a nest, don't update the env in that case */
         m_aqBackend->hasSession() &&
         /* Activation environment management is not disabled */
-        !Env::envEnabled("HYPRLAND_NO_SD_VARS")) {
+        !Env::envEnabled("HYPRLAND_NO_SD_VARS") &&
+        /* Being executed under systemd */
+        !getenv("MANAGERPID")) {
         const auto CMD =
 #ifdef USES_SYSTEMD
             "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -576,6 +576,10 @@ void CCompositor::cleanup() {
 #ifdef USES_SYSTEMD
     if (NSystemd::sdBooted() > 0 && !Env::envEnabled("HYPRLAND_NO_SD_NOTIFY"))
         NSystemd::sdNotify(0, "STOPPING=1");
+    if (m_aqBackend->hasSession() && !Env::envEnabled("HYPRLAND_NO_SD_TARGET")) {
+        Config::Supplementary::executor()->spawn("systemctl --user stop hyprland-session.target");
+        usleep(50000); // services blow up if there's no time to react
+    }
 #endif
 
     cleanEnvironment();
@@ -796,6 +800,10 @@ void CCompositor::startCompositor() {
 #endif
             "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS";
         Config::Supplementary::executor()->spawn(CMD);
+#ifdef USES_SYSTEMD
+        if (!Env::envEnabled("HYPRLAND_NO_SD_TARGET"))
+            Config::Supplementary::executor()->spawn("systemctl --user start hyprland-session.target");
+#endif
     }
 
     Log::logger->log(Log::DEBUG, "Running on WAYLAND_DISPLAY: {}", m_wlDisplaySocket);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -542,6 +542,11 @@ void CCompositor::cleanEnvironment() {
         unsetenv("XDG_CURRENT_DESKTOP");
 
     if (m_aqBackend->hasSession() && !Env::envEnabled("HYPRLAND_NO_SD_VARS")) {
+#ifdef USES_SYSTEMD
+        if (!Env::envEnabled("HYPRLAND_NO_SD_TARGET"))
+            // stopping hyprland-session doesn't wait for dependent services; this does
+            Config::Supplementary::executor()->spawn("systemctl --user stop graphical-session.target");
+#endif
         const auto CMD =
 #ifdef USES_SYSTEMD
             "systemctl --user unset-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "
@@ -576,10 +581,6 @@ void CCompositor::cleanup() {
 #ifdef USES_SYSTEMD
     if (NSystemd::sdBooted() > 0 && !Env::envEnabled("HYPRLAND_NO_SD_NOTIFY"))
         NSystemd::sdNotify(0, "STOPPING=1");
-    if (m_aqBackend->hasSession() && !Env::envEnabled("HYPRLAND_NO_SD_TARGET")) {
-        Config::Supplementary::executor()->spawn("systemctl --user stop hyprland-session.target");
-        usleep(50000); // services blow up if there's no time to react
-    }
 #endif
 
     cleanEnvironment();

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -74,6 +74,7 @@ class CCompositor {
     bool                     m_desktopEnvSet          = false;
     bool                     m_wantsXwayland          = true;
     bool                     m_onlyConfigVerification = false;
+    bool                     m_sdSessionTarget        = false;
 
     // ------------------------------------------------- //
 

--- a/systemd/hyprland-session.target
+++ b/systemd/hyprland-session.target
@@ -1,0 +1,6 @@
+[Unit]
+Description=Hyprland session
+BindsTo=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target
+PropagatesStopTo=graphical-session.target


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Back in June, xdg-desktop-portal broke stuff for any environments that didn't start `graphical-session.target` ([relevant discussion](https://github.com/hyprwm/Hyprland/discussions/15072)). Distros have applied some workarounds since then (notably, Arch just undoes the change that made x-d-p require graphical-session), but the actual proper fix is still on our end. Rather than making every systemd user (which is most of them) go find the wiki section on starting graphical-session, we might as well automate those steps ourselves.

Note that any non-systemd users can easily disable the logic this PR adds, by setting `HYPRLAND_NO_SD_TARGET`. Also respects the `NO_SYSTEMD` build flag if that's set.

Also just fyi, the original branch for this PR isn't actually mine, but @Dregu's. He didn't want to PR it, so I'll take the blame if this goes horribly wrong or whatever.

Prior discussion of this change: https://github.com/hyprwm/Hyprland/discussions/15072#discussioncomment-17345023.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not really. This pretty much just automates the [steps currently on the wiki](https://wiki.hypr.land/Useful-Utilities/Systemd-start/#hyprland-sessiontarget).

#### Is it ready for merging, or does it need work?

Should be good. Also, @tekstryder's [been using this patch](https://github.com/hyprwm/Hyprland/discussions/15072#discussioncomment-17352822) for a few months now, so maybe they have more feedback?