### PR TITLE
input: do not enforce keyboard exclusivity during dnd

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -452,7 +452,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     }
 
     // forced above all
-    if (!g_pInputManager->m_exclusiveLSes.empty()) {
+    if (!g_pInputManager->m_exclusiveLSes.empty() && !PROTO::data->dndActive()) {
         if (!foundSurface)
             foundSurface = Desktop::viewState()->hitTest().layerPopupSurfaceAt(mouseCoords, &g_pInputManager->m_exclusiveLSes, &surfaceCoords, &pFoundLayerSurface);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Keyboard exclusivity is enforced even during drag and drop, so other surfaces never have an opportunity to act on it.

Basically this breaks drag and drop for layer surfaces with keyboard interactivity set to exclusive.

#### Is it ready for merging, or does it need work?

ready
