### PR TITLE
screenshare: don't deref a null monitor when starting a window session

### DIFF
--- a/src/managers/screenshare/ScreenshareManager.cpp
+++ b/src/managers/screenshare/ScreenshareManager.cpp
@@ -78,6 +78,11 @@ UP<CScreenshareSession> CScreenshareManager::newSession(wl_client* client, PHLWI
         return nullptr;
     }
 
+    if UNLIKELY (window->m_monitor.expired()) {
+        LOGM(Log::ERR, "Client requested sharing of a window that isn't on a monitor");
+        return nullptr;
+    }
+
     UP<CScreenshareSession> session = UP<CScreenshareSession>(new CScreenshareSession(window, client));
 
     session->m_self = session;
@@ -136,6 +141,12 @@ WP<CScreenshareSession> CScreenshareManager::getManagedSession(eScreenshareType 
             case SHARE_NONE:
             default: return {};
         }
+
+        // init() can stop a session right away (e.g. the window has no monitor to capture from).
+        // don't cache it: the stopped listener isn't hooked up yet, so nothing would ever evict it
+        // and every later request would get handed the same dead session.
+        if UNLIKELY (!session->isActive())
+            return {};
 
         session->m_self = session;
         m_sessions.emplace_back(session);

--- a/src/managers/screenshare/ScreenshareSession.cpp
+++ b/src/managers/screenshare/ScreenshareSession.cpp
@@ -25,8 +25,14 @@ CScreenshareSession::CScreenshareSession(PHLWINDOW window, wl_client* client) : 
         m_events.constraintsChanged.emit();
     });
     m_listeners.windowMonitorChanged = m_window->m_events.monitorChanged.listen([this]() {
-        m_listeners.monitorDestroyed   = monitor()->m_events.disconnect.listen([this]() { stop(); });
-        m_listeners.monitorModeChanged = monitor()->m_events.modeChanged.listen([this]() {
+        const auto PMONITOR = monitor();
+        if UNLIKELY (!PMONITOR) {
+            stop();
+            return;
+        }
+
+        m_listeners.monitorDestroyed   = PMONITOR->m_events.disconnect.listen([this]() { stop(); });
+        m_listeners.monitorModeChanged = PMONITOR->m_events.modeChanged.listen([this]() {
             calculateConstraints();
             m_events.constraintsChanged.emit();
         });
@@ -66,6 +72,15 @@ bool CScreenshareSession::isActive() {
 }
 
 void CScreenshareSession::init() {
+    // a window can outlive the monitor it was on (e.g. all outputs got unplugged), in which
+    // case there is nothing to init the session against
+    const auto PMONITOR = monitor();
+    if UNLIKELY (!PMONITOR) {
+        LOGM(Log::ERR, "Not initing a screenshare session for ({}): no monitor", m_type);
+        stop();
+        return;
+    }
+
     uintptr_t ptr = m_type == SHARE_WINDOW && !m_window.expired() ? (uintptr_t)m_window.get() : (m_monitor.expired() ? (uintptr_t)nullptr : (uintptr_t)m_monitor.get());
     LOGM(Log::TRACE, "Created screenshare session for ({}): {}, {:x}", m_type, m_name, ptr);
 
@@ -82,10 +97,10 @@ void CScreenshareSession::init() {
 
     // scale capture box since it's in logical coords; round to integer pixel
     // dims so m_bufferSize matches the int32 size we send to the client
-    m_captureBox.scale(monitor()->m_scale).round();
+    m_captureBox.scale(PMONITOR->m_scale).round();
 
-    m_listeners.monitorDestroyed   = monitor()->m_events.disconnect.listen([this]() { stop(); });
-    m_listeners.monitorModeChanged = monitor()->m_events.modeChanged.listen([this]() {
+    m_listeners.monitorDestroyed   = PMONITOR->m_events.disconnect.listen([this]() { stop(); });
+    m_listeners.monitorModeChanged = PMONITOR->m_events.modeChanged.listen([this]() {
         calculateConstraints();
         m_events.constraintsChanged.emit();
     });

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -63,6 +63,12 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     m_resource->setDestroy([this](CHyprlandToplevelExportFrameV1* pFrame) { PROTO::toplevelExport->destroyResource(this); });
     m_resource->setCopy([this](CHyprlandToplevelExportFrameV1* pFrame, wl_resource* res, int32_t ignoreDamage) { shareFrame(res, !!ignoreDamage); });
 
+    if UNLIKELY (!m_session) {
+        LOGM(Log::ERR, "Couldn't capture (no share session for the toplevel)");
+        m_resource->sendFailed();
+        return;
+    }
+
     m_frame = m_session->nextFrame(overlayCursor);
 
     auto formats = m_session->allowedFormats();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a SIGSEGV when a screenshare session is created for a window that has no monitor at
that moment, e.g. when a client keeps capturing a toplevel while the outputs are powered
off and come back.

`CScreenshareSession::monitor()` returns `nullptr` for a `SHARE_WINDOW` session once
`m_window->m_monitor` expired, but `init()` dereferences it unconditionally:

    m_captureBox.scale(monitor()->m_scale).round();
    m_listeners.monitorDestroyed = monitor()->m_events.disconnect.listen([this]() { stop(); });

The `SHARE_MONITOR` and `SHARE_REGION` ctors bail out on `!m_monitor` before they reach
`init()`, while the window ctor only checks the window itself, so this is the one unguarded
path. `calculateConstraints()` and `CScreenshareFrame::done()` already treat a missing
monitor as "stop this session".

Reproducer, dual monitor setup: share a window through xdg-desktop-portal-hyprland, power
both monitors off, then turn them back on one at a time. Destroying the monitor stops and
drops the session, the portal keeps requesting frames, a new session gets constructed for
the same window, and by then the window's monitor ref is expired.

    #4 Screenshare::CScreenshareSession::init()
    #5 Screenshare::CScreenshareSession::CScreenshareSession(CSharedPointer<CWindow>, wl_client*)
    #6 Screenshare::CScreenshareManager::getManagedSession(eScreenshareType, wl_client*, ...)
    #7 Screenshare::CScreenshareManager::getManagedSession(wl_client*, CSharedPointer<CWindow>)
    #8 CToplevelExportClient::captureToplevel(unsigned int, int, CSharedPointer<CWindow>)

What the patch does:

- `CScreenshareSession::init()`: stop the session and return if there is no monitor. The
  check runs before the stop timer is created, so nothing half-initialized is left over.
- the window ctor's `monitorChanged` listener: same guard, it dereferences `monitor()` too
  and fires exactly while outputs are being torn down.
- `CScreenshareManager::getManagedSession()`: don't cache a session that `init()` already
  stopped. The stopped listener is hooked up after construction, so such a session would
  never be evicted and every later request would get the same dead one back, leaving the
  client broken instead of recovering once an output is back.
- `CScreenshareManager::newSession(client, window)`: reject a window that is not on a
  monitor. This is the other creation path, used by `ext-image-copy-capture-v1`, which so
  far only checked that the window is mapped.
- `CToplevelExportFrame`: send `failed` when there is no session instead of dereferencing
  an empty `WP`, same as the existing check in `shareFrame()`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No protocol or config changes, only failure paths are touched. A client asking to capture a
window with no monitor now gets `failed` / `stopped` instead of taking the compositor down.

Unrelated, but noticed while reading: nothing removes `m_shareStopTimer` from the event loop
when a session is destroyed. Left alone.

#### Is it ready for merging, or does it need work?

Ready.
