### PR TITLE
layout: fix pinned floating windows not reverting to last postion after exiting fullscreen

### DIFF
--- a/hyprtester/src/tests/main/layout.cpp
+++ b/hyprtester/src/tests/main/layout.cpp
@@ -158,6 +158,19 @@ TEST_CASE(posPreserve) {
         EXPECT_CONTAINS(str, "at: 581,420");
         EXPECT_CONTAINS(str, "size: 1337,69");
     }
+
+    OK(getFromSocket("/eval hl.config({ binds = { allow_pin_fullscreen = true } })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.pin({ action = 'set', window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '2' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen()"));
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen()"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "at: 581,420");
+        EXPECT_CONTAINS(str, "size: 1337,69");
+    }
 }
 
 TEST_CASE(focusMRUAfterClose) {

--- a/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
+++ b/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
@@ -137,8 +137,10 @@ void CDefaultFloatingAlgorithm::movedTarget(SP<ITarget> target, std::optional<Ve
 
         const auto THIS_BOX = m_parent->space()->workspace()->m_monitor->logicalBox();
 
-        if (!THIS_BOX.intersection(BOX).empty())
+        if (!THIS_BOX.intersection(BOX).empty()) {
+            updateTarget(target);
             return;
+        }
     }
 
     auto       LAST_SIZE    = target->lastFloatingSize();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Having a pinned floating window and changing workspaces doesn't call `updateTarget(target);` in `void CDefaultFloatingAlgorithm::movedTarget()` because of an early return for pinned windows. `.lastBox` is erased for our pinned floating window in `m_datas` on workspace change. So after exiting fullscreen after a workspace change the pinned floating window is getting centered in the middle of the monitor in `void CDefaultFloatingAlgorithm::recenter()`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Used LLM to explore codebase and find the problem.

#### Is it ready for merging, or does it need work?
Should be ready. Expanded the test that checks the restoring of floating window positions after cycling through fullscreen.