### PR TITLE
fp16: fix blur clear and invalidate

### DIFF
--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -197,10 +197,13 @@ void IElementRenderer::drawPreBlur(WP<CPreBlurElement> element, const CRegion& d
     auto&      m_renderData = g_pHyprRenderer->m_renderData;
 
     const auto SAVEDRENDERMODIF = m_renderData.renderModif;
+    const auto SAVEDDAMAGE      = m_renderData.damage;
     m_renderData.renderModif    = {}; // fix shit
 
     // make the fake dmg
     CRegion fakeDamage{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+
+    m_renderData.damage = fakeDamage; // the clear inside scissors to renderData.damage, it has to match the blit
 
     draw(element, fakeDamage);
 
@@ -208,6 +211,7 @@ void IElementRenderer::drawPreBlur(WP<CPreBlurElement> element, const CRegion& d
     m_renderData.pMonitor->m_blurFBShouldRender = false;
 
     m_renderData.renderModif = SAVEDRENDERMODIF;
+    m_renderData.damage      = SAVEDDAMAGE;
 }
 
 void IElementRenderer::drawClear(WP<CClearPassElement> element, const CRegion& damage) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -918,14 +918,12 @@ void CHyprOpenGLImpl::end() {
     g_pHyprRenderer->m_renderData.mainFB.reset();
     g_pHyprRenderer->m_renderData.outFB.reset();
     // invalidate our render FBs to signal to the driver we don't need them anymore
-    if (!g_pHyprRenderer->m_renderData.pMonitor->useFP16()) { // FIXME wtf?
-        g_pHyprRenderer->m_renderData.pMonitor->resources()->forEachUnusedFB(
-            [](const auto& fb) {
-                fb->bind();
-                GLFB(fb)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT, GL_COLOR_ATTACHMENT0});
-            },
-            false);
-    }
+    g_pHyprRenderer->m_renderData.pMonitor->resources()->forEachUnusedFB(
+        [](const auto& fb) {
+            fb->bind();
+            GLFB(fb)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT, GL_COLOR_ATTACHMENT0});
+        },
+        false);
 
     m_renderData.pMonitor.reset();
 

--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -4,6 +4,7 @@
 #include "macros.hpp"
 #include "../Framebuffer.hpp"
 #include <hyprgraphics/egl/Egl.hpp>
+#include <algorithm>
 #include <limits>
 
 using namespace Hyprgraphics::Egl;
@@ -259,7 +260,9 @@ void CGLFramebuffer::invalidate(const std::vector<GLenum>& attachments) {
     if (*PFBINVALIDATE)
         glInvalidateFramebuffer(GL_FRAMEBUFFER, attachments.size(), attachments.data());
 
-    m_cleared = false;
+    // m_cleared tracks the color attachment only, see clearAfterInvalidation()
+    if (std::ranges::contains(attachments, sc<GLenum>(GL_COLOR_ATTACHMENT0)))
+        m_cleared = false;
 }
 
 void CGLFramebuffer::clearAfterInvalidation() {


### PR DESCRIPTION
the clear was scissored to m_renderData.damage while we fakeDamaged full monitor. so in render pass when m_blurFBShouldRender is hit the FB was cleared over partial damage but rendered over whole monitor causing stale blur blends into the new outside damage. so save old damage, render fakeDamage, restore old damage.

invalidate({GL_DEPTH_STENCIL_ATTACHMENT}) at end of renderTextureWithBlurInternal cant set m_cleared = false because its not invalidated the COLOR_ATTACHMENT, so guard invalidate.


