### PR TITLE
scrolling/fullscreen: fix notification layer creation causing mouse flick in scrolling covering FS windows

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -485,7 +485,6 @@ void SScrollingData::recalculate(bool forceInstant) {
         return {.logicalBox = logical, .visualBox = visual};
     };
 
-
     SP<SScrollingTargetData> currentCoveringFsTdata = nullptr;
 
     for (size_t i = 0; i < columns.size(); ++i) {
@@ -505,9 +504,9 @@ void SScrollingData::recalculate(bool forceInstant) {
                 if (TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN) {
                     // Target is Covering Fullscreen
                     if (algorithm->m_scrollingFullscreenHandler->isFullscreen(TARGET, Fullscreen::FSMODE_FULLSCREEN, true)) {
-                        TDATA->layoutBox                     = MONBOX;
-                        currentCoveringFsTdata               = TDATA;
-                        targetIsCoveringFullscreen           = true;
+                        TDATA->layoutBox           = MONBOX;
+                        currentCoveringFsTdata     = TDATA;
+                        targetIsCoveringFullscreen = true;
                     }
                     // Target is non-covering fullscreen
                     else {
@@ -523,9 +522,9 @@ void SScrollingData::recalculate(bool forceInstant) {
                 } else if (TARGET_FS_MODE == Fullscreen::FSMODE_MAXIMIZED) {
                     // Target is Covering Maximised
                     if (algorithm->m_scrollingFullscreenHandler->isFullscreen(TARGET, Fullscreen::FSMODE_MAXIMIZED, true)) {
-                        TDATA->layoutBox                     = WORKAREA;
-                        currentCoveringFsTdata                       = TDATA;
-                        targetIsCoveringFullscreen           = true;
+                        TDATA->layoutBox           = WORKAREA;
+                        currentCoveringFsTdata     = TDATA;
+                        targetIsCoveringFullscreen = true;
                     }
                     // Target is non-covering Maximied
                     else {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -448,7 +448,8 @@ void SScrollingData::recalculate(bool forceInstant) {
     auto* const       PGAPSIN       = sc<Config::CCssGapData*>((PGAPSINDATA.ptr()));
     const auto        GAPSIN        = (WORKSPACERULE && WORKSPACERULE->m_gapsIn.has_value()) ? WORKSPACERULE->m_gapsIn.value() : *PGAPSIN;
 
-    if (const auto FULLSCREEN_WINDOW = Fullscreen::controller()->getFullscreenWindow(WORKSPACE);
+    // If there is a default covering fullscreen window (tiled or floating)
+    if (const auto FULLSCREEN_WINDOW = Fullscreen::controller()->getFullscreenWindow(WORKSPACE, true);
         FULLSCREEN_WINDOW && !Fullscreen::controller()->layoutManagedFS(FULLSCREEN_WINDOW)) {
         algorithm->m_scrollingFullscreenHandler->setNoMembersAboveFullscreen();
         return;
@@ -484,9 +485,8 @@ void SScrollingData::recalculate(bool forceInstant) {
         return {.logicalBox = logical, .visualBox = visual};
     };
 
-    bool                     targetWorkspaceHasCoveringFullscreen = false;
 
-    SP<SScrollingTargetData> currentFsTdata = nullptr;
+    SP<SScrollingTargetData> currentCoveringFsTdata = nullptr;
 
     for (size_t i = 0; i < columns.size(); ++i) {
         const auto& COL = columns[i];
@@ -506,8 +506,7 @@ void SScrollingData::recalculate(bool forceInstant) {
                     // Target is Covering Fullscreen
                     if (algorithm->m_scrollingFullscreenHandler->isFullscreen(TARGET, Fullscreen::FSMODE_FULLSCREEN, true)) {
                         TDATA->layoutBox                     = MONBOX;
-                        currentFsTdata                       = TDATA;
-                        targetWorkspaceHasCoveringFullscreen = true;
+                        currentCoveringFsTdata               = TDATA;
                         targetIsCoveringFullscreen           = true;
                     }
                     // Target is non-covering fullscreen
@@ -525,8 +524,7 @@ void SScrollingData::recalculate(bool forceInstant) {
                     // Target is Covering Maximised
                     if (algorithm->m_scrollingFullscreenHandler->isFullscreen(TARGET, Fullscreen::FSMODE_MAXIMIZED, true)) {
                         TDATA->layoutBox                     = WORKAREA;
-                        currentFsTdata                       = TDATA;
-                        targetWorkspaceHasCoveringFullscreen = true;
+                        currentCoveringFsTdata                       = TDATA;
                         targetIsCoveringFullscreen           = true;
                     }
                     // Target is non-covering Maximied
@@ -560,7 +558,8 @@ void SScrollingData::recalculate(bool forceInstant) {
         }
     }
 
-    algorithm->m_scrollingFullscreenHandler->sScrollingDataRecalculateHelper(currentFsTdata, MONITOR, targetWorkspaceHasCoveringFullscreen);
+    // Handles covering FS's setting pos , warp pos and size, and more
+    algorithm->m_scrollingFullscreenHandler->sScrollingDataRecalculateHelper(currentCoveringFsTdata, MONITOR);
 }
 
 double SScrollingData::maxWidth() {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -643,10 +643,8 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
         Updating window visibility states, animation, prev covering FS window info
     */
 
-
     // Keep logic in sync with CScrollingFullscreenHandler::setNoMembersAboveFullscreen
     const auto detectIfWindowHidingOutOfSync = [&]() -> bool {
-
         for (auto const& w : Desktop::windowState()->windows()) {
             if (!w || w->m_workspace != getSpace()->workspace())
                 continue;
@@ -658,19 +656,19 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
             }
         }
 
-
         // Not checking layers here since notifications (-> layers) ontop of scrolling FS windows cause cursor flicks.
-        
+
         // Let newly spawned layers detect if there is a covering FS present themselves
 
         // This is not a problem in the case of the default handled covering floating FS window being unFSed
         // as layers are not set as above fullscreen after a window is unFSed in any case, therefore we let the default FS handler handle leayers itself
-        
 
         return false;
     };
 
-    if (coveringFsWindowStatePositive || scrollingAwayFromCoveringFsWindow || coveringFsWindowStateNegative || (CURRENT_COVERING_FS_TDATA && detectIfWindowHidingOutOfSync())) {
+    if (coveringFsWindowStatePositive || scrollingAwayFromCoveringFsWindow || coveringFsWindowStateNegative ||
+        // For when you unFS the (default handled) covering floating FS window ontop of a Layout handled tiled covering FS window.
+        (CURRENT_COVERING_FS_TDATA && detectIfWindowHidingOutOfSync())) {
 
         /*
             DS and VRR setting must run before setNoMembersAboveFullscreen() because we need the last tiled layout managed fullscreen window before it is reset when no fullscreen
@@ -682,7 +680,6 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
         setNoMembersAboveFullscreen(CURRENT_COVERING_FS_TDATA ? CURRENT_COVERING_FS_TDATA->target->window()->m_target : nullptr);
         // Must run after setNoMembersAboveFullscreen() so it can properly set the windows' allowedOverFullscreen attributes
         updateFullscreenFade(sc<bool>(CURRENT_COVERING_FS_TDATA));
-
     }
 }
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -651,7 +651,7 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
 
             if (w != CURRENT_LAYOUT_HANDLED_FS_WINDOW && !w->m_pinned) {
                 // If it the window was hidden when the UNDERLYING_FS_WINDOW was FSed, or it is a tiled window; it remains hidden. else, it is allowed ontop of it
-                if (w->m_allowedOverFullscreen != w->m_isFloating && !m_fullscreenWindowHidingState.hiddenFloatingWindowsUnderFSWindow.contains(w))
+                if (w->m_allowedOverFullscreen != (w->m_isFloating && !m_fullscreenWindowHidingState.hiddenFloatingWindowsUnderFSWindow.contains(w)))
                     return true;
             }
         }

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -670,7 +670,7 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
         return false;
     };
 
-    if (coveringFsWindowStatePositive || scrollingAwayFromCoveringFsWindow || coveringFsWindowStateNegative || detectIfWindowHidingOutOfSync()) {
+    if (coveringFsWindowStatePositive || scrollingAwayFromCoveringFsWindow || coveringFsWindowStateNegative || (CURRENT_COVERING_FS_TDATA && detectIfWindowHidingOutOfSync())) {
 
         /*
             DS and VRR setting must run before setNoMembersAboveFullscreen() because we need the last tiled layout managed fullscreen window before it is reset when no fullscreen

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -201,8 +201,6 @@ eFullscreenRequestResult CScrollingFullscreenHandler::requestFullscreen(const SF
 
         setTargetFullscreenModeInternal(TARGET, FSMODE_FULLSCREEN);
 
-        setNoMembersAboveFullscreen();
-
         return FULLSCREEN_REQUEST_LAYOUT_HANDLED;
 
     } else if (REQUESTED_MODE == FSMODE_MAXIMIZED) {
@@ -236,8 +234,6 @@ eFullscreenRequestResult CScrollingFullscreenHandler::requestFullscreen(const SF
 
         setTargetFullscreenModeInternal(TARGET, FSMODE_MAXIMIZED);
 
-        setNoMembersAboveFullscreen();
-
         return FULLSCREEN_REQUEST_LAYOUT_HANDLED;
     }
 
@@ -247,7 +243,6 @@ eFullscreenRequestResult CScrollingFullscreenHandler::requestFullscreen(const SF
 
     // UnFS target
     setTargetFullscreenModeInternal(TARGET, FSMODE_NONE);
-    setNoMembersAboveFullscreen();
     m_scrollingAlgorithm->m_scrollingData->centerOrFitCol(currentCol);
     return (REQUESTED_MODE == FSMODE_NONE && !isFullscreen(TARGET, std::nullopt, std::nullopt)) ? FULLSCREEN_REQUEST_LAYOUT_HANDLED : FULLSCREEN_REQUEST_FAILED;
 }
@@ -309,7 +304,7 @@ void CScrollingFullscreenHandler::updateTargetRulesAndDecos(const SP<Layout::ITa
 }
 
 void CScrollingFullscreenHandler::setTargetSizeAndPosition(const SP<Layout::ITarget> target) {
-    // We don't need to do anything explicitly here because in scrolling, pos/size setting as well as managing window/workspace rules are done in scrolling's recalculate()
+    // We don't need to do anything explicitly here because in scrolling, pos/size setting as well as managing window/workspace rules are done in scrolling's recalculate() and its FS helper
     ;
 }
 
@@ -318,7 +313,7 @@ void CScrollingFullscreenHandler::syncTargetSizeAndPosition() {
     ;
 }
 
-void CScrollingFullscreenHandler::setNoMembersAboveFullscreen() {
+void CScrollingFullscreenHandler::setNoMembersAboveFullscreen(const std::optional<SP<Layout::ITarget>> coveringFsTarget) {
     if (!m_scrollingAlgorithm->m_parent || !getSpace() || !getSpace()->workspace() || !getSpace()->workspace()->m_monitor)
         return;
 
@@ -343,7 +338,7 @@ void CScrollingFullscreenHandler::setNoMembersAboveFullscreen() {
         }
         for (auto const& ls : Desktop::layerState()->layers()) {
             if (ls->m_monitor == MONITOR)
-                ls->m_aboveFullscreen = !SET;
+                ls->m_aboveFullscreen = false;
         }
     };
 
@@ -361,14 +356,18 @@ void CScrollingFullscreenHandler::setNoMembersAboveFullscreen() {
     ontop of the floating FS windows that were layered ontop of the tiled FS window.
     */
 
-    const auto COVERING_FULLSCREEN_WINDOW      = Fullscreen::controller()->getFullscreenWindow(WORKSPACE, true);
-    const auto LAYOUT_TILED_COVERING_FS_TARGET = getFullscreen(true);
-    const auto LAYOUT_TILED_COVERING_FS_WINDOW = LAYOUT_TILED_COVERING_FS_TARGET && LAYOUT_TILED_COVERING_FS_TARGET->window() ? LAYOUT_TILED_COVERING_FS_TARGET->window() : nullptr;
+    // Need not be layout handled/tiled
+    const auto COVERING_FS_WINDOW = Fullscreen::controller()->getFullscreenWindow(WORKSPACE, true);
 
-    const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW         = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
+    // scrolling layout handled
+    const auto LAYOUT_TILED_COVERING_FS_WINDOW_TARGET = coveringFsTarget.value_or(getFullscreen(true));
+    const auto LAYOUT_TILED_COVERING_FS_WINDOW        = LAYOUT_TILED_COVERING_FS_WINDOW_TARGET ? LAYOUT_TILED_COVERING_FS_WINDOW_TARGET->window() : nullptr;
+
+    const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW =
+        m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow ? m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock() : nullptr;
     const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW_FS_MODE = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindowMode;
 
-    if (!COVERING_FULLSCREEN_WINDOW && LAYOUT_TILED_COVERING_FS_WINDOW) {
+    if (!COVERING_FS_WINDOW && LAYOUT_TILED_COVERING_FS_WINDOW) {
         // This means that controller doesn't recognise tiled layout handled FS window as fullscreen.
         Log::logger->log(Log::WARN,
                          "Workspace doesn't recognise a tiled layout handled fullscreen/maximised window as such! This is a an error! We will attempt to recover by ignoring "
@@ -377,57 +376,48 @@ void CScrollingFullscreenHandler::setNoMembersAboveFullscreen() {
     }
 
     // There is no FS window; tiled or floating
-    if (!COVERING_FULLSCREEN_WINDOW) {
+    if (!COVERING_FS_WINDOW) {
         m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow = nullptr;
         clear_hiddenFloatingWindowsUnderFSWindow();
         setNoMembersAboveFS_layoutUnaware(false);
         return;
     }
 
-    if (Fullscreen::controller()->getFullscreenHandlerName(COVERING_FULLSCREEN_WINDOW) != FULLSCREEN_HANDLER_SCROLLING) {
-        // TODO - this will fire when default handling FS windows in scrolling workspace. When FS related logic is properly extracted from recalculate(), this will no longer fire when no errors occur, and can be turned into a WARN
-        Log::logger->log(Log::DEBUG, "Default handled FS window called CScrollingFullscreenHandler::setNoMembersAboveFullscreen(). Recovering...");
-
+    // Have a defult handled covering FS window
+    if (Fullscreen::controller()->getFullscreenHandlerName(COVERING_FS_WINDOW) != FULLSCREEN_HANDLER_SCROLLING) {
         setNoMembersAboveFS_layoutUnaware(true);
         return;
     }
 
-    // There's only a floating FS window
-    if (COVERING_FULLSCREEN_WINDOW && !LAYOUT_TILED_COVERING_FS_WINDOW) {
+    // There's only a floating FS window - which is always default handled
+    if (COVERING_FS_WINDOW && !LAYOUT_TILED_COVERING_FS_WINDOW) {
         Log::logger->log(Log::WARN,
-                         "non-scroll-handled FS window called CScrollingFullscreenHandler::setNoMembersAboveFullscreen(). This should never happen: setNoMembersAboveFullscreen() "
-                         "call should have been dispatched to default FS handler. This is a bug, but is not fatal. Recovering...");
+                         "non-scroll-handled FS window called CScrollingFullscreenHandler::setNoMembersAboveFullscreen(). This is a bug, but is not fatal. Recovering...");
 
         clear_hiddenFloatingWindowsUnderFSWindow();
         setNoMembersAboveFS_layoutUnaware(true);
         return;
     }
 
-    // There is an FS window ontop of the layout handled tiled FS window
-    if (COVERING_FULLSCREEN_WINDOW != LAYOUT_TILED_COVERING_FS_WINDOW) {
-        Log::logger->log(Log::WARN,
-                         "non-scroll-handled FS window called CScrollingFullscreenHandler::setNoMembersAboveFullscreen(). This should never happen: setNoMembersAboveFullscreen() "
-                         "call should have been dispatched to default FS handler. This is a bug, but is not fatal. Recovering...");
-        setNoMembersAboveFS_layoutUnaware(true);
-        return;
-    }
-
     // layout handled tiled FS window is the only covering FS window
-    if (COVERING_FULLSCREEN_WINDOW == LAYOUT_TILED_COVERING_FS_WINDOW) {
-        // we are newly scrolling onto this tiled layout handled FS window, or we are changing from maximised to fullscreen or vice versa while in the same FS window
-        if (!LAST_SCROLL_HANDLED_TILED_FS_WINDOW || LAST_SCROLL_HANDLED_TILED_FS_WINDOW != LAYOUT_TILED_COVERING_FS_WINDOW ||
-            getFullscreenModes(LAYOUT_TILED_COVERING_FS_TARGET).internal != LAST_SCROLL_HANDLED_TILED_FS_WINDOW_FS_MODE) {
+    if (COVERING_FS_WINDOW == LAYOUT_TILED_COVERING_FS_WINDOW) {
+        /* These checks must be kept synced with CScrollingFullscreenHandler::sScrollingDataRecalculateHelper()'s */
+        // If there's a new covering FS window, the covering FS window has its mode changed (maximised -> fullscreen), or we scrolled onto a covering FS window
+        if ((LAYOUT_TILED_COVERING_FS_WINDOW && LAST_SCROLL_HANDLED_TILED_FS_WINDOW != LAYOUT_TILED_COVERING_FS_WINDOW) ||
+            getFullscreenModes(LAYOUT_TILED_COVERING_FS_WINDOW_TARGET).internal != LAST_SCROLL_HANDLED_TILED_FS_WINDOW_FS_MODE) {
             clear_hiddenFloatingWindowsUnderFSWindow();
             saveCurrentFsAndAllHiddenFloatingWindows(LAYOUT_TILED_COVERING_FS_WINDOW);
             setNoMembersAboveFS_layoutUnaware(true);
             return;
-        } else {
+        }
+        // If we once more only have a layout handled tiled FS window, possibly after having another covering FS window layered ontop
+        else {
 
             for (auto const& w : Desktop::windowState()->windows()) {
                 if (!w || w->m_workspace != getSpace()->workspace())
                     continue;
 
-                if (w != COVERING_FULLSCREEN_WINDOW && !w->m_pinned) {
+                if (w != COVERING_FS_WINDOW && !w->m_pinned) {
                     // If it the window was hidden when the UNDERLYING_FS_WINDOW was FSed, or it is a tiled window; it remains hidden. else, it is allowed ontop of it
                     w->m_allowedOverFullscreen = w->m_isFloating && !m_fullscreenWindowHidingState.hiddenFloatingWindowsUnderFSWindow.contains(w);
                     w->updateFullscreenInputState();
@@ -442,20 +432,10 @@ void CScrollingFullscreenHandler::setNoMembersAboveFullscreen() {
         }
     }
 
-    if (!LAST_SCROLL_HANDLED_TILED_FS_WINDOW) {
-        if (LAYOUT_TILED_COVERING_FS_WINDOW)
-            m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow = LAYOUT_TILED_COVERING_FS_WINDOW;
-        else
-            m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow = nullptr;
-
-        clear_hiddenFloatingWindowsUnderFSWindow();
-        return;
-    }
-
     Log::logger->log(Log::ERR,
                      "setNoMembersAboveFullscreen() failed to correctly execute. Current FS window: {} Current Tiled layout handled FS window: {} Current last focused tiled "
                      "layout handled FS window: {}",
-                     COVERING_FULLSCREEN_WINDOW, LAYOUT_TILED_COVERING_FS_WINDOW, LAST_SCROLL_HANDLED_TILED_FS_WINDOW);
+                     COVERING_FS_WINDOW, LAYOUT_TILED_COVERING_FS_WINDOW, LAST_SCROLL_HANDLED_TILED_FS_WINDOW);
 }
 
 void CScrollingFullscreenHandler::syncFullscreenTargets() {
@@ -573,29 +553,59 @@ eFullscreenHandler CScrollingFullscreenHandler::getFullscreenHandlerName() const
     return FULLSCREEN_HANDLER_TYPE;
 }
 
-void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layout::Tiled::SScrollingTargetData> CURRENT_FS_TDATA, const PHLMONITOR MONITOR,
-                                                                  const bool TARGET_WORKSPACE_HAS_FS) {
+void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layout::Tiled::SScrollingTargetData> CURRENT_COVERING_FS_TDATA, const PHLMONITOR MONITOR) {
+
     // TODO Decouple FS logic from SScrollingData::recalculate() to avoid having to schedule a prop refresh: it has to be here and it's a mess because recalculate() handled scrolling
     // onto/away from FS windows and this process doesn't call the controller's FS setters which are normally responsible for handling window rule checks.
 
+    if (CURRENT_COVERING_FS_TDATA && !CURRENT_COVERING_FS_TDATA->target && getSpace() && getSpace()->workspace())
+        return;
+
+    // This would not have been updated to the new value it might have yet at this point
+    const auto LAST_FS_LAYOUT_HANDLED_TILED_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
+    // If window group, grabs the current window
+    const auto CURRENT_LAYOUT_HANDLED_FS_WINDOW = CURRENT_COVERING_FS_TDATA ? CURRENT_COVERING_FS_TDATA->target->window() : nullptr;
+
+    /* These checks must be kept synced with CScrollingFullscreenHandler::setNoMembersAboveFullscreen()'s */
+
+    // If there's a new covering FS window, the covering FS window has its mode changed (maximised -> fullscreen), or we scrolled onto a covering FS window
+    const bool coveringFsWindowStatePositive = CURRENT_COVERING_FS_TDATA &&
+        (CURRENT_LAYOUT_HANDLED_FS_WINDOW != LAST_FS_LAYOUT_HANDLED_TILED_WINDOW ||
+         getFullscreenModes(CURRENT_COVERING_FS_TDATA->target.lock()).internal != m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindowMode);
+
+    // check that LAST_FS_LAYOUTMANAGED_TILED_WINDOW was not unfullscreened
+    const bool scrollingAwayFromCoveringFsWindow = LAST_FS_LAYOUT_HANDLED_TILED_WINDOW &&
+        getFullscreenModes(LAST_FS_LAYOUT_HANDLED_TILED_WINDOW->m_target).internal != FSMODE_NONE &&
+        // Current widnow is not FS or it's not the same FS window we were on
+        (!CURRENT_COVERING_FS_TDATA || LAST_FS_LAYOUT_HANDLED_TILED_WINDOW != CURRENT_LAYOUT_HANDLED_FS_WINDOW);
+
+    // If scrolling away from or unFsing the covering FS window
+    const bool coveringFsWindowStateNegative = scrollingAwayFromCoveringFsWindow ||
+        (!CURRENT_COVERING_FS_TDATA && LAST_FS_LAYOUT_HANDLED_TILED_WINDOW && getFullscreenModes(LAST_FS_LAYOUT_HANDLED_TILED_WINDOW->m_target).internal == FSMODE_NONE);
+
+    /*
+        Refreshing window rules and decos
+    */
+
     // Scrolling onto or have a new FS window
-    if ((TARGET_WORKSPACE_HAS_FS && CURRENT_FS_TDATA && CURRENT_FS_TDATA->target && CURRENT_FS_TDATA->target->window() &&
-         CURRENT_FS_TDATA->target->window() != m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow)) {
+    if (coveringFsWindowStatePositive) {
 
         // If window group, get the current window
-        const auto LAST_FS_WINDOW_TARGET = CURRENT_FS_TDATA->target->window()->m_target;
+        const auto LAST_FS_WINDOW_TARGET = CURRENT_COVERING_FS_TDATA->target->window()->m_target;
 
+        // Needn't set pos/size here as recalc correctly handles accounting for reserved areas, etc...
+        // We need to update the application of window rules here
         updateTargetRulesAndDecos(LAST_FS_WINDOW_TARGET);
-
     }
     // Scrolling away from an FS window
-    else if (m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow && !TARGET_WORKSPACE_HAS_FS) {
-        const auto LAST_FS_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
+    else if (coveringFsWindowStateNegative) {
 
-        updateTargetRulesAndDecos(LAST_FS_WINDOW->m_target);
+        updateTargetRulesAndDecos(LAST_FS_LAYOUT_HANDLED_TILED_WINDOW->m_target);
     }
 
-    /* Setting DS and VRR */
+    /*
+        Setting DS and VRR 
+    */
 
     // If a window is being un-FSed, set its DS and VRR in requestFullscreen()
     // If we are scrolling away from an FS window that is not unFSed yet, we set its DS and VRR in sScrollingDataRecalculateHelper()
@@ -605,43 +615,75 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
 
     // If we are scrolling away from a layout managed tiled FS window, send it a regular tranche
     // we need only check its internal state as if the window was saved in lastTiledLayoutManagedFsWindow, it is guaranteed to be as its name suggests
-    if (const auto LAST_FS_LAYOUTMANAGED_TILED_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
-        // check if LAST_FS_LAYOUTMANAGED_TILED_WINDOW exists, and that we either don't have a covering FS window, or if we do; it's not the same as LAST_FS_LAYOUTMANAGED_TILED_WINDOW
-        LAST_FS_LAYOUTMANAGED_TILED_WINDOW &&
-        (!CURRENT_FS_TDATA || (CURRENT_FS_TDATA && LAST_FS_LAYOUTMANAGED_TILED_WINDOW != CURRENT_FS_TDATA->target->window()))
-        // check that LAST_FS_LAYOUTMANAGED_TILED_WINDOW was not unfullscreened (requestFullscreen() would have handled setting its DSO/VRR)
-        && getFullscreenModes(LAST_FS_LAYOUTMANAGED_TILED_WINDOW->m_target).internal != FSMODE_NONE) {
+    if (scrollingAwayFromCoveringFsWindow) {
 
         // send a regular tranche
         // ignore if DS is disabled.
-        if ((*PDIRECTSCANOUT == 1 || (*PDIRECTSCANOUT == 2 && LAST_FS_LAYOUTMANAGED_TILED_WINDOW->getContentType() == NContentType::CONTENT_TYPE_GAME))) {
-            auto surf = LAST_FS_LAYOUTMANAGED_TILED_WINDOW->getSolitaryResource();
+        if ((*PDIRECTSCANOUT == 1 || (*PDIRECTSCANOUT == 2 && LAST_FS_LAYOUT_HANDLED_TILED_WINDOW->getContentType() == NContentType::CONTENT_TYPE_GAME))) {
+            auto surf = LAST_FS_LAYOUT_HANDLED_TILED_WINDOW->getSolitaryResource();
             if (surf)
                 g_pHyprRenderer->setSurfaceScanoutMode(surf, nullptr);
         }
     }
-
     // If we are scrolling onto, or have newly FSed a window
-    if (CURRENT_FS_TDATA && CURRENT_FS_TDATA->target->window()) {
-        const auto  CURRENTLY_FS_WINDOW = CURRENT_FS_TDATA->target->window();
+    else if (coveringFsWindowStatePositive) {
 
         static auto PDIRECTSCANOUT = CConfigValue<Config::INTEGER>("render:direct_scanout");
-        if (*PDIRECTSCANOUT == 1 || (*PDIRECTSCANOUT == 2 && CURRENTLY_FS_WINDOW->getContentType() == NContentType::CONTENT_TYPE_GAME)) {
+        if (*PDIRECTSCANOUT == 1 || (*PDIRECTSCANOUT == 2 && CURRENT_LAYOUT_HANDLED_FS_WINDOW->getContentType() == NContentType::CONTENT_TYPE_GAME)) {
             // send a scanout tranche
             // ignore if DS is disabled.
-            auto surf = CURRENTLY_FS_WINDOW->getSolitaryResource();
+            auto surf = CURRENT_LAYOUT_HANDLED_FS_WINDOW->getSolitaryResource();
             if (surf)
                 g_pHyprRenderer->setSurfaceScanoutMode(surf, MONITOR->m_self.lock());
         }
     }
-
     Config::monitorRuleMgr()->ensureVRR(MONITOR);
 
-    // DS and VRR setting must run before setNoMembersAboveFullscreen() because we need the last tiled layout managed fullscreen window before it is reset when no fullscreen
-    setNoMembersAboveFullscreen();
+    /*
+        Updating window visibility states, animation, prev covering FS window info
+    */
 
-    // Must run after setNoMembersAboveFullscreen() so it can properly set the windows' allowedOverFullscreen attributes
-    updateFullscreenFade(TARGET_WORKSPACE_HAS_FS);
+
+    // Keep logic in sync with CScrollingFullscreenHandler::setNoMembersAboveFullscreen
+    const auto detectIfWindowHidingOutOfSync = [&]() -> bool {
+
+        for (auto const& w : Desktop::windowState()->windows()) {
+            if (!w || w->m_workspace != getSpace()->workspace())
+                continue;
+
+            if (w != CURRENT_LAYOUT_HANDLED_FS_WINDOW && !w->m_pinned) {
+                // If it the window was hidden when the UNDERLYING_FS_WINDOW was FSed, or it is a tiled window; it remains hidden. else, it is allowed ontop of it
+                if (w->m_allowedOverFullscreen != w->m_isFloating && !m_fullscreenWindowHidingState.hiddenFloatingWindowsUnderFSWindow.contains(w))
+                    return true;
+            }
+        }
+
+
+        // Not checking layers here since notifications (-> layers) ontop of scrolling FS windows cause cursor flicks.
+        
+        // Let newly spawned layers detect if there is a covering FS present themselves
+
+        // This is not a problem in the case of the default handled covering floating FS window being unFSed
+        // as layers are not set as above fullscreen after a window is unFSed in any case, therefore we let the default FS handler handle leayers itself
+        
+
+        return false;
+    };
+
+    if (coveringFsWindowStatePositive || scrollingAwayFromCoveringFsWindow || coveringFsWindowStateNegative || detectIfWindowHidingOutOfSync()) {
+
+        /*
+            DS and VRR setting must run before setNoMembersAboveFullscreen() because we need the last tiled layout managed fullscreen window before it is reset when no fullscreen
+
+            It is IMPERATIVE that setNoMembersAboveFullscreen() is NOT called before this when FSing or unFSing a window. We need the information about the prev/current FS window to survive till here!
+        
+            If window group, gets the current window
+        */
+        setNoMembersAboveFullscreen(CURRENT_COVERING_FS_TDATA ? CURRENT_COVERING_FS_TDATA->target->window()->m_target : nullptr);
+        // Must run after setNoMembersAboveFullscreen() so it can properly set the windows' allowedOverFullscreen attributes
+        updateFullscreenFade(sc<bool>(CURRENT_COVERING_FS_TDATA));
+
+    }
 }
 
 void CScrollingFullscreenHandler::saveCurrentFsAndAllHiddenFloatingWindows(PHLWINDOW fullscreenWindow) {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.hpp
@@ -60,7 +60,7 @@ namespace Fullscreen::ScrollingFullscreenHandler {
 
         virtual void syncTargetSizeAndPosition();
 
-        virtual void setNoMembersAboveFullscreen();
+        virtual void setNoMembersAboveFullscreen(const std::optional<SP<Layout::ITarget>> coveringFsTarget = std::nullopt);
         virtual void syncFullscreenTargets();
         virtual void removeFsTarget(SP<Layout::ITarget> target, const bool recursionGuard = false);
 
@@ -70,7 +70,7 @@ namespace Fullscreen::ScrollingFullscreenHandler {
 
         // Scrolling Specific Helpers
 
-        void sScrollingDataRecalculateHelper(const SP<Layout::Tiled::SScrollingTargetData> CURRENT_FS_TDATA, const PHLMONITOR MONITOR, const bool TARGET_WORKSPACE_HAS_FS);
+        void sScrollingDataRecalculateHelper(const SP<Layout::Tiled::SScrollingTargetData> CURRENT_COVERING_FS_TDATA, const PHLMONITOR MONITOR);
 
       private:
         struct SScrollingFullscreenWindowHidingState {

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -268,7 +268,7 @@ void IFullscreenHandler::syncTargetSizeAndPosition() {
     Fullscreen::controller()->m_windowPosSettingQueued = false;
 }
 
-void IFullscreenHandler::setNoMembersAboveFullscreen() {
+void IFullscreenHandler::setNoMembersAboveFullscreen(const std::optional<SP<Layout::ITarget>> coveringFsTarget) {
     if (!getSpace() || !getSpace()->workspace() || !getSpace()->workspace()->m_monitor)
         return;
 
@@ -286,7 +286,7 @@ void IFullscreenHandler::setNoMembersAboveFullscreen() {
     }
     for (auto const& ls : Desktop::layerState()->layers()) {
         if (ls->m_monitor == MONITOR)
-            ls->m_aboveFullscreen = !SET;
+            ls->m_aboveFullscreen = false;
     }
 }
 

--- a/src/managers/fullscreen/handler/FullscreenHandler.hpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.hpp
@@ -62,7 +62,7 @@ namespace Fullscreen {
 
         virtual void syncTargetSizeAndPosition();
 
-        virtual void setNoMembersAboveFullscreen();
+        virtual void setNoMembersAboveFullscreen(const std::optional<SP<Layout::ITarget>> coveringFsTarget = std::nullopt);
 
         virtual void syncFullscreenTargets();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Title

Fixes:
https://github.com/hyprwm/Hyprland/discussions/15565
https://github.com/hyprwm/Hyprland/discussions/15693

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No


#### Is it ready for merging, or does it need work?

Ready when marked as such - This is not testable (cursor flick when you receive a notification when are moving view in blender was the repo method we went with)

