### PR TITLE
compositor: set bits for all double buffered commits

### DIFF
--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -174,6 +174,8 @@ void CPointerManager::setCursorSurface(SP<Desktop::View::CWLSurface> surf, const
         m_currentCursorImage.surface = surf;
         m_currentCursorImage.scale   = surf->resource()->m_current.scale;
 
+        surf->resource()->m_pending.updated.bits.cursor = true;
+
         surf->resource()->map();
 
         m_currentCursorImage.destroySurface = surf->m_events.destroy.listen([this] { resetCursorImage(); });

--- a/src/protocols/InputMethodV2.cpp
+++ b/src/protocols/InputMethodV2.cpp
@@ -135,6 +135,8 @@ bool CInputMethodPopupV2::good() {
 
 void CInputMethodPopupV2::sendInputRectangle(const CBox& box) {
     m_resource->sendTextInputRectangle(box.x, box.y, box.w, box.h);
+    if (m_surface)
+        m_surface->m_pending.updated.bits.imePopup = true;
 }
 
 SP<CWLSurfaceResource> CInputMethodPopupV2::surface() {

--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -22,7 +22,11 @@ CSessionLockSurface::CSessionLockSurface(SP<CExtSessionLockSurfaceV1> resource_,
         PROTO::sessionLock->destroyResource(this);
     });
 
-    m_resource->setAckConfigure([this](CExtSessionLockSurfaceV1* r, uint32_t serial) { m_ackdConfigure = true; });
+    m_resource->setAckConfigure([this](CExtSessionLockSurfaceV1* r, uint32_t serial) {
+        m_ackdConfigure = true;
+        if (m_surface)
+            m_surface->m_pending.updated.bits.sessionLock = true;
+    });
 
     m_listeners.surfaceCommit = m_surface->m_events.commit.listen([this] {
         if (!m_surface->m_current.texture) {

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -73,6 +73,8 @@ CXDGPopupResource::CXDGPopupResource(SP<CXdgPopup> resource_, SP<CXDGSurfaceReso
         if (!pos)
             return;
         m_positionerRules = CXDGPositionerRules{pos};
+        if (m_surface && m_surface->m_surface)
+            m_surface->m_surface->m_pending.updated.bits.xdgPopup = true;
         m_events.reposition.emit();
     });
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -187,6 +187,11 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
             // remove any pending states.
             m_stateQueue.clear();
             m_pending.reset();
+
+            // gtk destroys its dialog/toplevel on hiding to tray, commits a null buffer
+            // but keeps the surface alive, next time when its time to show its going to think
+            // its already m_mapped, because we never unmapped it. so unmap it on null buffers..
+            unmap();
             return;
         }
 

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -578,8 +578,9 @@ void CWLDataDeviceProtocol::initiateDrag(WP<CWLDataSourceResource> currentSource
     m_dnd.originSurface = origin;
     m_dnd.dndSurface    = dragSurface;
     if (dragSurface) {
-        m_dnd.dndSurfaceDestroy = dragSurface->m_events.destroy.listen([this] { abortDrag(); });
-        m_dnd.dndSurfaceCommit  = dragSurface->m_events.commit.listen([this] {
+        dragSurface->m_pending.updated.bits.dndIcon = true;
+        m_dnd.dndSurfaceDestroy                     = dragSurface->m_events.destroy.listen([this] { abortDrag(); });
+        m_dnd.dndSurfaceCommit                      = dragSurface->m_events.commit.listen([this] {
             if (m_dnd.dndSurface->m_current.texture && !m_dnd.dndSurface->m_mapped) {
                 m_dnd.dndSurface->map();
                 return;

--- a/src/protocols/core/Subcompositor.cpp
+++ b/src/protocols/core/Subcompositor.cpp
@@ -10,7 +10,10 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
     m_resource->setOnDestroy([this](CWlSubsurface* r) { destroy(); });
     m_resource->setDestroy([this](CWlSubsurface* r) { destroy(); });
 
-    m_resource->setSetPosition([this](CWlSubsurface* r, int32_t x, int32_t y) { m_position = {x, y}; });
+    m_resource->setSetPosition([this](CWlSubsurface* r, int32_t x, int32_t y) {
+        m_position = {x, y};
+        markPlacementPending();
+    });
 
     m_resource->setSetDesync([this](CWlSubsurface* r) { m_sync = false; });
     m_resource->setSetSync([this](CWlSubsurface* r) { m_sync = true; });
@@ -43,6 +46,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
         }
 
         m_parent->sortSubsurfaces();
+        markPlacementPending();
     });
 
     m_resource->setPlaceBelow([this](CWlSubsurface* r, wl_resource* surf) {
@@ -73,6 +77,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
         }
 
         m_parent->sortSubsurfaces();
+        markPlacementPending();
     });
 
     m_listeners.commitSurface = m_surface->m_events.commit.listen([this] {
@@ -106,6 +111,11 @@ void CWLSubsurfaceResource::destroy() {
     }
     m_events.destroy.emit();
     PROTO::subcompositor->destroyResource(this);
+}
+
+void CWLSubsurfaceResource::markPlacementPending() {
+    if (m_surface)
+        m_surface->m_pending.updated.bits.subsurfacePlacement = true;
 }
 
 void CWLSubsurfaceResource::unlinkFromParent() {

--- a/src/protocols/core/Subcompositor.hpp
+++ b/src/protocols/core/Subcompositor.hpp
@@ -56,6 +56,7 @@ class CWLSubsurfaceResource {
 
     void              destroy();
     void              unlinkFromParent();
+    void              markPlacementPending();
 
     struct {
         CHyprSignalListener commitSurface;

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -62,6 +62,13 @@ struct SSurfaceState {
             bool alphaModifier : 1;
             bool hyprlandSurface : 1;
             bool backgroundEffect : 1;
+            bool subsurfacePlacement : 1;
+            bool sessionLock : 1;
+            bool imePopup : 1;
+            bool dndIcon : 1;
+            bool cursor : 1;
+            bool xwayland : 1;
+            bool xdgPopup : 1;
         } bits;
     } updated;
 

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -199,6 +199,9 @@ void CXWaylandSurface::configure(const CBox& box) {
 
     m_geometry = box;
 
+    if (m_surface)
+        m_surface->m_pending.updated.bits.xwayland = true;
+
     uint32_t mask     = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT | XCB_CONFIG_WINDOW_BORDER_WIDTH;
     uint32_t values[] = {box.x, box.y, box.width, box.height, 0};
     xcb_configure_window(g_pXWayland->m_wm->getConnection(), m_xID, mask, values);


### PR DESCRIPTION
set a updated.bit for all protos listening to surface .commit that applies a double buffered state, gtk is being a PITA and sends various shit it expects before it sends buffer attach and what not, so they get dropped early by the empty commit return early if guard.

@fxzzi 


