### PR TITLE
config: enable skip_non_kms_dmabuf_formats by default

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -752,7 +752,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
          */
 
         MS<Int>("quirks:prefer_hdr", "Prefer HDR mode.", 0, {.min = 0, .max = 2, .map = OptionMap{{"disable", 0}, {"enable", 1}, {"gamescope_only", 2}}}),
-        MS<Bool>("quirks:skip_non_kms_dmabuf_formats", "Do not report dmabuf formats which cannot be imported into KMS", false),
+        MS<Bool>("quirks:skip_non_kms_dmabuf_formats", "Do not report dmabuf formats which cannot be imported into KMS", true),
     };
 
 #undef MS


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

fixes stuff for nvidia users, don't see why we can't enable it by default for us plebians
or maybe @UjinT34 has an objection

https://github.com/hyprwm/Hyprland/discussions/15781
https://github.com/hyprwm/Hyprland/discussions/14843

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

naw

#### Is it ready for merging, or does it need work?

ye
