### PR TITLE
fix a lot of expand_undersized resize artifact/smear/issues

### DIFF
--- a/src/desktop/view/WLSurface.cpp
+++ b/src/desktop/view/WLSurface.cpp
@@ -51,9 +51,16 @@ bool CWLSurface::small() const {
     if (!O || !O->mapped() || !O->acceptsInput() || !O->alphaNonZero())
         return false;
 
-    const auto REPORTED_SIZE = O->backend().reportedSize();
+    const auto  REPORTED_SIZE = O->backend().reportedSize();
+    const auto& CURRENT_SIZE  = m_resource->m_current.size;
 
-    return REPORTED_SIZE.x > m_resource->m_current.size.x + 1 || REPORTED_SIZE.y > m_resource->m_current.size.y + 1;
+    if (REPORTED_SIZE.x <= CURRENT_SIZE.x + 1 && REPORTED_SIZE.y <= CURRENT_SIZE.y + 1)
+        return false;
+
+    // acking a configure and attaching the buffer for it are separate commits, and we may have
+    // configured the window again since. a buffer matching an older configure is behind, not small:
+    // shrinking the box down to it would leave the rest of the window unpainted until it catches up.
+    return !O->backend().configuredSizeRecently(CURRENT_SIZE);
 }
 
 Vector2D CWLSurface::correctSmallVec() const {

--- a/src/desktop/view/window/WaylandBackend.cpp
+++ b/src/desktop/view/window/WaylandBackend.cpp
@@ -299,6 +299,7 @@ void CWaylandBackend::configure(const CBox& logicalBox, PHLMONITOR preferredMoni
         return;
 
     m_pendingReportedSize = CLIENT_BOX.size();
+    recordConfiguredSize(CLIENT_BOX.size());
     m_configureAcks.add(TOPLEVEL->setSize(CLIENT_BOX.size()), CLIENT_BOX.size().floor());
 }
 

--- a/src/desktop/view/window/WindowBackend.cpp
+++ b/src/desktop/view/window/WindowBackend.cpp
@@ -1,6 +1,7 @@
 #include "WindowBackend.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 using namespace Desktop::View;
 
@@ -10,6 +11,16 @@ IWindowBackend::~IWindowBackend() = default;
 
 bool IWindowBackend::isX11() const {
     return type() == eBackendType::WINDOW_BACKEND_X11;
+}
+
+void IWindowBackend::recordConfiguredSize(const Vector2D& size) {
+    m_recentConfiguredSizes.emplace_back(size.floor());
+    if (m_recentConfiguredSizes.size() > 4)
+        m_recentConfiguredSizes.erase(m_recentConfiguredSizes.begin());
+}
+
+bool IWindowBackend::configuredSizeRecently(const Vector2D& size) const {
+    return std::ranges::any_of(m_recentConfiguredSizes, [&size](const auto& s) { return DELTALESSTHAN(size.x, s.x, 2) && DELTALESSTHAN(size.y, s.y, 2); });
 }
 
 void CWindowConfigureAckTracker::add(uint32_t serial, const Vector2D& size) {

--- a/src/desktop/view/window/WindowBackend.hpp
+++ b/src/desktop/view/window/WindowBackend.hpp
@@ -116,6 +116,10 @@ namespace Desktop::View {
         virtual double                 surfaceScale() const                     = 0;
         virtual Vector2D               reportedSize() const                     = 0;
 
+        // whether we configured the client to (roughly) this size in the last few configures.
+        // a client presenting a buffer for one of these that isn't the current one is behind, not small.
+        bool                           configuredSizeRecently(const Vector2D& size) const;
+
         virtual CBox                   clientToLogical(const CBox& box, PHLMONITOR preferredMonitor) const = 0;
         virtual CBox                   logicalToClient(const CBox& box, PHLMONITOR preferredMonitor) const = 0;
         virtual Vector2D               surfaceLocalToBuffer(const Vector2D& local) const                   = 0;
@@ -161,6 +165,12 @@ namespace Desktop::View {
 
         virtual void attach(PHLWINDOWREF window) = 0;
 
+        void         recordConfiguredSize(const Vector2D& size);
+
         friend class CWindow;
+
+      private:
+        // the last few sizes we configured the client to, newest last. see configuredSizeRecently().
+        std::vector<Vector2D> m_recentConfiguredSizes;
     };
 }

--- a/src/desktop/view/window/X11Backend.cpp
+++ b/src/desktop/view/window/X11Backend.cpp
@@ -342,6 +342,7 @@ void CX11Backend::configure(const CBox& logicalBox, PHLMONITOR preferredMonitor_
 
     m_reportedPosition    = CLIENT_BOX.pos();
     m_pendingReportedSize = CLIENT_BOX.size();
+    recordConfiguredSize(CLIENT_BOX.size());
     SURFACE->configure(CLIENT_BOX);
 }
 

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -106,9 +106,18 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
             const bool SCALE_UNAWARE    = pMonitor->m_scale != 1.f && (MONITOR_WL_SCALE == pSurface->m_current.scale || !pSurface->m_current.viewport.hasDestination);
             const auto EXPECTED_SIZE    = getSurfaceExpectedSize(pWindow, pSurface, pMonitor, main).value_or((projSize * pMonitor->m_scale).round());
 
+            // mid animation the box is transient, so it cant tell us whether the texture is undersized.
+            // judge that against the animation goal instead, if the texture is already the size the window
+            // is heading for, nothing is undersized and expanding would only clamp the UVs past 1.0 and
+            // smear its last row/column. cropping stays fine though, the box is animating towards the size
+            // the texture already has, so it uncrops itself by the time the animation ends.
+            const auto GOALSIZE = pWindow ? (pWindow->size(Desktop::View::IGeometric::GEOMETRIC_GOAL) * pMonitor->m_scale).round() : Vector2D{};
+            const bool ANIMONLYMISMATCH =
+                pWindow && pWindow->sizeAnimation()->isBeingAnimated() && DELTALESSTHAN(GOALSIZE.x, EXPECTED_SIZE.x, 2) && DELTALESSTHAN(GOALSIZE.y, EXPECTED_SIZE.y, 2);
+
             const auto RATIO = projSize / EXPECTED_SIZE;
             if (!SCALE_UNAWARE || MONITOR_WL_SCALE == 1) {
-                if (*PEXPANDEDGES && !SCALE_UNAWARE && (RATIO.x > 1 || RATIO.y > 1)) {
+                if (*PEXPANDEDGES && !ANIMONLYMISMATCH && !SCALE_UNAWARE && (RATIO.x > 1 || RATIO.y > 1)) {
                     const auto FIX = RATIO.clamp(Vector2D{1, 1}, Vector2D{1000000, 1000000});
                     uvBR           = uvBR * FIX;
                 }


### PR DESCRIPTION
we have to check against animation target size, otherwise the undersized
checks misinterprets it as undersized and smears and artifacts the UV

a client can ack a configure and attach the buffer for it in separate
commits, and we may have configured it again in between. the buffer it
still presents then matches an older configure, small() fires and the box
shrinks below the window, leaving the rest of it unpainted for a frame.

Before:


https://github.com/user-attachments/assets/2f5a8ae8-5033-4c0a-9cdd-6311aeab5022


https://github.com/user-attachments/assets/9834349e-72ad-4e78-bce4-0b05c7514c95



After:


https://github.com/user-attachments/assets/7782726a-aa1a-461c-90f1-f8b6c68d974c




