### PR TITLE
dispatch/center: `hl.dsp.window.center()` doesn't save the new pos of the floating window

### DIFF
--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -1180,3 +1180,46 @@ TEST_CASE(defaultHandledFsfocusInDirection) {
         EXPECT_CONTAINS(str, "fullscreenClient: 0");
     }
 }
+
+TEST_CASE(dwindleFullsreenCenterDispatchSavesPos) {
+    /*
+        This test serves as a test for all layouts that use deafult FS behaviour
+
+        Also tests hl.dsp.window.center() incidentally
+
+    */
+
+    SPAWN_KITTY("kot");
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set', window = 'class:kot' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x =100 , y =100 , relative = false, window = 'class:kot' })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: kot");
+        EXPECT_CONTAINS(str, "at: 100,100");
+        EXPECT_CONTAINS(str, "fullscreen: 0");
+        EXPECT_CONTAINS(str, "fullscreenClient: 0");
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.window.center({ window = 'class:kot' })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: kot");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "fullscreen: 0");
+        EXPECT_CONTAINS(str, "fullscreenClient: 0");
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', window = 'class:kot' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', window = 'class:kot' })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: kot");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "fullscreen: 0");
+        EXPECT_CONTAINS(str, "fullscreenClient: 0");
+    }
+}

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -567,8 +567,10 @@ ActionResult Actions::center(std::optional<PHLWINDOW> w) {
 
     const auto PMONITOR = window->m_monitor.lock();
 
-    window->layoutTarget()->setPositionGlobal(
-        CBox{PMONITOR->logicalBoxMinusReserved().middle() - window->size(Desktop::View::IGeometric::GEOMETRIC_GOAL) / 2.F, window->layoutTarget()->position().size()});
+    if (window->m_isFloating)
+        g_layoutManager->setTargetGeom(
+            CBox{PMONITOR->logicalBoxMinusReserved().middle() - window->size(Desktop::View::IGeometric::GEOMETRIC_GOAL) / 2.F, window->layoutTarget()->position().size()},
+            window->m_target);
 
     return {};
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes bug where hl.dsp.window.center() doesn't save the new pos of the floating window

Fixes case:

1. spawn floating kitty
2. Move it to somewhere not centre
3. hl.dsp.window.center()
4. FS and unFS
5. The window won't return to the centre but to where you moved it before


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

- [x] Test (also incidentally tests `hl.dsp.window.center()` since there wasn't test for this before)

