### PR TITLE
desktop/view: fix focus when closing pinned window on special workspace

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -534,6 +534,36 @@ TEST_CASE(pinnedWorkspacesValid) {
     }
 }
 
+TEST_CASE(pinnedCloseFocusSpecialWorkspace) {
+    OK(getFromSocket("/eval hl.config({ input = { focus_on_close = 0 } })"));
+
+    SPAWN_KITTY("pinned");
+    SPAWN_KITTY("workspace");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set', window = 'class:pinned' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.pin({ action = 'set', window = 'class:pinned' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'special:special' })"));
+    SPAWN_KITTY("special");
+    {
+        auto str = getFromSocket("/monitors");
+        ASSERT_CONTAINS(str, "special workspace: -");
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:pinned' })"));
+    ASSERT(isActiveWindow("pinned"), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.window.kill({ window = 'class:pinned' })"));
+    Tests::waitUntilWindowsN(2);
+
+    {
+        auto str = getFromSocket("/monitors");
+        ASSERT_CONTAINS(str, "special workspace: -");
+    }
+
+    ASSERT(isActiveWindow("special"), true);
+}
+
 TEST_CASE(windowruleWorkspaceEmpty) {
     OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_A' }, workspace = 'empty' })"));
     OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_B' }, workspace = 'emptyn' })"));

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2673,9 +2673,13 @@ void CWindow::unmapWindow() {
                 candidate = (Desktop::viewState()->hitTest().windowAt(g_pInputManager->getMouseCoordsInternal(),
                                                                       Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING));
             else {
-                const auto CAND = g_layoutManager->getNextCandidate(m_workspace->m_space, layoutTarget());
-                if (CAND)
-                    candidate = CAND->window();
+                if (m_pinned && PMONITOR && PMONITOR->m_activeSpecialWorkspace)
+                    candidate = PMONITOR->m_activeSpecialWorkspace->getFocusCandidate();
+                if (!candidate) {
+                    const auto CAND = g_layoutManager->getNextCandidate(m_workspace->m_space, layoutTarget());
+                    if (CAND)
+                        candidate = CAND->window();
+                }
             }
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes https://github.com/hyprwm/Hyprland/discussions/15812. If there is no window on the special workspace it will close the special workspace.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
As I wrote above I'm not sure if an empty special workspace should close when a pinned window gets closed. It's quite a niche case.