### PR TITLE
render/cm: fix hdrMetadataEqual returning inverted result

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2304,7 +2304,7 @@ static bool hdrMetadataEqual(const hdr_output_metadata& a, const hdr_output_meta
         return false;
 
     static_assert(std::has_unique_object_representations_v<hdr_metadata_infoframe>);
-    return std::memcmp(&a.hdmi_metadata_type1, &b.hdmi_metadata_type1, sizeof(a.hdmi_metadata_type1));
+    return std::memcmp(&a.hdmi_metadata_type1, &b.hdmi_metadata_type1, sizeof(a.hdmi_metadata_type1)) == 0;
 }
 
 void IHyprRenderer::handleFullscreenSettings(PHLMONITOR pMonitor) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Symptom: 
one CPU core pinned; compositor thread ramps and never settles; log spams drm: Modesetting DP-2/DP-3 (180,289 modesets in ~8 min) + [CM] Updating HDR metadata from monitor on a display with cm=hdredid.

Root cause: 
hdrMetadataEqual() (src/render/Renderer.cpp:2302) returns std::memcmp(...) raw — truthy when buffers differ. The caller (commitFrame, line 2374) tests !hdrMetadataEqual(WANTED, CURRENT), so identical HDR metadata is re-sent every frame → aquamarine sets AQ_OUTPUT_STATE_HDR → NEEDS_RECONFIG (DRM.cpp:1994) → full modeset per commit.

Fix: 
return std::memcmp(...) == 0;

Verification: 

built from the patched commit, flat ~10% CPU (was ramping 24→40%), modesets frozen at 5 (startup only), no Updating HDR metadata spam. CPU core isn't going above about 8% for me, prior using this commit and even latest commit on main, cpu would slowly rise to 100% until it would stay there, causing Hyprland to essentially be a windows 95 gateway computer.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I used AI to diagnose this as it was a weird one, originally I thought it was related to https://github.com/hyprwm/Hyprland/discussions/11411 as this describes the same scenario, after having AI essentially sit there and do traces on logs and cpu/proc stuff it was able to pin down this commit https://github.com/hyprwm/Hyprland/pull/15761/changes/72ca6a4e5a18820114a17340f388af86bd1db8a5 and had to do with some inverted logic

#### Is it ready for merging, or does it need work?
I believe it's ready, but could use more valid eyes

