### PR TITLE
hyprpm: add experimental persistent cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -742,6 +742,9 @@ if(BUILD_TESTING)
   add_custom_target(tests)
 
   add_dependencies(tests hyprland_gtests)
+  if(TARGET hyprpm_gtests)
+    add_dependencies(tests hyprpm_gtests)
+  endif()
 
 else()
   message(STATUS "Testing is disabled")

--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -33,6 +33,16 @@ set_target_properties(hyprpm PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 target_link_libraries(hyprpm PUBLIC PkgConfig::hyprpm_deps glaze::glaze)
 
+if (BUILD_TESTING OR WITH_TESTS)
+    find_package(GTest CONFIG REQUIRED)
+    include(GoogleTest)
+    enable_testing()
+
+    add_executable(hyprpm_gtests tests/RepositoryCache.cpp src/core/RepositoryCache.cpp)
+    target_link_libraries(hyprpm_gtests PRIVATE GTest::gtest_main)
+    gtest_discover_tests(hyprpm_gtests TEST_PREFIX "hyprpm.")
+endif()
+
 # binary
 install(TARGETS hyprpm)
 

--- a/hyprpm/hyprpm.bash
+++ b/hyprpm/hyprpm.bash
@@ -15,10 +15,10 @@ _hyprpm () {
     local words cword
     _get_comp_words_by_ref -n "$COMP_WORDBREAKS" words cword
 
-    declare -a literals=(--no-shallow -n ::= disable list --help update add --verbose -v --force -s remove enable --notify -h reload -f)
+    declare -a literals=(--no-shallow -n ::= disable list --help update add --verbose -v --force -s remove enable --notify -h reload -f --experimental-cache)
     declare -A literal_transitions
-    literal_transitions[0]="([0]=7 [3]=3 [4]=4 [8]=7 [9]=7 [6]=4 [7]=4 [11]=7 [5]=7 [10]=7 [12]=2 [13]=3 [15]=7 [16]=4 [17]=7)"
-    literal_transitions[1]="([12]=2 [13]=3 [3]=3 [4]=4 [16]=4 [6]=4 [7]=4)"
+    literal_transitions[0]="([0]=7 [3]=3 [4]=4 [8]=7 [9]=7 [6]=4 [7]=4 [11]=7 [5]=7 [10]=7 [12]=2 [13]=3 [15]=7 [16]=4 [17]=7 [18]=7)"
+    literal_transitions[1]="([12]=2 [13]=3 [3]=3 [4]=4 [16]=4 [6]=4 [7]=4 [18]=7)"
     literal_transitions[5]="([2]=6)"
     literal_transitions[6]="([1]=7 [14]=7)"
     declare -A match_anything_transitions=([1]=1 [4]=5 [3]=4 [2]=4 [0]=1)

--- a/hyprpm/hyprpm.fish
+++ b/hyprpm/hyprpm.fish
@@ -19,7 +19,7 @@ function _hyprpm
         set COMP_CWORD (count $COMP_WORDS)
     end
 
-    set literals "--no-shallow" "-n" "::=" "disable" "list" "--help" "update" "add" "--verbose" "-v" "--force" "-s" "remove" "enable" "--notify" "-h" "reload" "-f"
+    set literals "--no-shallow" "-n" "::=" "disable" "list" "--help" "update" "add" "--verbose" "-v" "--force" "-s" "remove" "enable" "--notify" "-h" "reload" "-f" "--experimental-cache"
 
     set descriptions
     set descriptions[1] "Disable shallow cloning of Hyprland sources"
@@ -39,10 +39,11 @@ function _hyprpm
     set descriptions[16] "Show help menu"
     set descriptions[17] "Reload all plugins"
     set descriptions[18] "Force an operation ignoring checks (e.g. update -f)"
+    set descriptions[19] "Persist plugin repositories and their build caches locally"
 
     set literal_transitions
-    set literal_transitions[1] "set inputs 1 4 5 9 10 7 8 12 6 11 13 14 16 17 18; set tos 8 4 5 8 8 5 5 8 8 8 3 4 8 5 8"
-    set literal_transitions[2] "set inputs 13 14 4 5 17 7 8; set tos 3 4 4 5 5 5 5"
+    set literal_transitions[1] "set inputs 1 4 5 9 10 7 8 12 6 11 13 14 16 17 18 19; set tos 8 4 5 8 8 5 5 8 8 8 3 4 8 5 8 8"
+    set literal_transitions[2] "set inputs 13 14 4 5 17 7 8 19; set tos 3 4 4 5 5 5 5 8"
     set literal_transitions[6] "set inputs 3; set tos 7"
     set literal_transitions[7] "set inputs 2 15; set tos 8 8"
 

--- a/hyprpm/hyprpm.usage
+++ b/hyprpm/hyprpm.usage
@@ -6,6 +6,7 @@ hyprpm [<FLAGS>]... <ARGUMENT>
         |   (--verbose | -v)            "Enable too much logging"
         |   (--force | -f)              "Force an operation ignoring checks (e.g. update -f)"
         |   (--no-shallow | -s)         "Disable shallow cloning of Hyprland sources"
+        |   (--experimental-cache)      "Persist plugin repositories and their build caches locally"
         ;
 
 <ARGUMENT> ::= (add)                    "Install a new plugin repository from git"

--- a/hyprpm/hyprpm.zsh
+++ b/hyprpm/hyprpm.zsh
@@ -9,7 +9,7 @@ _hyprpm_cmd_1 () {
 }
 
 _hyprpm () {
-    local -a literals=("--no-shallow" "-n" "::=" "disable" "list" "--help" "update" "add" "--verbose" "-v" "--force" "-s" "remove" "enable" "--notify" "-h" "reload" "-f")
+    local -a literals=("--no-shallow" "-n" "::=" "disable" "list" "--help" "update" "add" "--verbose" "-v" "--force" "-s" "remove" "enable" "--notify" "-h" "reload" "-f" "--experimental-cache")
 
     local -A descriptions
     descriptions[1]="Disable shallow cloning of Hyprland sources"
@@ -29,10 +29,11 @@ _hyprpm () {
     descriptions[16]="Show help menu"
     descriptions[17]="Reload all plugins"
     descriptions[18]="Force an operation ignoring checks (e.g. update -f)"
+    descriptions[19]="Persist plugin repositories and their build caches locally"
 
     local -A literal_transitions
-    literal_transitions[1]="([1]=8 [4]=4 [5]=5 [9]=8 [10]=8 [7]=5 [8]=5 [12]=8 [6]=8 [11]=8 [13]=3 [14]=4 [16]=8 [17]=5 [18]=8)"
-    literal_transitions[2]="([13]=3 [14]=4 [4]=4 [5]=5 [17]=5 [7]=5 [8]=5)"
+    literal_transitions[1]="([1]=8 [4]=4 [5]=5 [9]=8 [10]=8 [7]=5 [8]=5 [12]=8 [6]=8 [11]=8 [13]=3 [14]=4 [16]=8 [17]=5 [18]=8 [19]=8)"
+    literal_transitions[2]="([13]=3 [14]=4 [4]=4 [5]=5 [17]=5 [7]=5 [8]=5 [19]=8)"
     literal_transitions[6]="([3]=7)"
     literal_transitions[7]="([2]=8 [15]=8)"
 

--- a/hyprpm/src/core/DataState.cpp
+++ b/hyprpm/src/core/DataState.cpp
@@ -1,13 +1,22 @@
 #include "DataState.hpp"
 #include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <unistd.h>
+#include <cerrno>
 #include <toml++/toml.hpp>
 #include <print>
 #include <sstream>
-#include <fstream>
+#include <string_view>
+#include <format>
 #include "PluginManager.hpp"
 #include "../helpers/Die.hpp"
 #include "../helpers/Sys.hpp"
 #include "../helpers/StringUtils.hpp"
+
+#include <hyprutils/memory/Casts.hpp>
+using namespace Hyprutils::Memory;
 
 static std::string getTempRoot() {
     static auto ENV = getenv("XDG_RUNTIME_DIR");
@@ -16,7 +25,7 @@ static std::string getTempRoot() {
         exit(1);
     }
 
-    const auto STR = ENV + std::string{"/hyprpm/"};
+    const auto STR = std::format("{}/hyprpm/", ENV);
 
     if (!std::filesystem::exists(STR))
         mkdir(STR.c_str(), S_IRWXU);
@@ -24,21 +33,66 @@ static std::string getTempRoot() {
     return STR;
 }
 
+static bool writeAll(int fd, std::string_view data) {
+    size_t written = 0;
+    while (written < data.size()) {
+        const auto WRITE = write(fd, data.data() + written, data.size() - written);
+        if (WRITE < 0) {
+            if (errno == EINTR)
+                continue;
+            return false;
+        }
+        if (WRITE == 0)
+            return false;
+        written += WRITE;
+    }
+    return true;
+}
+
 // write the state to a file
 static bool writeState(const std::string& str, const std::string& to) {
-    // create temp file in a safe temp root
-    std::ofstream of(std::format("{}.temp-state", getTempRoot()), std::ios::trunc);
-    if (!of.good())
+    int TEMP_FD = open(getTempRoot().c_str(), O_RDWR | O_TMPFILE | O_CLOEXEC, S_IRUSR | S_IWUSR);
+    if (TEMP_FD < 0)
+        TEMP_FD = memfd_create("hyprpm-state", MFD_CLOEXEC);
+    if (TEMP_FD < 0)
         return false;
 
-    of << str;
-    of.close();
-
-    return NSys::root::install(std::format("{}.temp-state", getTempRoot()), to, "644");
+    const bool WRITTEN   = writeAll(TEMP_FD, str) && lseek(TEMP_FD, 0, SEEK_SET) == 0;
+    const bool INSTALLED = WRITTEN && NSys::root::installFromFD(TEMP_FD, to, "644");
+    close(TEMP_FD);
+    return INSTALLED;
 }
 
 std::filesystem::path DataState::getDataStatePath() {
     return std::filesystem::path(std::format("/var/cache/hyprpm/{}", g_pPluginManager->m_szUsername));
+}
+
+std::filesystem::path DataState::getRepositoryCachePath() {
+    const auto XDG_CACHE_HOME = getenv("XDG_CACHE_HOME");
+    if (XDG_CACHE_HOME && std::filesystem::path{XDG_CACHE_HOME}.is_absolute())
+        return std::filesystem::path{XDG_CACHE_HOME} / "hyprpm" / "repos";
+
+    const auto USER = getpwuid(NSys::getUID());
+    if (!USER || !USER->pw_dir)
+        Debug::die("getRepositoryCachePath: Failed to determine the user's home directory");
+
+    return std::filesystem::path{USER->pw_dir} / ".cache" / "hyprpm" / "repos";
+}
+
+static bool installPluginBinary(const std::filesystem::path& source, const std::filesystem::path& destination) {
+    const int SOURCE_FD = open(source.c_str(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (SOURCE_FD < 0)
+        return false;
+
+    struct stat sourceStat;
+    if (fstat(SOURCE_FD, &sourceStat) != 0 || !S_ISREG(sourceStat.st_mode) || sourceStat.st_uid != sc<uid_t>(NSys::getUID())) {
+        close(SOURCE_FD);
+        return false;
+    }
+
+    const bool INSTALLED = NSys::root::installFromFD(SOURCE_FD, destination.string(), "0755");
+    close(SOURCE_FD);
+    return INSTALLED;
 }
 
 std::string DataState::getHeadersPath() {
@@ -103,8 +157,8 @@ void DataState::addNewPluginRepo(const SPluginRepository& repo) {
         const auto filename = std::format("{}.so", p.name);
 
         // copy .so to the good place and chmod 755
-        if (std::filesystem::exists(p.filename)) {
-            if (!NSys::root::install(p.filename, (PATH / filename).string(), "0755"))
+        if (!p.failed && std::filesystem::exists(p.filename)) {
+            if (!installPluginBinary(p.filename, PATH / filename))
                 Debug::die("addNewPluginRepo: failed to install so file");
         }
 
@@ -296,15 +350,28 @@ bool DataState::setPluginEnabled(const SPluginRepoIdentifier& identifier, bool e
 
 void DataState::purgeAllCache() {
     std::error_code ec;
-    if (!std::filesystem::exists(getDataStatePath()) && !ec) {
-        std::println("{}", infoString("Nothing to do"));
-        return;
+    bool            removed = false;
+
+    if (std::filesystem::exists(getDataStatePath(), ec) && !ec) {
+        const auto PATH = getDataStatePath().string();
+        if (PATH.contains('\''))
+            return;
+        // scary!
+        if (!NSys::root::removeRecursive(PATH))
+            Debug::die("Failed to run a superuser cmd");
+        removed = true;
     }
 
-    const auto PATH = getDataStatePath().string();
-    if (PATH.contains('\''))
-        return;
-    // scary!
-    if (!NSys::root::removeRecursive(PATH))
-        Debug::die("Failed to run a superuser cmd");
+    ec.clear();
+    const auto REPOSITORY_CACHE        = getRepositoryCachePath();
+    const auto REPOSITORY_CACHE_STATUS = std::filesystem::symlink_status(REPOSITORY_CACHE, ec);
+    if (!ec && REPOSITORY_CACHE_STATUS.type() != std::filesystem::file_type::not_found) {
+        std::filesystem::remove_all(REPOSITORY_CACHE, ec);
+        if (ec)
+            Debug::die("Failed to remove the local repository cache");
+        removed = true;
+    }
+
+    if (!removed)
+        std::println("{}", infoString("Nothing to do"));
 }

--- a/hyprpm/src/core/DataState.hpp
+++ b/hyprpm/src/core/DataState.hpp
@@ -11,6 +11,7 @@ struct SGlobalState {
 
 namespace DataState {
     std::filesystem::path              getDataStatePath();
+    std::filesystem::path              getRepositoryCachePath();
     std::string                        getHeadersPath();
     std::vector<std::filesystem::path> getPluginStates();
     void                               ensureStateStoreExists();

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -4,6 +4,7 @@
 #include "../progress/CProgressBar.hpp"
 #include "Manifest.hpp"
 #include "DataState.hpp"
+#include "RepositoryCache.hpp"
 #include "HyprlandSocket.hpp"
 #include "../helpers/Sys.hpp"
 #include "../helpers/Die.hpp"
@@ -20,6 +21,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/file.h>
+#include <fcntl.h>
 #include <pwd.h>
 #include <unistd.h>
 
@@ -33,15 +36,35 @@ using namespace Hyprutils::String;
 using namespace Hyprutils::OS;
 using namespace Hyprutils::Memory;
 
-static std::string execAndGet(std::string cmd) {
+struct SExecResult {
+    std::string output;
+    int         exitCode = -1;
+};
+
+static SExecResult execCommand(std::string cmd) {
     cmd += " 2>&1";
 
     CProcess proc("/bin/sh", {"-c", cmd});
 
     if (!proc.runSync())
-        return "error";
+        return {.output = "error"};
 
-    return proc.stdOut();
+    return {.output = proc.stdOut(), .exitCode = proc.exitCode()};
+}
+
+static std::string execAndGet(std::string cmd) {
+    return execCommand(std::move(cmd)).output;
+}
+
+static std::string shellQuote(std::string_view value) {
+    std::string result = "'";
+    for (const auto c : value) {
+        if (c == '\'')
+            result += "'\\''";
+        else
+            result += c;
+    }
+    return result + "'";
 }
 
 static std::string getTempRoot() {
@@ -65,6 +88,11 @@ CPluginManager::CPluginManager() {
         Debug::die("Don't run hyprpm as a superuser.");
 
     m_szUsername = getpwuid(NSys::getUID())->pw_name;
+}
+
+CPluginManager::~CPluginManager() {
+    if (m_iRepositoryCacheLockFD >= 0)
+        close(m_iRepositoryCacheLockFD);
 }
 
 SHyprlandVersion CPluginManager::getHyprlandVersion(bool running) {
@@ -140,6 +168,180 @@ bool CPluginManager::validArg(const std::string& s) {
     return !s.contains("'") && !s.ends_with("\\") && !s.starts_with("\\");
 }
 
+std::string CPluginManager::getPluginRepositoryPath(const std::string& url) {
+    if (!m_bExperimentalCache)
+        return getTempRoot() + m_szUsername;
+
+    return (DataState::getRepositoryCachePath() / std::format("{:016x}", NRepositoryCache::key(url))).string();
+}
+
+bool CPluginManager::acquireRepositoryCacheLock() {
+    if (m_iRepositoryCacheLockFD >= 0)
+        return true;
+
+    const auto      CACHE_ROOT = DataState::getRepositoryCachePath();
+    const auto      CACHE_HOME = CACHE_ROOT.parent_path().parent_path();
+    const auto      HYPRPM_DIR = CACHE_ROOT.parent_path();
+
+    std::error_code ec;
+    for (const auto& path : {CACHE_HOME, HYPRPM_DIR}) {
+        const bool existed = std::filesystem::exists(path, ec);
+        if (ec)
+            return false;
+
+        if (existed && !NRepositoryCache::secureDirectory(path, NSys::getUID())) {
+            std::println(stderr, "\n{}", failureString("Local repository cache path is not a secure user-owned directory: {}", path.string()));
+            return false;
+        }
+
+        std::filesystem::create_directories(path, ec);
+        if (ec) {
+            std::println(stderr, "\n{}", failureString("Could not create the local repository cache: {}", ec.message()));
+            return false;
+        }
+
+        if (!existed || path != CACHE_HOME)
+            std::filesystem::permissions(path, std::filesystem::perms::owner_all, std::filesystem::perm_options::replace, ec);
+
+        if (ec || !NRepositoryCache::secureDirectory(path, NSys::getUID())) {
+            std::println(stderr, "\n{}", failureString("Local repository cache path is not a secure user-owned directory: {}", path.string()));
+            return false;
+        }
+    }
+
+    const auto LOCK_PATH     = HYPRPM_DIR / ".lock";
+    m_iRepositoryCacheLockFD = open(LOCK_PATH.c_str(), O_CREAT | O_CLOEXEC | O_RDWR | O_NOFOLLOW, S_IRUSR | S_IWUSR);
+    if (m_iRepositoryCacheLockFD < 0) {
+        std::println(stderr, "\n{}", failureString("Could not open the local repository cache lock"));
+        return false;
+    }
+
+    struct stat lockStat;
+    if (fstat(m_iRepositoryCacheLockFD, &lockStat) != 0 || !S_ISREG(lockStat.st_mode) || lockStat.st_uid != sc<uid_t>(NSys::getUID()) || (lockStat.st_mode & (S_IWGRP | S_IWOTH)) ||
+        flock(m_iRepositoryCacheLockFD, LOCK_EX | LOCK_NB) != 0) {
+        close(m_iRepositoryCacheLockFD);
+        m_iRepositoryCacheLockFD = -1;
+        std::println(stderr, "\n{}", failureString("Local repository cache is already in use or has an unsafe lock file"));
+        return false;
+    }
+
+    return true;
+}
+
+bool CPluginManager::preparePluginRepository(const std::string& url) {
+    m_szWorkingPluginDirectory = getPluginRepositoryPath(url);
+
+    if (!m_bExperimentalCache) {
+        if (!std::filesystem::exists(getTempRoot())) {
+            std::filesystem::create_directory(getTempRoot());
+            std::filesystem::permissions(getTempRoot(), std::filesystem::perms::owner_all, std::filesystem::perm_options::replace);
+        } else if (!std::filesystem::is_directory(getTempRoot())) {
+            std::println(stderr, "\n{}", failureString("Could not prepare working dir for hyprpm"));
+            return false;
+        }
+
+        if (!createSafeDirectory(m_szWorkingPluginDirectory)) {
+            std::println(stderr, "\n{}", failureString("Could not prepare working dir for repo"));
+            return false;
+        }
+
+        const auto RET = execAndGet(std::format("cd '{}' && git clone --recursive '{}' '{}'", getTempRoot(), url, m_szUsername));
+        if (!std::filesystem::exists(m_szWorkingPluginDirectory + "/.git")) {
+            std::println(stderr, "\n{}", failureString("Could not clone the plugin repository. shell returned:\n{}", RET));
+            return false;
+        }
+
+        return true;
+    }
+
+    if (!acquireRepositoryCacheLock())
+        return false;
+
+    const auto      CACHE_ROOT = DataState::getRepositoryCachePath();
+    std::error_code ec;
+    const bool      cacheRootExisted = std::filesystem::exists(CACHE_ROOT, ec);
+    if (ec || (cacheRootExisted && !NRepositoryCache::secureDirectory(CACHE_ROOT, NSys::getUID()))) {
+        std::println(stderr, "\n{}", failureString("The local repository cache is unsafe. Run hyprpm purge-cache and try again."));
+        return false;
+    }
+
+    std::filesystem::create_directories(CACHE_ROOT, ec);
+    if (!cacheRootExisted)
+        std::filesystem::permissions(CACHE_ROOT, std::filesystem::perms::owner_all, std::filesystem::perm_options::replace, ec);
+    if (ec || !NRepositoryCache::secureDirectory(CACHE_ROOT, NSys::getUID())) {
+        std::println(stderr, "\n{}", failureString("Could not create a secure local repository cache"));
+        return false;
+    }
+
+    if (!std::filesystem::exists(m_szWorkingPluginDirectory)) {
+        const auto RET = execCommand(std::format("cd {} && git clone --recursive {} {}", shellQuote(CACHE_ROOT.string()), shellQuote(url),
+                                                 shellQuote(std::filesystem::path{m_szWorkingPluginDirectory}.filename().string())));
+        if (RET.exitCode != 0 || !std::filesystem::exists(m_szWorkingPluginDirectory + "/.git")) {
+            std::println(stderr, "\n{}", failureString("Could not clone the plugin repository into the local cache. shell returned:\n{}", RET.output));
+            return false;
+        }
+
+        std::filesystem::permissions(m_szWorkingPluginDirectory, std::filesystem::perms::owner_all, std::filesystem::perm_options::replace, ec);
+        if (ec || !NRepositoryCache::secureDirectory(m_szWorkingPluginDirectory, NSys::getUID())) {
+            std::println(stderr, "\n{}", failureString("The cloned repository cache directory is unsafe"));
+            return false;
+        }
+
+        return true;
+    }
+
+    if (!NRepositoryCache::secureDirectory(m_szWorkingPluginDirectory, NSys::getUID()) || !std::filesystem::exists(m_szWorkingPluginDirectory + "/.git")) {
+        std::println(stderr, "\n{}", failureString("The local repository cache is corrupted. Run hyprpm purge-cache and try again."));
+        return false;
+    }
+
+    const auto ORIGIN = trim(execAndGet(std::format("git -C {} remote get-url origin", shellQuote(m_szWorkingPluginDirectory))));
+    if (ORIGIN != url) {
+        std::println(stderr, "\n{}", failureString("The local repository cache belongs to a different URL. Run hyprpm purge-cache and try again."));
+        return false;
+    }
+
+    const auto QUOTED_PATH = shellQuote(m_szWorkingPluginDirectory);
+    const auto RET         = execCommand(std::format("git -C {} fetch --prune --recurse-submodules origin && "
+                                                     "git -C {} remote set-head origin --auto && "
+                                                     "git -C {} reset --hard --recurse-submodules refs/remotes/origin/HEAD && "
+                                                     "git -C {} submodule sync --recursive && "
+                                                     "git -C {} submodule update --init --recursive",
+                                                     QUOTED_PATH, QUOTED_PATH, QUOTED_PATH, QUOTED_PATH, QUOTED_PATH));
+
+    if (RET.exitCode != 0) {
+        std::println(stderr, "\n{}", failureString("Could not update the cached plugin repository. shell returned:\n{}", RET.output));
+        return false;
+    }
+
+    return true;
+}
+
+bool CPluginManager::preparePluginOutput(const std::string& output) {
+    std::error_code ec;
+    const auto      OUTPUT_PATH = NRepositoryCache::resolvePathSlotWithin(m_szWorkingPluginDirectory, output);
+    if (!OUTPUT_PATH)
+        return false;
+
+    if (!std::filesystem::exists(*OUTPUT_PATH, ec))
+        return !ec;
+
+    return std::filesystem::remove(*OUTPUT_PATH, ec) && !ec;
+}
+
+std::optional<std::filesystem::path> CPluginManager::pluginOutputPath(const std::string& output) {
+    const auto OUTPUT_PATH = NRepositoryCache::resolvePathWithin(m_szWorkingPluginDirectory, output);
+    if (!OUTPUT_PATH || !NRepositoryCache::regularFileOwnedBy(*OUTPUT_PATH, NSys::getUID()))
+        return std::nullopt;
+
+    return OUTPUT_PATH;
+}
+
+void CPluginManager::cleanWorkingPluginDirectory() {
+    if (!m_bExperimentalCache)
+        std::filesystem::remove_all(m_szWorkingPluginDirectory);
+}
+
 bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string& rev) {
     const auto HLVER = getHyprlandVersion();
 
@@ -193,42 +395,25 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
 
     progress.print();
 
-    if (!std::filesystem::exists(getTempRoot())) {
-        std::filesystem::create_directory(getTempRoot());
-        std::filesystem::permissions(getTempRoot(), std::filesystem::perms::owner_all, std::filesystem::perm_options::replace);
-    } else if (!std::filesystem::is_directory(getTempRoot())) {
-        std::println(stderr, "\n{}", failureString("Could not prepare working dir for hyprpm"));
+    progress.printMessageAbove(infoString("{} {}", m_bExperimentalCache ? "Preparing cached repository" : "Cloning", url));
+
+    if (!preparePluginRepository(url))
         return false;
-    }
 
-    const std::string USERNAME = getpwuid(getuid())->pw_name;
-
-    m_szWorkingPluginDirectory = std::format("{}{}", getTempRoot(), USERNAME);
-
-    if (!createSafeDirectory(m_szWorkingPluginDirectory)) {
-        std::println(stderr, "\n{}", failureString("Could not prepare working dir for repo"));
-        return false;
-    }
-
-    progress.printMessageAbove(infoString("Cloning {}", url));
-
-    std::string ret = execAndGet(std::format("cd {} && git clone --recursive '{}' {}", getTempRoot(), url, USERNAME));
-
-    if (!std::filesystem::exists(std::format("{}/.git", m_szWorkingPluginDirectory))) {
-        std::println(stderr, "\n{}", failureString("Could not clone the plugin repository. shell returned:\n{}", ret));
-        return false;
-    }
+    std::string ret;
 
     if (!rev.empty()) {
-        std::string ret = execAndGet(std::format("git -C {} reset --hard --recurse-submodules {}", m_szWorkingPluginDirectory, rev));
+        std::string ret = execAndGet(std::format("git -C {} reset --hard --recurse-submodules {}", shellQuote(m_szWorkingPluginDirectory), shellQuote(rev)));
         if (ret.compare(0, 6, "fatal:") == 0) {
             std::println(stderr, "\n{}", failureString("Could not check out revision {}. shell returned:\n{}", rev, ret));
             return false;
         }
-        ret = execAndGet(std::format("git -C {} submodule update --init", m_szWorkingPluginDirectory));
+        ret = execAndGet(std::format("git -C {} submodule update --init", shellQuote(m_szWorkingPluginDirectory)));
         if (m_bVerbose)
             std::println("{}", verboseString("git submodule update --init returned: {}", ret));
     }
+
+    const auto FETCHED_REPOSITORY_HASH = trim(execAndGet("git -C " + shellQuote(m_szWorkingPluginDirectory) + " rev-parse HEAD"));
 
     progress.m_iSteps = 1;
     progress.printMessageAbove(successString("cloned"));
@@ -286,9 +471,9 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
 
             progress.printMessageAbove(successString("commit pin {} matched hl, resetting", plugin));
 
-            execAndGet(std::format("cd {} && git reset --hard --recurse-submodules '{}'", m_szWorkingPluginDirectory, plugin));
+            execAndGet(std::format("cd {} && git reset --hard --recurse-submodules {}", shellQuote(m_szWorkingPluginDirectory), shellQuote(plugin)));
 
-            ret = execAndGet(std::format("git -C {} submodule update --init", m_szWorkingPluginDirectory));
+            ret = execAndGet(std::format("git -C {} submodule update --init", shellQuote(m_szWorkingPluginDirectory)));
             if (m_bVerbose)
                 std::println("{}", verboseString("git submodule update --init returned: {}", ret));
 
@@ -325,8 +510,14 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
 
         const auto env = getPluginBuildEnv();
 
+        if (m_bExperimentalCache && !preparePluginOutput(p.output)) {
+            progress.printMessageAbove(failureString("Refusing unsafe or unremovable cached output path for {}", p.name));
+            p.failed = true;
+            continue;
+        }
+
         for (auto const& bs : p.buildSteps) {
-            const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && {} {}", m_szWorkingPluginDirectory, env, bs), HLVER);
+            const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && {} {}", shellQuote(m_szWorkingPluginDirectory), env, bs), HLVER);
 
             if (!CMD_RAW) {
                 progress.printMessageAbove(failureString("Failed to build {}: {}", p.name, CMD_RAW.error()));
@@ -339,7 +530,7 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
         if (m_bVerbose)
             std::println("{}", verboseString("shell returned: {}", out));
 
-        if (!std::filesystem::exists(std::format("{}/{}", m_szWorkingPluginDirectory, p.output))) {
+        if (!pluginOutputPath(p.output)) {
             progress.printMessageAbove(failureString("Plugin {} failed to build.\n"
                                                      "  This likely means that the plugin is either outdated, not yet available for your version, or broken.\n"
                                                      "  If you are on -git, update first\n"
@@ -360,18 +551,17 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
 
     // add repo toml to DataState
     SPluginRepository repo;
-    std::string       repohash = execAndGet(std::format("cd {} && git rev-parse HEAD", m_szWorkingPluginDirectory));
-    if (repohash.length() > 0)
-        repohash.pop_back();
-    auto lastSlash       = url.find_last_of('/');
-    auto secondLastSlash = url.find_last_of('/', lastSlash - 1);
-    repo.name            = pManifest->m_repository.name.empty() ? url.substr(lastSlash + 1) : pManifest->m_repository.name;
-    repo.author          = url.substr(secondLastSlash + 1, lastSlash - secondLastSlash - 1);
-    repo.url             = url;
-    repo.rev             = rev;
-    repo.hash            = repohash;
+    std::string repohash  = m_bExperimentalCache ? FETCHED_REPOSITORY_HASH : trim(execAndGet(std::format("cd {} && git rev-parse HEAD", shellQuote(m_szWorkingPluginDirectory))));
+    auto        lastSlash = url.find_last_of('/');
+    auto        secondLastSlash = url.find_last_of('/', lastSlash - 1);
+    repo.name                   = pManifest->m_repository.name.empty() ? url.substr(lastSlash + 1) : pManifest->m_repository.name;
+    repo.author                 = url.substr(secondLastSlash + 1, lastSlash - secondLastSlash - 1);
+    repo.url                    = url;
+    repo.rev                    = rev;
+    repo.hash                   = repohash;
     for (auto const& p : pManifest->m_plugins) {
-        repo.plugins.push_back(SPlugin{p.name, std::format("{}/{}", m_szWorkingPluginDirectory, p.output), false, p.failed});
+        const auto OUTPUT_PATH = p.failed ? std::nullopt : pluginOutputPath(p.output);
+        repo.plugins.push_back(SPlugin{p.name, OUTPUT_PATH ? OUTPUT_PATH->string() : "", false, p.failed || !OUTPUT_PATH});
     }
     DataState::addNewPluginRepo(repo);
 
@@ -384,7 +574,7 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
     std::print("\n");
 
     // remove build files
-    std::filesystem::remove_all(m_szWorkingPluginDirectory);
+    cleanWorkingPluginDirectory();
 
     return true;
 }
@@ -691,14 +881,11 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
     progress.m_szCurrentMessage = "Updating repositories";
     progress.print();
 
-    const std::string USERNAME = getpwuid(getuid())->pw_name;
-    m_szWorkingPluginDirectory = std::format("{}{}", getTempRoot(), USERNAME);
-
     std::vector<std::string> failedRepos;
 
     const auto               markRepoFailed = [&](const SPluginRepository& repo, bool advanceProgress) {
         failedRepos.emplace_back(repo.name);
-        std::filesystem::remove_all(m_szWorkingPluginDirectory);
+        cleanWorkingPluginDirectory();
 
         if (advanceProgress) {
             progress.m_iSteps++;
@@ -715,22 +902,19 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
 
         progress.printMessageAbove(infoString("checking for updates for {}", repo.name));
 
-        createSafeDirectory(m_szWorkingPluginDirectory);
+        progress.printMessageAbove(infoString("{} {}", m_bExperimentalCache ? "Preparing cached repository" : "Cloning", repo.url));
 
-        progress.printMessageAbove(infoString("Cloning {}", repo.url));
-
-        std::string ret = execAndGet(std::format("cd {} && git clone --recursive '{}' {}", getTempRoot(), repo.url, USERNAME));
-
-        if (!std::filesystem::exists(std::format("{}/.git", m_szWorkingPluginDirectory))) {
-            std::println(stderr, "\n{}", failureString("could not clone repo: shell returned: {}", ret));
+        if (!preparePluginRepository(repo.url)) {
             markRepoFailed(repo, true);
             continue;
         }
 
+        std::string ret;
+
         if (!repo.rev.empty()) {
             progress.printMessageAbove(infoString("Plugin has revision set, resetting: {}", repo.rev));
 
-            std::string ret = execAndGet(std::format("git -C {} reset --hard --recurse-submodules \'{}\'", m_szWorkingPluginDirectory, repo.rev));
+            std::string ret = execAndGet(std::format("git -C {} reset --hard --recurse-submodules {}", shellQuote(m_szWorkingPluginDirectory), shellQuote(repo.rev)));
             if (ret.compare(0, 6, "fatal:") == 0) {
                 std::println(stderr, "\n{}", failureString("could not check out revision {}: shell returned:\n{}", repo.rev, ret));
 
@@ -739,17 +923,17 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
             }
         }
 
+        const auto FETCHED_REPOSITORY_HASH = trim(execAndGet("git -C " + shellQuote(m_szWorkingPluginDirectory) + " rev-parse HEAD"));
+
         if (!update) {
             // check if git has updates
-            std::string hash = execAndGet(std::format("cd {} && git rev-parse HEAD", m_szWorkingPluginDirectory));
-            if (!hash.empty())
-                hash.pop_back();
+            const auto hash = trim(execAndGet(std::format("cd {} && git rev-parse HEAD", shellQuote(m_szWorkingPluginDirectory))));
 
             update = update || hash != repo.hash;
         }
 
         if (!update) {
-            std::filesystem::remove_all(m_szWorkingPluginDirectory);
+            cleanWorkingPluginDirectory();
             progress.printMessageAbove(successString("repository {} is up-to-date.", repo.name));
             progress.m_iSteps++;
             progress.print();
@@ -805,7 +989,7 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
 
                 progress.printMessageAbove(successString("commit pin {} matched hl, resetting", plugin));
 
-                execAndGet(std::format("cd {} && git reset --hard --recurse-submodules '{}'", m_szWorkingPluginDirectory, plugin));
+                execAndGet(std::format("cd {} && git reset --hard --recurse-submodules {}", shellQuote(m_szWorkingPluginDirectory), shellQuote(plugin)));
             }
 
             if (commitPinFailed)
@@ -829,8 +1013,15 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
 
             const auto env = getPluginBuildEnv();
 
+            if (m_bExperimentalCache && !preparePluginOutput(p.output)) {
+                progress.printMessageAbove(failureString("Refusing unsafe or unremovable cached output path for {}", p.name));
+                p.failed               = true;
+                anyPluginFailedToBuild = true;
+                continue;
+            }
+
             for (auto const& bs : p.buildSteps) {
-                const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && {} {}", m_szWorkingPluginDirectory, env, bs), HLVER);
+                const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && {} {}", shellQuote(m_szWorkingPluginDirectory), env, bs), HLVER);
 
                 if (!CMD_RAW) {
                     progress.printMessageAbove(failureString("Failed to build {}: {}", p.name, CMD_RAW.error()));
@@ -843,7 +1034,7 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
             if (m_bVerbose)
                 std::println("{}", verboseString("shell returned: {}", out));
 
-            if (!std::filesystem::exists(std::format("{}/{}", m_szWorkingPluginDirectory, p.output))) {
+            if (!pluginOutputPath(p.output)) {
                 std::println(stderr,
                              "\n{}\n"
                              "  This likely means that the plugin is either outdated, not yet available for your version, or broken.\n"
@@ -861,25 +1052,29 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
         // add repo toml to DataState
         SPluginRepository newrepo = repo;
         newrepo.plugins.clear();
-        execAndGet(std::format("cd {} && git pull --recurse-submodules && git reset --hard --recurse-submodules",
-                               m_szWorkingPluginDirectory)); // repo hash in the state.toml has to match head and not any pin
-        std::string repohash = execAndGet(std::format("cd {} && git rev-parse HEAD", m_szWorkingPluginDirectory));
-        if (!repohash.empty())
-            repohash.pop_back();
+        std::string repohash;
+        if (m_bExperimentalCache)
+            repohash = FETCHED_REPOSITORY_HASH;
+        else {
+            execAndGet(std::format("cd {} && git pull --recurse-submodules && git reset --hard --recurse-submodules",
+                                   shellQuote(m_szWorkingPluginDirectory))); // repo hash in the state.toml has to match head and not any pin
+            repohash = trim(execAndGet(std::format("cd {} && git rev-parse HEAD", shellQuote(m_szWorkingPluginDirectory))));
+        }
         // a build failure must not record the fetched hash: the next update would consider the
         // repo up-to-date and never retry the build. An empty hash never matches, so it retries.
         newrepo.hash = anyPluginFailedToBuild ? "" : repohash;
         for (auto const& p : pManifest->m_plugins) {
             const auto OLDPLUGINIT = std::ranges::find_if(repo.plugins, [&](const auto& other) { return other.name == p.name; });
+            const auto OUTPUT_PATH = p.failed ? std::nullopt : pluginOutputPath(p.output);
             newrepo.plugins.emplace_back(SPlugin{.name     = p.name,
-                                                 .filename = std::format("{}/{}", m_szWorkingPluginDirectory, p.output),
+                                                 .filename = OUTPUT_PATH ? OUTPUT_PATH->string() : "",
                                                  .enabled  = OLDPLUGINIT != repo.plugins.end() ? OLDPLUGINIT->enabled : false,
-                                                 .failed   = p.failed});
+                                                 .failed   = p.failed || !OUTPUT_PATH});
         }
         DataState::removePluginRepo(SPluginRepoIdentifier::fromName(newrepo.name));
         DataState::addNewPluginRepo(newrepo);
 
-        std::filesystem::remove_all(m_szWorkingPluginDirectory);
+        cleanWorkingPluginDirectory();
 
         if (anyPluginFailedToBuild) {
             failedRepos.emplace_back(repo.name);

--- a/hyprpm/src/core/PluginManager.hpp
+++ b/hyprpm/src/core/PluginManager.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <expected>
+#include <filesystem>
 #include "Plugin.hpp"
 
 enum eHeadersErrors {
@@ -47,6 +48,7 @@ struct SHyprlandVersion {
 class CPluginManager {
   public:
     CPluginManager();
+    ~CPluginManager();
 
     bool                   addNewPluginRepo(const std::string& url, const std::string& rev);
     bool                   removePluginRepo(const SPluginRepoIdentifier& identifier);
@@ -70,10 +72,12 @@ class CPluginManager {
     const std::string&     getPkgConfigPath();
 
     bool                   hasDeps();
+    bool                   acquireRepositoryCacheLock();
 
-    bool                   m_bVerbose   = false;
-    bool                   m_bNoShallow = false;
-    bool                   m_bNoNix     = false;
+    bool                   m_bVerbose           = false;
+    bool                   m_bNoShallow         = false;
+    bool                   m_bNoNix             = false;
+    bool                   m_bExperimentalCache = false;
     std::string            m_szCustomHlUrl, m_szUsername, m_szArgv0;
 
     // will delete recursively if exists!!
@@ -83,10 +87,16 @@ class CPluginManager {
     std::string                             headerError(const eHeadersErrors err);
     std::string                             headerErrorShort(const eHeadersErrors err);
     bool                                    validArg(const std::string& s);
+    bool                                    preparePluginRepository(const std::string& url);
+    bool                                    preparePluginOutput(const std::string& output);
+    std::optional<std::filesystem::path>    pluginOutputPath(const std::string& output);
+    void                                    cleanWorkingPluginDirectory();
+    std::string                             getPluginRepositoryPath(const std::string& url);
 
     std::expected<std::string, std::string> nixDevelopIfNeeded(const std::string& cmd, const SHyprlandVersion& ver);
 
     std::string                             m_szWorkingPluginDirectory;
+    int                                     m_iRepositoryCacheLockFD = -1;
 };
 
 inline std::unique_ptr<CPluginManager> g_pPluginManager;

--- a/hyprpm/src/core/RepositoryCache.cpp
+++ b/hyprpm/src/core/RepositoryCache.cpp
@@ -1,0 +1,70 @@
+#include "RepositoryCache.hpp"
+
+#include <bit>
+#include <system_error>
+#include <sys/stat.h>
+
+uint64_t NRepositoryCache::key(std::string_view url) {
+    uint64_t hash = 14695981039346656037ULL;
+
+    for (const auto c : url) {
+        hash ^= std::bit_cast<uint8_t>(c);
+        hash *= 1099511628211ULL;
+    }
+
+    return hash;
+}
+
+bool NRepositoryCache::secureDirectory(const std::filesystem::path& path, uid_t owner) {
+    struct stat statBuf;
+    if (lstat(path.c_str(), &statBuf) != 0)
+        return false;
+
+    return S_ISDIR(statBuf.st_mode) && statBuf.st_uid == owner && !(statBuf.st_mode & (S_IWGRP | S_IWOTH));
+}
+
+std::optional<std::filesystem::path> NRepositoryCache::resolvePathSlotWithin(const std::filesystem::path& root, const std::filesystem::path& candidate) {
+    if (candidate.empty() || candidate.is_absolute() || candidate.filename().empty())
+        return std::nullopt;
+
+    std::error_code ec;
+    const auto      CANONICAL_ROOT = std::filesystem::canonical(root, ec);
+    if (ec)
+        return std::nullopt;
+
+    const auto RESOLVED_PARENT = std::filesystem::weakly_canonical(CANONICAL_ROOT / candidate.parent_path(), ec);
+    if (ec)
+        return std::nullopt;
+
+    const auto RELATIVE_PARENT = RESOLVED_PARENT.lexically_relative(CANONICAL_ROOT);
+    if (RELATIVE_PARENT.is_absolute() || (!RELATIVE_PARENT.empty() && *RELATIVE_PARENT.begin() == ".."))
+        return std::nullopt;
+
+    const auto SLOT = (RESOLVED_PARENT / candidate.filename()).lexically_normal();
+    if (SLOT == CANONICAL_ROOT)
+        return std::nullopt;
+
+    return SLOT;
+}
+
+std::optional<std::filesystem::path> NRepositoryCache::resolvePathWithin(const std::filesystem::path& root, const std::filesystem::path& candidate) {
+    std::error_code ec;
+    const auto      CANONICAL_ROOT = std::filesystem::canonical(root, ec);
+    if (ec)
+        return std::nullopt;
+
+    const auto RESOLVED = std::filesystem::weakly_canonical(CANONICAL_ROOT / candidate, ec);
+    if (ec || RESOLVED == CANONICAL_ROOT)
+        return std::nullopt;
+
+    const auto RELATIVE = RESOLVED.lexically_relative(CANONICAL_ROOT);
+    if (RELATIVE.empty() || RELATIVE.is_absolute() || *RELATIVE.begin() == "..")
+        return std::nullopt;
+
+    return RESOLVED;
+}
+
+bool NRepositoryCache::regularFileOwnedBy(const std::filesystem::path& path, uid_t owner) {
+    struct stat statBuf;
+    return lstat(path.c_str(), &statBuf) == 0 && S_ISREG(statBuf.st_mode) && statBuf.st_uid == owner;
+}

--- a/hyprpm/src/core/RepositoryCache.hpp
+++ b/hyprpm/src/core/RepositoryCache.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <sys/types.h>
+
+namespace NRepositoryCache {
+    uint64_t                             key(std::string_view url);
+    bool                                 secureDirectory(const std::filesystem::path& path, uid_t owner);
+    std::optional<std::filesystem::path> resolvePathSlotWithin(const std::filesystem::path& root, const std::filesystem::path& candidate);
+    std::optional<std::filesystem::path> resolvePathWithin(const std::filesystem::path& root, const std::filesystem::path& candidate);
+    bool                                 regularFileOwnedBy(const std::filesystem::path& path, uid_t owner);
+}

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -4,8 +4,10 @@
 
 #include <pwd.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <sstream>
 #include <print>
+#include <format>
 #include <filesystem>
 #include <algorithm>
 #include <sstream>
@@ -161,6 +163,17 @@ bool NSys::root::install(const std::string& what, const std::string& where, cons
     CProcess proc(subin(), {"install", std::format("-m{}", mode), "-o", "0", "-g", "0", what, where});
 
     return proc.runSync() && proc.exitCode() == 0;
+}
+
+bool NSys::root::installFromFD(int fd, const std::string& where, const std::string& mode) {
+    if (fd < 0)
+        return false;
+
+    struct stat statBuf;
+    if (fstat(fd, &statBuf) != 0 || !S_ISREG(statBuf.st_mode))
+        return false;
+
+    return install(std::format("/proc/{}/fd/{}", getpid(), fd), where, mode);
 }
 
 std::string NSys::root::runAsSuperuserUnsafe(const std::string& cmd) {

--- a/hyprpm/src/helpers/Sys.hpp
+++ b/hyprpm/src/helpers/Sys.hpp
@@ -18,6 +18,7 @@ namespace NSys {
         [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool createDirectory(const std::string& path, const std::string& mode);
         [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool removeRecursive(const std::string& path);
         [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool install(const std::string& what, const std::string& where, const std::string& mode);
+        [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool installFromFD(int fd, const std::string& where, const std::string& mode);
 
         // Do not use this unless absolutely necessary!
         std::string runAsSuperuserUnsafe(const std::string& cmd);

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -21,7 +21,7 @@ constexpr std::string_view HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┣ update                        → Check and update all plugins if needed.
 ┣ reload                        → Reload hyprpm state. Ensure all enabled plugins are loaded.
 ┣ list                          → List all installed plugins.
-┣ purge-cache                   → Remove the entire hyprpm cache, built plugins, hyprpm settings and headers.
+┣ purge-cache                   → Remove built plugins, hyprpm settings, headers and cached repositories.
 ┃
 ┣ Flags:
 ┃
@@ -33,6 +33,7 @@ constexpr std::string_view HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┣ --force        | -f           → Force an operation ignoring checks (e.g. update -f).
 ┣ --no-shallow   | -s           → Disable shallow cloning of Hyprland sources.
 ┣ --hl-url       |              → Pass a custom hyprland source url.
+┣ --experimental-cache          → Persist plugin repositories and their build caches locally.
 ┗
 )#";
 
@@ -48,7 +49,7 @@ int                        main(int argc, char** argv, char** envp) {
     }
 
     std::vector<std::string> command;
-    bool                     notify = false, verbose = false, force = false, noShallow = false, noNix = false;
+    bool                     notify = false, verbose = false, force = false, noShallow = false, noNix = false, experimentalCache = false;
     std::string              customHlUrl;
 
     for (int i = 1; i < argc; ++i) {
@@ -68,6 +69,8 @@ int                        main(int argc, char** argv, char** envp) {
                 noNix = true;
             } else if (ARGS[i] == "--no-shallow" || ARGS[i] == "-s") {
                 noShallow = true;
+            } else if (ARGS[i] == "--experimental-cache") {
+                experimentalCache = true;
             } else if (ARGS[i] == "--hl-url") {
                 if (i + 1 >= argc) {
                     std::println(stderr, "Missing argument for --hl-url");
@@ -91,12 +94,16 @@ int                        main(int argc, char** argv, char** envp) {
         return 1;
     }
 
-    g_pPluginManager                  = std::make_unique<CPluginManager>();
-    g_pPluginManager->m_bVerbose      = verbose;
-    g_pPluginManager->m_bNoShallow    = noShallow;
-    g_pPluginManager->m_bNoNix        = noNix;
-    g_pPluginManager->m_szCustomHlUrl = customHlUrl;
-    g_pPluginManager->m_szArgv0       = argv[0];
+    g_pPluginManager                       = std::make_unique<CPluginManager>();
+    g_pPluginManager->m_bVerbose           = verbose;
+    g_pPluginManager->m_bNoShallow         = noShallow;
+    g_pPluginManager->m_bNoNix             = noNix;
+    g_pPluginManager->m_bExperimentalCache = experimentalCache;
+    g_pPluginManager->m_szCustomHlUrl      = customHlUrl;
+    g_pPluginManager->m_szArgv0            = argv[0];
+
+    if (experimentalCache && (command[0] == "add" || command[0] == "update") && !g_pPluginManager->acquireRepositoryCacheLock())
+        return 1;
 
     if (command[0] == "add") {
         if (command.size() < 2) {
@@ -223,6 +230,9 @@ int                        main(int argc, char** argv, char** envp) {
             g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");
         }
     } else if (command[0] == "purge-cache") {
+        if (!g_pPluginManager->acquireRepositoryCacheLock())
+            return 1;
+
         NSys::root::cacheSudo();
         CScopeGuard x([] { NSys::root::dropSudo(); });
         DataState::purgeAllCache();

--- a/hyprpm/tests/RepositoryCache.cpp
+++ b/hyprpm/tests/RepositoryCache.cpp
@@ -1,0 +1,92 @@
+#include "../src/core/RepositoryCache.hpp"
+
+#include <fstream>
+#include <format>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+class CRepositoryCacheTest : public testing::Test {
+  protected:
+    void SetUp() override {
+        auto path = (std::filesystem::temp_directory_path() / "hyprpm-cache-test-XXXXXX").string();
+        ASSERT_NE(mkdtemp(path.data()), nullptr);
+        m_root = path;
+        std::filesystem::create_directories(m_root / "build");
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(m_root, ec);
+    }
+
+    std::filesystem::path m_root;
+};
+
+TEST(RepositoryCache, keyIsStableAndUrlSpecific) {
+    EXPECT_EQ(NRepositoryCache::key("https://example.com/plugin.git"), 0x08684eeac71708a9ULL);
+    EXPECT_NE(NRepositoryCache::key("https://example.com/plugin.git"), NRepositoryCache::key("https://example.com/other.git"));
+}
+
+TEST_F(CRepositoryCacheTest, secureDirectoryRejectsUnsafeModesAndOwners) {
+    ASSERT_EQ(chmod(m_root.c_str(), S_IRWXU), 0);
+    EXPECT_TRUE(NRepositoryCache::secureDirectory(m_root, getuid()));
+    EXPECT_FALSE(NRepositoryCache::secureDirectory(m_root, getuid() + 1));
+
+    ASSERT_EQ(chmod(m_root.c_str(), S_IRWXU | S_IWGRP), 0);
+    EXPECT_FALSE(NRepositoryCache::secureDirectory(m_root, getuid()));
+}
+
+TEST_F(CRepositoryCacheTest, resolvePathWithinAcceptsNestedOutput) {
+    const auto OUTPUT = NRepositoryCache::resolvePathWithin(m_root, "build/plugin.so");
+    ASSERT_TRUE(OUTPUT.has_value());
+    EXPECT_EQ(*OUTPUT, m_root / "build/plugin.so");
+}
+
+TEST_F(CRepositoryCacheTest, resolvePathWithinRejectsTraversalAndAbsolutePaths) {
+    EXPECT_FALSE(NRepositoryCache::resolvePathWithin(m_root, "../plugin.so").has_value());
+    EXPECT_FALSE(NRepositoryCache::resolvePathWithin(m_root, m_root.parent_path() / "plugin.so").has_value());
+    EXPECT_FALSE(NRepositoryCache::resolvePathWithin(m_root, ".").has_value());
+}
+
+TEST_F(CRepositoryCacheTest, resolvePathWithinAllowsInTreeSymlinks) {
+    std::ofstream{m_root / "build/plugin-real.so"} << "plugin";
+    std::filesystem::create_symlink("plugin-real.so", m_root / "build/plugin.so");
+
+    const auto OUTPUT = NRepositoryCache::resolvePathWithin(m_root, "build/plugin.so");
+    ASSERT_TRUE(OUTPUT.has_value());
+    EXPECT_EQ(*OUTPUT, m_root / "build/plugin-real.so");
+    EXPECT_TRUE(NRepositoryCache::regularFileOwnedBy(*OUTPUT, getuid()));
+}
+
+TEST_F(CRepositoryCacheTest, resolvePathSlotWithinKeepsFinalSymlink) {
+    std::ofstream{m_root / "build/plugin-real.so"} << "plugin";
+    std::filesystem::create_symlink("plugin-real.so", m_root / "build/plugin.so");
+
+    const auto OUTPUT = NRepositoryCache::resolvePathSlotWithin(m_root, "build/plugin.so");
+    ASSERT_TRUE(OUTPUT.has_value());
+    EXPECT_EQ(*OUTPUT, m_root / "build/plugin.so");
+    EXPECT_TRUE(std::filesystem::is_symlink(std::filesystem::symlink_status(*OUTPUT)));
+}
+
+TEST_F(CRepositoryCacheTest, resolvePathWithinRejectsOutsideSymlinks) {
+    const auto OUTSIDE = m_root.parent_path() / std::format("{}-outside.so", m_root.filename().string());
+    std::ofstream{OUTSIDE} << "plugin";
+    std::filesystem::create_symlink(OUTSIDE, m_root / "build/plugin.so");
+
+    EXPECT_FALSE(NRepositoryCache::resolvePathWithin(m_root, "build/plugin.so").has_value());
+
+    std::error_code ec;
+    std::filesystem::remove(OUTSIDE, ec);
+}
+
+TEST_F(CRepositoryCacheTest, resolvePathSlotWithinRejectsOutsideParentSymlinks) {
+    const auto OUTSIDE = m_root.parent_path() / std::format("{}-outside", m_root.filename().string());
+    std::filesystem::create_directory(OUTSIDE);
+    std::filesystem::create_directory_symlink(OUTSIDE, m_root / "outside");
+
+    EXPECT_FALSE(NRepositoryCache::resolvePathSlotWithin(m_root, "outside/plugin.so").has_value());
+
+    std::error_code ec;
+    std::filesystem::remove_all(OUTSIDE, ec);
+}


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This adds an opt-in `--experimental-cache` mode to hyprpm `add` and `update`.

Without the flag, hyprpm keeps its existing temporary clone/build/delete behavior. With the flag, plugin repositories live under `$XDG_CACHE_HOME/hyprpm/repos` (falling back to `~/.cache/hyprpm/repos`), so subsequent updates can reuse CMake/Ninja build output instead of cloning and configuring every repository from scratch.

The cached checkout is fetched and hard-reset to `origin/HEAD`, while untracked build directories are retained. `purge-cache` also removes the persistent repositories.

Because persistence makes filesystem state longer-lived, this also adds:

- a non-blocking per-user cache lock for add/update/purge serialization;
- user ownership and mode checks for cache directories and lock files;
- quoted command arguments and checked command exit codes;
- manifest output containment checks, including safe in-tree symlink support;
- FD-based root installation to avoid pathname replacement races;
- anonymous temporary state writes, with `memfd_create` fallback when `O_TMPFILE` is unavailable;
- bash, fish, and zsh completion entries plus CLI usage text;
- focused unit coverage for cache keys, ownership/modes, traversal, and symlink boundaries.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The behavior is experimental and disabled by default. This is a CLI flag rather than a Hyprland config option, so there is no config compatibility change or wiki option to migrate.

Checks run:

- `cmake --build ... --target tests -j2`
- `ctest --output-on-failure -j2` — 334/334 passed
- separate Release configure/build of the `hyprpm` target
- `clang-format --dry-run --Werror` on all changed C++ files
- `git diff --check`
- `bash -n` and `zsh -n` on completions (`fish` is not installed locally; its completion was reviewed statically)
- CLI help and invalid-option handling
- isolated Git fetch/reset test confirming that the checkout advances while an untracked build marker remains

I did not rerun a real authenticated plugin update for this final revision because it requires an interactive privilege prompt; the deterministic repository/cache behavior and full test suite above were run against the final source.

#### Is it ready for merging, or does it need work?

The implementation and tests are complete. The PR is opened as a draft for maintainer feedback on the experimental interface and cache policy.
