### PR TITLE
cmakelists: omit -Wno-clobbered flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ add_compile_options(
   -Wno-missing-field-initializers
   -Wno-narrowing
   -Wno-pointer-arith
-  -Wno-clobbered
   -frtti
   -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Removes the -Wno-clobbered flag from CMakeLists.txt as it's no longer needed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I falsely presumed you would reply to [my](https://github.com/hyprwm/.github/discussions/26) post with an indication of whether you wanted to obliterate the flag entirely or have the conditional snippet; this is a very menial issue, so it's no biggie, I will just remove the flag (feel free 2 edit as u please). Presumably the code in question wthat was causing the warnings is gone now, and plus even if there are warnings I don't think that should cause a build failure (that's -Werror's job!). Good day Ɛ>

#### Is it ready for merging, or does it need work?
Good to go. I think.

