### PR TITLE
lua(window): make `stable_id` field a string

### DIFF
--- a/src/config/lua/objects/LuaWindow.cpp
+++ b/src/config/lua/objects/LuaWindow.cpp
@@ -167,7 +167,7 @@ static int windowIndex(lua_State* L) {
     } else if (key == "content_type")
         lua_pushstring(L, NContentType::toString(w->getContentType()).c_str());
     else if (key == "stable_id")
-        lua_pushinteger(L, sc<lua_Integer>(w->m_stableID));
+        lua_pushstring(L, std::format("{:x}", w->m_stableID).c_str());
     else if (key == "layout") {
         const auto target = w->layoutTarget();
         if (!target || target->floating() || !w->m_workspace || !w->m_workspace->m_space) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Makes window objects' `stable_id` field a hex string (it was a decimal number before). That's literally it.

This matches the format shown by `hyprctl activewindow/clients`, and the format that the `stableid:` window selector wants. Without that, users would have to e.g.
```lua
local stable_id = string.format("%x", hl.get_active_window().stable_id)
hl.dsp.whatever({ window = "stableid:"..stable_id })
```
Which is just unnecessary.

Also, the Wayland protocol that stable_id exists for, passes it as a string too.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nerp

#### Is it ready for merging, or does it need work?

Ready
