### PR TITLE
monitor: properly un-orphan workspaces to fallback output

### DIFF
--- a/hyprtester/src/tests/main/state.cpp
+++ b/hyprtester/src/tests/main/state.cpp
@@ -9,6 +9,10 @@
 TEST_CASE(state) {
     NLog::log("{}Testing Fallback State", Colors::YELLOW);
 
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-2' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '9' })"));
+    SPAWN_KITTY("fallback-workspace-a");
+
     OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-1', disabled = true })"));
     OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', disabled = true })"));
     OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-3', disabled = true })"));
@@ -31,5 +35,15 @@ TEST_CASE(state) {
         ASSERT_CONTAINS(str, "FALLBACK");
     }
 
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9 (9) on monitor FALLBACK:");
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '9' })"));
+    SPAWN_KITTY("fallback-workspace-b");
+
     OK(getFromSocket("/reload"));
+    Tests::sync();
+
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9 (9) on monitor HEADLESS-2:");
+
+    Tests::killAllWindows();
 }

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -326,6 +326,8 @@ void CMonitor::onConnect(bool noRule) {
     if (!isMirror())
         setupDefaultWS(monitorRule);
 
+    const auto REAL_MONITOR_COUNT = std::ranges::count_if(State::monitorState()->monitors(), [](const auto& mon) { return !mon->m_isUnsafeFallback; });
+
     for (auto const& ws : State::workspaceState()->workspacesCopy()) {
         if (!valid(ws))
             continue;
@@ -333,8 +335,7 @@ void CMonitor::onConnect(bool noRule) {
         const auto CURRENTMON = ws->m_monitor.lock();
         const bool ORPHANED   = !CURRENTMON || std::ranges::none_of(State::monitorState()->monitors(), [&](const auto& mon) { return mon == CURRENTMON; });
         const bool RETURNING  = ws->m_lastMonitor == m_name;
-        const bool RECOVERY   = ORPHANED &&
-            std::ranges::count_if(State::monitorState()->monitors(), [](const auto& mon) { return !mon->m_isUnsafeFallback; }) == 1; // temporarily recover orphaned workspaces
+        const bool RECOVERY   = ORPHANED && (m_isUnsafeFallback || REAL_MONITOR_COUNT == 1); // temporarily recover orphaned workspaces
 
         if (RETURNING || RECOVERY) {
             State::workspacePlacementController()->moveWorkspaceToMonitor(ws, m_self.lock());
@@ -475,9 +476,9 @@ void CMonitor::onDisconnect(bool destroy) {
     }
 
     // Preserve ownership across cascaded monitor disconnects.
-    // The first disconnected monitor "owns" where a workspace should return.
+    // The first disconnected real monitor "owns" where a workspace should return.
     for (auto const& w : wspToMove) {
-        if (w && w->m_lastMonitor.empty())
+        if (!m_isUnsafeFallback && w && w->m_lastMonitor.empty())
             w->m_lastMonitor = m_name;
     }
 


### PR DESCRIPTION
fixes #15800 hopefully another burrito can verify

codex found the bug and wrote tests

