### PR TITLE
layout/scrolling: defer click-triggered view movement to button release

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -637,6 +637,12 @@ CScrollingAlgorithm::CScrollingAlgorithm() : m_scrollingFullscreenHandler(makeUn
         if (!pWindow)
             return;
 
+        // Defer click-triggered view movement to button release (see m_mouseButtonCallback):
+        // moving the view while the button is still held slides the window under the cursor
+        // and the app receives pointer-motion mid-press, which it interprets as a drag.
+        if (reason == Desktop::FOCUS_REASON_CLICK)
+            return;
+
         static const auto PFOLLOW_FOCUS = CConfigValue<Config::INTEGER>("scrolling:follow_focus");
 
         if (!*PFOLLOW_FOCUS && !Desktop::isHardInputFocusReason(reason))


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Clicking a window that is not fully in view in the scrolling layout moved
the view while the button was still held. The window slides under the cursor
mid-press, so the app receives pointer motion during the press and treats
the click as a drag (text selection, file drag, ...). With
`input:follow_mouse = 2` this happens on every click, with `1` it happens
occasionally (fast clicks, follow_mouse_threshold misses).

The view move now happens on button release instead of on focus: clicks are
skipped in the focus callback, and the existing release-time callback (added
for #13351) performs the same focusOnInput call after the button is up, where
the motion is harmless. The clicked window still ends up in view, just one
beat later. Side effect: starting a real drag (text selection, DnD) from a
side window no longer yanks the view under the cursor mid-drag.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
One behavior change: with `scrolling:follow_focus = 0`, clicking a side
window no longer moves the view at all (before it moved on press, since a
click is a hard input reason). I believe this matches the intent of the
option - in #13351 users expected follow_focus=0 to mean mouse input has no
impact on the layout.

Tested on v0.56.2 with this change, scrolling layout:
- click on a side window: clean click, no selection made in the app (checked
  via kitty's primary selection before/after), window slides in after release
- keyboard movefocus and wheel over unfocused windows: unchanged
- follow_mouse 1 and 2, follow_focus on and off: all as above

Related to #13351 and #13558.

The patch was drafted with AI assistance (I used it to walk through the
layout code); I reviewed the diff and tested each of the cases above myself.

First PR here, would appreciate a vouch.