### PR TITLE
overview: add overview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ pkg_check_modules(udis_dep IMPORTED_TARGET udis86>=1.7.2)
 # Find non-pkgconfig udis86, otherwise fallback to subproject
 if(NOT udis_dep_FOUND)
   find_library(udis_nopc udis86)
-  if(NOT("${udis_nopc}" MATCHES "udis_nopc-NOTFOUND"))
+  if(NOT("${udis_nopc}"  "udis_nopc-NOTFOUND"))
     message(STATUS "Found udis86 at ${udis_nopc}")
   else()
     add_subdirectory("subprojects/udis86")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,12 @@ pkg_check_modules(hyprlang_dep REQUIRED IMPORTED_TARGET hyprlang>=${HYPRLANG_MIN
 pkg_check_modules(hyprcursor_dep REQUIRED IMPORTED_TARGET hyprcursor>=${HYPRCURSOR_MINIMUM_VERSION})
 pkg_check_modules(hyprutils_dep REQUIRED IMPORTED_TARGET hyprutils>=${HYPRUTILS_MINIMUM_VERSION})
 pkg_check_modules(hyprgraphics_dep REQUIRED IMPORTED_TARGET hyprgraphics>=${HYPRGRAPHICS_MINIMUM_VERSION})
+pkg_check_modules(hyprtoolkit_dep REQUIRED IMPORTED_TARGET hyprtoolkit)
+
+find_path(HYPRTOOLKIT_EMBEDDED_BACKEND_INCLUDE_DIR "hyprtoolkit/core/EmbeddedBackend.hpp" PATHS ${hyprtoolkit_dep_INCLUDE_DIRS} NO_DEFAULT_PATH)
+if(NOT HYPRTOOLKIT_EMBEDDED_BACKEND_INCLUDE_DIR)
+  message(FATAL_ERROR "hyprtoolkit does not provide the embedded surface API")
+endif()
 
 string(REPLACE "." ";" AQ_VERSION_LIST ${aquamarine_dep_VERSION})
 list(GET AQ_VERSION_LIST 0 AQ_VERSION_MAJOR)
@@ -452,6 +458,7 @@ target_link_libraries(
   PkgConfig::hyprutils_dep
   PkgConfig::hyprcursor_dep
   PkgConfig::hyprgraphics_dep
+  PkgConfig::hyprtoolkit_dep
   PkgConfig::deps
   PkgConfig::LUA
 )

--- a/flake.lock
+++ b/flake.lock
@@ -108,7 +108,9 @@
         "hyprlang": [
           "hyprlang"
         ],
-        "hyprtoolkit": "hyprtoolkit",
+        "hyprtoolkit": [
+          "hyprtoolkit"
+        ],
         "hyprutils": [
           "hyprutils"
         ],
@@ -188,45 +190,39 @@
     "hyprtoolkit": {
       "inputs": {
         "aquamarine": [
-          "hyprland-guiutils",
           "aquamarine"
         ],
         "hyprgraphics": [
-          "hyprland-guiutils",
           "hyprgraphics"
         ],
         "hyprlang": [
-          "hyprland-guiutils",
           "hyprlang"
         ],
         "hyprutils": [
-          "hyprland-guiutils",
           "hyprutils"
         ],
         "hyprwayland-scanner": [
-          "hyprland-guiutils",
           "hyprwayland-scanner"
         ],
         "nixpkgs": [
-          "hyprland-guiutils",
           "nixpkgs"
         ],
         "systems": [
-          "hyprland-guiutils",
           "systems"
         ]
       },
       "locked": {
-        "lastModified": 1785930473,
-        "narHash": "sha256-DitTu625BhEYpZjtjxtGpjrEJwPwW+X/+jJvhSZNSJM=",
+        "lastModified": 1786377817,
+        "narHash": "sha256-YDGxUL6Lt6ORijQIhTiTaP7I/qMricD3JtqAz8l/8Ds=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "af515b69dfbe366dc7873aa1475cb2f4db3ebad7",
+        "rev": "aac6072eb3cc95e40a658ceae8b09460726f2fb9",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
+        "rev": "aac6072eb3cc95e40a658ceae8b09460726f2fb9",
         "type": "github"
       }
     },
@@ -347,6 +343,7 @@
         "hyprland-guiutils": "hyprland-guiutils",
         "hyprland-protocols": "hyprland-protocols",
         "hyprlang": "hyprlang",
+        "hyprtoolkit": "hyprtoolkit",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
         "hyprwire": "hyprwire",

--- a/flake.lock
+++ b/flake.lock
@@ -212,17 +212,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1786377817,
-        "narHash": "sha256-YDGxUL6Lt6ORijQIhTiTaP7I/qMricD3JtqAz8l/8Ds=",
+        "lastModified": 1787154144,
+        "narHash": "sha256-S3RGvs8jkayNAMC+Byjd0lc9rKiVA/18NP0wtRh1Gfs=",
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "aac6072eb3cc95e40a658ceae8b09460726f2fb9",
+        "rev": "e5373a8543888f5505854fd2c2955db06e12668c",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprtoolkit",
-        "rev": "aac6072eb3cc95e40a658ceae8b09460726f2fb9",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
     };
 
     hyprtoolkit = {
-      url = "github:hyprwm/hyprtoolkit/aac6072eb3cc95e40a658ceae8b09460726f2fb9";
+      url = "github:hyprwm/hyprtoolkit";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
       inputs.aquamarine.follows = "aquamarine";

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,18 @@
       inputs.hyprutils.follows = "hyprutils";
       inputs.hyprlang.follows = "hyprlang";
       inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
+      inputs.hyprtoolkit.follows = "hyprtoolkit";
+    };
+
+    hyprtoolkit = {
+      url = "github:hyprwm/hyprtoolkit/aac6072eb3cc95e40a658ceae8b09460726f2fb9";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.systems.follows = "systems";
+      inputs.aquamarine.follows = "aquamarine";
+      inputs.hyprgraphics.follows = "hyprgraphics";
+      inputs.hyprlang.follows = "hyprlang";
+      inputs.hyprutils.follows = "hyprutils";
+      inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
     };
 
     hyprlang = {

--- a/hyprtester/src/tests/main/animations.cpp
+++ b/hyprtester/src/tests/main/animations.cpp
@@ -10,4 +10,8 @@ TEST_CASE(animationsTrivial) {
     auto str = getFromSocket("/animations");
     NLog::yellow("Testing bezier curve output from `hyprctl animations`");
     ASSERT_CONTAINS(str, std::format("beziers:\n\n\tname: quick\n\t\tX0: 0.15\n\t\tY0: 0.00\n\t\tX1: 0.10\n\t\tY1: 1.00"));
+    ASSERT_CONTAINS(str, "name: overviewIn");
+    ASSERT_CONTAINS(str, "name: overviewOut");
+    ASSERT_CONTAINS(str, "name: overviewMove");
+    ASSERT_CONTAINS(str, "name: overviewFade");
 }

--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -832,6 +832,37 @@ TEST_CASE(keybinds) {
     CALL_SUBTEST(unbind);
 }
 
+TEST_CASE(overviewKeyboardRouting) {
+    clearFlag();
+
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'name:y', persistent = true }); "
+                     "hl.workspace_rule({ workspace = 'name:overview-source', persistent = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:y' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:overview-source' })"));
+
+    EXPECT(getFromSocket(std::format("/eval hl.bind('Y', hl.dsp.exec_cmd('touch {}'))", flagFile)), "ok");
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    OK(getFromSocket(pluginKeybindCmd(true, 0, 29)));
+    OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
+    EXPECT(attemptCheckFlag(20, 50), true);
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    EXPECT(getFromSocket(std::format("/eval hl.bind('Y', hl.dsp.exec_cmd('touch {}'), {{ non_consuming = true }})", flagFile)), "ok");
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    OK(getFromSocket(pluginKeybindCmd(true, 0, 29)));
+    OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
+    EXPECT(attemptCheckFlag(20, 50), true);
+    OK(getFromSocket(pluginKeybindCmd(true, 0, 36)));
+    OK(getFromSocket(pluginKeybindCmd(false, 0, 36)));
+    EXPECT_CONTAINS(getFromSocket("/activeworkspace"), "(y)");
+    EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:overview-source' })"));
+}
+
 TEST_CASE(unorderedSubChordDeferral) {
     constexpr uint32_t X = KEY_X + 8;
     constexpr uint32_t D = KEY_D + 8;

--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -959,6 +959,58 @@ TEST_CASE(overviewCreatesTrailingNumericWorkspace) {
     ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "workspace ID 9302 (9302)");
 }
 
+TEST_CASE(overviewLuaApi) {
+    Hyprutils::Utils::CScopeGuard cleanup = {[&] {
+        getFromSocket("/dispatch hl.dsp.overview.toggle({ action = 'disable' })");
+        getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })");
+        getFromSocket("/reload");
+    }};
+
+    const auto                    pressKey = [](uint32_t key) {
+        const bool PRESSED  = getFromSocket(pluginKeybindCmd(true, 0, key)) == "ok";
+        const bool RELEASED = getFromSocket(pluginKeybindCmd(false, 0, key)) == "ok";
+        return PRESSED && RELEASED;
+    };
+
+    OK(getFromSocket("/eval hl.config({ overview = { only_current_monitor = true } }); "
+                     "hl.workspace_rule({ workspace = 'name:overview-api-alpha', persistent = true }); "
+                     "hl.workspace_rule({ workspace = 'name:overview-api-beta', persistent = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:overview-api-alpha' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:overview-api-beta' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle({ query = 'overview-api' })"));
+    OK(getFromSocket("/eval local overview = hl.get_overview(); "
+                     "assert(overview.open); "
+                     "assert(overview.monitor == hl.get_active_monitor()); "
+                     "assert(overview.workspace.name == 'overview-api-beta'); "
+                     "assert(overview.query == 'overview-api')"));
+
+    ASSERT(pressKey(KEY_LEFT + 8), true);
+    OK(getFromSocket("/eval local overview = hl.get_overview(); "
+                     "assert(overview.workspace.name == 'overview-api-alpha'); "
+                     "assert(overview.query == 'overview-api')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.move_right()"));
+    OK(getFromSocket("/eval assert(hl.get_overview().workspace.name == 'overview-api-beta')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle({ action = 'disable' })"));
+    OK(getFromSocket("/eval local overview = hl.get_overview(); "
+                     "assert(not overview.open); "
+                     "assert(overview.monitor == nil); "
+                     "assert(overview.workspace == nil); "
+                     "assert(overview.query == '')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle({ action = 'enable', query = 'overview-api-alpha' })"));
+    OK(getFromSocket("/eval local overview = hl.get_overview(); "
+                     "assert(overview.open); "
+                     "assert(overview.workspace.name == 'overview-api-alpha'); "
+                     "assert(overview.query == 'overview-api-alpha')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle({ action = 'disable' })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "(overview-api-alpha)");
+}
+
 TEST_CASE(overviewDragCreatesOneTrailingNumericWorkspace) {
     Hyprutils::Utils::CScopeGuard cleanup = {[&] {
         getFromSocket(pluginClickCmd(false, BTN_LEFT));

--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -1,6 +1,7 @@
 #include <filesystem>
 #include <linux/input-event-codes.h>
 #include <format>
+#include <hyprutils/utils/ScopeGuard.hpp>
 #include <thread>
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
@@ -861,6 +862,196 @@ TEST_CASE(overviewKeyboardRouting) {
     EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:overview-source' })"));
+}
+
+TEST_CASE(overviewCreatesTrailingNumericWorkspace) {
+    Hyprutils::Utils::CScopeGuard cleanup = {[&] {
+        getFromSocket("/dispatch hl.dsp.overview.toggle({ action = 'disable' })");
+        getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })");
+        Tests::killAllWindows();
+        getFromSocket("/output remove HEADLESS-3");
+        getFromSocket("/reload");
+    }};
+
+    const auto                    pressKey = [](uint32_t key) {
+        const bool PRESSED  = getFromSocket(pluginKeybindCmd(true, 0, key)) == "ok";
+        const bool RELEASED = getFromSocket(pluginKeybindCmd(false, 0, key)) == "ok";
+        return PRESSED && RELEASED;
+    };
+    const auto         workspaceCount = [] { return Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID "); };
+
+    constexpr uint32_t LEFT  = KEY_LEFT + 8;
+    constexpr uint32_t RIGHT = KEY_RIGHT + 8;
+    constexpr uint32_t ENTER = KEY_ENTER + 8;
+
+    OK(getFromSocket("/eval hl.config({ overview = { only_current_monitor = true } })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '9000' })"));
+    SPAWN_KITTY("overview-new-workspace");
+    Tests::sync();
+
+    const int BEFORE_CREATE = workspaceCount();
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    ASSERT(pressKey(RIGHT), true);
+    Tests::sync();
+
+    ASSERT(workspaceCount(), BEFORE_CREATE + 1);
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9001 (9001)");
+
+    ASSERT(pressKey(LEFT), true);
+    Tests::sync();
+
+    ASSERT(workspaceCount(), BEFORE_CREATE);
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9001 (9001)");
+
+    ASSERT(pressKey(RIGHT), true);
+    Tests::sync();
+
+    ASSERT(workspaceCount(), BEFORE_CREATE + 1);
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9001 (9001)");
+
+    ASSERT(pressKey(ENTER), true);
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "workspace ID 9001 (9001)");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    const int BEFORE_EMPTY = workspaceCount();
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    ASSERT(pressKey(RIGHT), true);
+    Tests::sync();
+
+    ASSERT(workspaceCount(), BEFORE_EMPTY);
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9002 (9002)");
+
+    ASSERT(pressKey(ENTER), true);
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "workspace ID 9001 (9001)");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:overview-new-workspace-named' })"));
+    SPAWN_KITTY("overview-new-workspace-named");
+    Tests::sync();
+
+    const int BEFORE_NAMED = workspaceCount();
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    ASSERT(pressKey(RIGHT), true);
+    Tests::sync();
+
+    ASSERT(workspaceCount(), BEFORE_NAMED);
+    ASSERT(pressKey(ENTER), true);
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "(overview-new-workspace-named)");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    Tests::killAllWindows();
+    OK(getFromSocket("/output create headless HEADLESS-3"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = '9301', monitor = 'HEADLESS-3' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '9300' })"));
+    SPAWN_KITTY("overview-skip-bound-workspace");
+    Tests::sync();
+
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    ASSERT(pressKey(RIGHT), true);
+    Tests::sync();
+
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9302 (9302)");
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9301 (9301)");
+    ASSERT(pressKey(ENTER), true);
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "workspace ID 9302 (9302)");
+}
+
+TEST_CASE(overviewDragCreatesOneTrailingNumericWorkspace) {
+    Hyprutils::Utils::CScopeGuard cleanup = {[&] {
+        getFromSocket(pluginClickCmd(false, BTN_LEFT));
+        getFromSocket(pluginKeybindMaskCmd(false, {}, KEY_Y + 8));
+        getFromSocket("/dispatch hl.dsp.overview.toggle({ action = 'disable' })");
+        getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })");
+        Tests::killAllWindows();
+        getFromSocket("/reload");
+    }};
+
+    OK(getFromSocket("/eval hl.config({ overview = { only_current_monitor = true }, binds = { drag_threshold = 0 } })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '9100' })"));
+    SPAWN_KITTY("overview-edge-drag");
+    Tests::sync();
+
+    const int BEFORE_CREATE = Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID ");
+
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 960, y = 540 })"));
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    OK(getFromSocket(pluginKeybindMaskCmd(true, {MOD_META}, KEY_Y + 8)));
+    OK(getFromSocket(pluginClickCmd(true, BTN_LEFT)));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 1900, y = 540 })"));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    Tests::sync();
+
+    ASSERT(Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID "), BEFORE_CREATE + 1);
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9101 (9101)");
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9102 (9102)");
+
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 20, y = 540 })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 960, y = 540 })"));
+    Tests::sync();
+
+    ASSERT(Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID "), BEFORE_CREATE);
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9101 (9101)");
+
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 1900, y = 540 })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 960, y = 540 })"));
+    Tests::sync();
+
+    ASSERT(Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID "), BEFORE_CREATE);
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9101 (9101)");
+
+    OK(getFromSocket(pluginClickCmd(false, BTN_LEFT)));
+    OK(getFromSocket(pluginKeybindMaskCmd(false, {}, KEY_Y + 8)));
+
+    OK(getFromSocket(pluginKeybindMaskCmd(true, {MOD_META}, KEY_Y + 8)));
+    OK(getFromSocket(pluginClickCmd(true, BTN_LEFT)));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 1900, y = 540 })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    Tests::sync();
+
+    ASSERT(Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID "), BEFORE_CREATE + 1);
+    ASSERT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9101 (9101)");
+
+    OK(getFromSocket(pluginClickCmd(false, BTN_LEFT)));
+    OK(getFromSocket(pluginKeybindMaskCmd(false, {}, KEY_Y + 8)));
+    OK(getFromSocket(pluginKeybindCmd(true, 0, KEY_ENTER + 8)));
+    OK(getFromSocket(pluginKeybindCmd(false, 0, KEY_ENTER + 8)));
+
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "workspace ID 9101 (9101)");
+    ASSERT_CONTAINS(getFromSocket("/activewindow"), "workspace: 9101 (9101)");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '9200' })"));
+    SPAWN_KITTY("overview-filtered-edge-drag");
+    Tests::sync();
+
+    const int BEFORE_FILTERED_DRAG = Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID ");
+
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 960, y = 540 })"));
+    OK(getFromSocket("/dispatch hl.dsp.overview.toggle()"));
+    for (const auto KEY : {KEY_9, KEY_2, KEY_0, KEY_0}) {
+        OK(getFromSocket(pluginKeybindCmd(true, 0, KEY + 8)));
+        OK(getFromSocket(pluginKeybindCmd(false, 0, KEY + 8)));
+    }
+    OK(getFromSocket(pluginKeybindMaskCmd(true, {MOD_META}, KEY_Y + 8)));
+    OK(getFromSocket(pluginClickCmd(true, BTN_LEFT)));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 1900, y = 540 })"));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    Tests::sync();
+
+    ASSERT(Tests::countOccurrences(getFromSocket("/workspaces"), "workspace ID "), BEFORE_FILTERED_DRAG);
+    ASSERT_NOT_CONTAINS(getFromSocket("/workspaces"), "workspace ID 9201 (9201)");
+
+    OK(getFromSocket(pluginClickCmd(false, BTN_LEFT)));
+    OK(getFromSocket(pluginKeybindMaskCmd(false, {}, KEY_Y + 8)));
+    OK(getFromSocket(pluginKeybindCmd(true, 0, KEY_ENTER + 8)));
+    OK(getFromSocket(pluginKeybindCmd(false, 0, KEY_ENTER + 8)));
 }
 
 TEST_CASE(unorderedSubChordDeferral) {

--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -552,6 +552,10 @@ def generate_stub(root: Path) -> str:
         "hl.get_last_window": "fun(): HL.Window|nil",
         "hl.get_last_workspace": "fun(monitor?: HL.MonitorSelector): HL.Workspace|nil",
         "hl.get_current_submap": "fun(): string",
+        "hl.get_overview": "fun(): HL.OverviewState",
+        "hl.dsp.overview.toggle": "fun(options?: HL.OverviewToggleOptions): HL.Dispatcher",
+        "hl.dsp.overview.move_left": "fun(): HL.Dispatcher",
+        "hl.dsp.overview.move_right": "fun(): HL.Dispatcher",
         "hl.notification.create": "fun(opts?: HL.NotificationOptions): HL.Notification",
         "hl.notification.get": "fun(): HL.Notification[]",
         "hl.layout.register": "fun(name: string, provider: HL.LayoutProvider): nil",
@@ -695,6 +699,30 @@ def generate_stub(root: Path) -> str:
             "HL.GetMonitorsOptions",
             [
                 ("all", "boolean", True),
+            ],
+        )
+    )
+    lines.append("")
+
+    lines.extend(
+        emit_class_block(
+            "HL.OverviewState",
+            [
+                ("open", "boolean", False),
+                ("monitor", "HL.Monitor|nil", False),
+                ("workspace", "HL.Workspace|nil", False),
+                ("query", "string", False),
+            ],
+        )
+    )
+    lines.append("")
+
+    lines.extend(
+        emit_class_block(
+            "HL.OverviewToggleOptions",
+            [
+                ("action", '"toggle"|"enable"|"disable"|"on"|"off"', True),
+                ("query", "string", True),
             ],
         )
     )

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,6 +18,7 @@
   hyprgraphics,
   hyprland-protocols,
   hyprland-guiutils,
+  hyprtoolkit,
   hyprlang,
   hyprutils,
   hyprwayland-scanner,
@@ -129,7 +130,7 @@ customStdenv.mkDerivation (finalAttrs: {
             ../systemd
             ../VERSION
             (fs.fileFilter (file: file.hasExt "1") ../docs)
-            (fs.fileFilter (file: file.hasExt "conf" || file.hasExt "in" || file.hasExt "lua" ) ../example)
+            (fs.fileFilter (file: file.hasExt "conf" || file.hasExt "in" || file.hasExt "lua") ../example)
             (fs.fileFilter (file: file.hasExt "sh") ../scripts)
             (fs.fileFilter (file: file.name == "CMakeLists.txt") ../.)
             (optional withTests [
@@ -187,6 +188,7 @@ customStdenv.mkDerivation (finalAttrs: {
       hyprcursor
       hyprgraphics
       hyprland-protocols
+      hyprtoolkit
       hyprlang
       hyprutils
       hyprwire

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -32,6 +32,10 @@ in
     inputs.hyprgraphics.overlays.default
     inputs.hyprland-protocols.overlays.default
     inputs.hyprland-guiutils.overlays.default
+    inputs.hyprtoolkit.overlays.default
+    (final: prev: {
+      hyprtoolkit = prev.hyprtoolkit.override { stdenv = final.gcc16Stdenv; };
+    })
     inputs.hyprlang.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
@@ -41,11 +45,14 @@ in
   ];
 
   # Hyprland with its internal dependencies.
-  hyprland = lib.composeManyExtensions (with self.overlays; [
-    udis86
-    glaze
-    hyprland-no-deps
-  ]);
+  hyprland = lib.composeManyExtensions (
+    with self.overlays;
+    [
+      udis86
+      glaze
+      hyprland-no-deps
+    ]
+  );
 
   # Hyprland without any dependencies.
   hyprland-no-deps =

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -33,9 +33,6 @@ in
     inputs.hyprland-protocols.overlays.default
     inputs.hyprland-guiutils.overlays.default
     inputs.hyprtoolkit.overlays.default
-    (final: prev: {
-      hyprtoolkit = prev.hyprtoolkit.override { stdenv = final.gcc16Stdenv; };
-    })
     inputs.hyprlang.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1,4 +1,3 @@
-
 #include "Compositor.hpp"
 #include "render/decorations/DecorationPositioner.hpp"
 #include "config/supplementary/executor/Executor.hpp"
@@ -22,6 +21,7 @@
 #include "managers/ANRManager.hpp"
 #include "managers/eventLoop/EventLoopManager.hpp"
 #include "managers/permissions/DynamicPermissionManager.hpp"
+#include "hyprtoolkit/embedded/EmbeddedToolkitManager.hpp"
 #include "state/FallbackState.hpp"
 #include "state/MonitorState.hpp"
 #include "state/WorkspaceState.hpp"
@@ -619,6 +619,7 @@ void CCompositor::cleanup() {
     Debug::overlay().reset();
     IPC::Socket2::sock().reset();
     g_pSessionLockManager.reset();
+    EmbeddedToolkit::manager().reset();
     g_pHyprRenderer.reset();
     g_pProtocolManager.reset();
     g_pHyprOpenGL.reset();
@@ -702,6 +703,9 @@ void CCompositor::initManagers(eManagersInitStage stage) {
 
             Log::logger->log(Log::DEBUG, "Creating the HyprRenderer!");
             g_pHyprRenderer = makeUnique<CHyprGLRenderer>();
+
+            Log::logger->log(Log::DEBUG, "Creating the embedded hyprtoolkit manager!");
+            EmbeddedToolkit::manager() = makeUnique<EmbeddedToolkit::CManager>();
 
             Log::logger->log(Log::DEBUG, "Creating the ProtocolManager!");
             g_pProtocolManager = makeUnique<CProtocolManager>();

--- a/src/animation/WorkspaceAnimationController.cpp
+++ b/src/animation/WorkspaceAnimationController.cpp
@@ -10,6 +10,7 @@
 #include "../desktop/view/window/WindowPresentation.hpp"
 #include "../layout/target/Target.hpp"
 #include "../output/Monitor.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "../managers/fullscreen/FullscreenController.hpp"
 #include "wlr-layer-shell-unstable-v1.hpp"
 
@@ -22,38 +23,27 @@ void Animation::Workspace::startAnimation(PHLWORKSPACE ws, eAnimationType type, 
     if (!ws)
         return;
 
-    const bool IN = type == ANIMATION_TYPE_IN;
+    const auto PMONITOR = ws->m_monitor.lock();
+    if (!PMONITOR)
+        return;
+
+    auto&      transition = PMONITOR->m_workspaceTransition->ensure(ws);
+    const bool IN         = type == ANIMATION_TYPE_IN;
 
     if (!instant) {
         const std::string ANIMNAME = std::format("{}{}", ws->m_isSpecialWorkspace ? "specialWorkspace" : "workspaces", IN ? "In" : "Out");
 
-        ws->m_alpha->setConfig(Config::animationTree()->getAnimationPropertyConfig(ANIMNAME));
-        ws->m_renderOffset->setConfig(Config::animationTree()->getAnimationPropertyConfig(ANIMNAME));
+        transition.alpha->setConfig(Config::animationTree()->getAnimationPropertyConfig(ANIMNAME));
+        transition.offset->setConfig(Config::animationTree()->getAnimationPropertyConfig(ANIMNAME));
     }
 
     static auto PWORKSPACEGAP = CConfigValue<Config::INTEGER>("general:gaps_workspaces");
-    const auto  PMONITOR      = ws->m_monitor.lock();
-    const auto  ANIMSTYLE     = style.value_or(ws->m_alpha->getStyle());
+    const auto  ANIMSTYLE     = style.value_or(transition.alpha->getStyle());
 
-    if (!PMONITOR)
-        return;
+    float       movePerc = 100.F;
+    bool        vert     = ANIMSTYLE.starts_with("slidevert") || ANIMSTYLE.starts_with("slidefadevert");
 
-    float movePerc = 100.F;
-    bool  vert     = ANIMSTYLE.starts_with("slidevert") || ANIMSTYLE.starts_with("slidefadevert");
-
-    ws->m_renderOffset->setUpdateCallback([weak = PHLWORKSPACEREF{ws}](auto) {
-        if (!weak)
-            return;
-
-        for (auto const& w : Desktop::windowState()->windows()) {
-            if (!validMapped(w) || w->workspaceID() != weak->m_id)
-                continue;
-
-            w->presentation().onWorkspaceAnimUpdate();
-        };
-    });
-
-    CVarList args(ANIMSTYLE, 0, 's');
+    CVarList    args(ANIMSTYLE, 0, 's');
     if (args.size() > 1) {
         const auto ARG2 = args[1];
         if (ARG2 == "top") {
@@ -79,75 +69,75 @@ void Animation::Workspace::startAnimation(PHLWORKSPACE ws, eAnimationType type, 
     }
 
     if (ANIMSTYLE.starts_with("slidefade")) {
-        ws->m_alpha->setValueAndWarp(1.F);
-        ws->m_renderOffset->setValueAndWarp(Vector2D(0, 0));
+        transition.alpha->setValueAndWarp(1.F);
+        transition.offset->setValueAndWarp(Vector2D(0, 0));
 
         if (vert) {
             if (IN) {
-                ws->m_alpha->setValueAndWarp(0.F);
-                ws->m_renderOffset->setValueAndWarp(Vector2D(0.0, (left ? PMONITOR->m_size.y : -PMONITOR->m_size.y) * (movePerc / 100.F)));
-                *ws->m_alpha        = 1.F;
-                *ws->m_renderOffset = Vector2D(0, 0);
+                transition.alpha->setValueAndWarp(0.F);
+                transition.offset->setValueAndWarp(Vector2D(0.0, (left ? PMONITOR->m_size.y : -PMONITOR->m_size.y) * (movePerc / 100.F)));
+                *transition.alpha  = 1.F;
+                *transition.offset = Vector2D(0, 0);
             } else {
-                ws->m_alpha->setValueAndWarp(1.F);
-                *ws->m_alpha        = 0.F;
-                *ws->m_renderOffset = Vector2D(0.0, (left ? -PMONITOR->m_size.y : PMONITOR->m_size.y) * (movePerc / 100.F));
+                transition.alpha->setValueAndWarp(1.F);
+                *transition.alpha  = 0.F;
+                *transition.offset = Vector2D(0.0, (left ? -PMONITOR->m_size.y : PMONITOR->m_size.y) * (movePerc / 100.F));
             }
         } else {
             if (IN) {
-                ws->m_alpha->setValueAndWarp(0.F);
-                ws->m_renderOffset->setValueAndWarp(Vector2D((left ? PMONITOR->m_size.x : -PMONITOR->m_size.x) * (movePerc / 100.F), 0.0));
-                *ws->m_alpha        = 1.F;
-                *ws->m_renderOffset = Vector2D(0, 0);
+                transition.alpha->setValueAndWarp(0.F);
+                transition.offset->setValueAndWarp(Vector2D((left ? PMONITOR->m_size.x : -PMONITOR->m_size.x) * (movePerc / 100.F), 0.0));
+                *transition.alpha  = 1.F;
+                *transition.offset = Vector2D(0, 0);
             } else {
-                ws->m_alpha->setValueAndWarp(1.F);
-                *ws->m_alpha        = 0.F;
-                *ws->m_renderOffset = Vector2D((left ? -PMONITOR->m_size.x : PMONITOR->m_size.x) * (movePerc / 100.F), 0.0);
+                transition.alpha->setValueAndWarp(1.F);
+                *transition.alpha  = 0.F;
+                *transition.offset = Vector2D((left ? -PMONITOR->m_size.x : PMONITOR->m_size.x) * (movePerc / 100.F), 0.0);
             }
         }
     } else if (ANIMSTYLE == "fade") {
-        ws->m_renderOffset->setValueAndWarp(Vector2D(0, 0));
+        transition.offset->setValueAndWarp(Vector2D(0, 0));
 
         if (IN) {
-            ws->m_alpha->setValueAndWarp(0.F);
-            *ws->m_alpha = 1.F;
+            transition.alpha->setValueAndWarp(0.F);
+            *transition.alpha = 1.F;
         } else {
-            ws->m_alpha->setValueAndWarp(1.F);
-            *ws->m_alpha = 0.F;
+            transition.alpha->setValueAndWarp(1.F);
+            *transition.alpha = 0.F;
         }
     } else if (vert) {
         const auto YDISTANCE = (PMONITOR->m_size.y + *PWORKSPACEGAP) * (movePerc / 100.F);
-        ws->m_alpha->setValueAndWarp(1.F);
+        transition.alpha->setValueAndWarp(1.F);
 
         if (IN) {
-            ws->m_renderOffset->setValueAndWarp(Vector2D(0.0, left ? YDISTANCE : -YDISTANCE));
-            *ws->m_renderOffset = Vector2D(0, 0);
+            transition.offset->setValueAndWarp(Vector2D(0.0, left ? YDISTANCE : -YDISTANCE));
+            *transition.offset = Vector2D(0, 0);
         } else
-            *ws->m_renderOffset = Vector2D(0.0, left ? -YDISTANCE : YDISTANCE);
+            *transition.offset = Vector2D(0.0, left ? -YDISTANCE : YDISTANCE);
     } else {
         const auto XDISTANCE = (PMONITOR->m_size.x + *PWORKSPACEGAP) * (movePerc / 100.F);
-        ws->m_alpha->setValueAndWarp(1.F);
+        transition.alpha->setValueAndWarp(1.F);
 
         if (IN) {
-            ws->m_renderOffset->setValueAndWarp(Vector2D(left ? XDISTANCE : -XDISTANCE, 0.0));
-            *ws->m_renderOffset = Vector2D(0, 0);
+            transition.offset->setValueAndWarp(Vector2D(left ? XDISTANCE : -XDISTANCE, 0.0));
+            *transition.offset = Vector2D(0, 0);
         } else
-            *ws->m_renderOffset = Vector2D(left ? -XDISTANCE : XDISTANCE, 0.0);
+            *transition.offset = Vector2D(left ? -XDISTANCE : XDISTANCE, 0.0);
     }
 
     if (ws->m_isSpecialWorkspace) {
         if (IN) {
-            ws->m_alpha->setValueAndWarp(0.F);
-            *ws->m_alpha = 1.F;
+            transition.alpha->setValueAndWarp(0.F);
+            *transition.alpha = 1.F;
         } else {
-            ws->m_alpha->setValueAndWarp(1.F);
-            *ws->m_alpha = 0.F;
+            transition.alpha->setValueAndWarp(1.F);
+            *transition.alpha = 0.F;
         }
     }
 
     if (instant) {
-        ws->m_renderOffset->warp();
-        ws->m_alpha->warp();
+        transition.offset->warp();
+        transition.alpha->warp();
     }
 }
 

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -182,7 +182,7 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             Log::logger->log(Log::ERR, "failed to unregister plugin event for lua {}: {}", name, ret.error());
     }));
 
-    m_listeners.push_back(bus()->m_events.input.keyboard.key.listen([this](const IKeyboard::SKeyEvent& keyEvent, const SCallbackInfo& _) {
+    m_listeners.push_back(bus()->m_events.input.keyboard.key.listen([this](const IKeyboard::SKeyEvent& keyEvent, SP<IKeyboard>, const SCallbackInfo& _) {
         dispatch("input.keyboard.key", 3, [&](lua_State* L) {
             lua_pushinteger(L, keyEvent.keycode + 8); // Because to xkbcommon it's +8 from libinput
             lua_pushinteger(L, keyEvent.timeMs);

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -178,7 +178,7 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             Log::logger->log(Log::ERR, "failed to unregister plugin event for lua {}: {}", name, ret.error());
     }));
 
-    m_listeners.push_back(bus()->m_events.input.keyboard.key.listen([this](const IKeyboard::SKeyEvent& keyEvent, const SCallbackInfo& _) {
+    m_listeners.push_back(bus()->m_events.input.keyboard.key.listen([this](const IKeyboard::SKeyEvent& keyEvent, SP<IKeyboard>, const SCallbackInfo& _) {
         dispatch("input.keyboard.key", 3, [&](lua_State* L) {
             lua_pushinteger(L, keyEvent.keycode + 8); // Because to xkbcommon it's +8 from libinput
             lua_pushinteger(L, keyEvent.timeMs);

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -37,6 +37,7 @@
 #include "../../../managers/input/trackpad/gestures/FullscreenGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/LuaFunctionGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/MoveGesture.hpp"
+#include "../../../managers/input/trackpad/gestures/OverviewGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/ResizeGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/SpecialWorkspaceGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/WorkspaceSwipeGesture.hpp"
@@ -945,6 +946,8 @@ static int hlGesture(lua_State* L) {
             result = g_pTrackpadGestures->addGesture(makeUnique<CResizeTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
         else if (action == "move")
             result = g_pTrackpadGestures->addGesture(makeUnique<CMoveTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
+        else if (action == "overview")
+            result = g_pTrackpadGestures->addGesture(makeUnique<COverviewTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
         else if (action == "special")
             result = g_pTrackpadGestures->addGesture(makeUnique<CSpecialWorkspaceGesture>(workspaceName), fingerCount, direction, modMask, deltaScale, disableInhibit);
         else if (action == "close")

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -37,6 +37,7 @@
 #include "../../../managers/input/trackpad/gestures/FullscreenGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/LuaFunctionGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/MoveGesture.hpp"
+#include "../../../managers/input/trackpad/gestures/OverviewGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/ResizeGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/SpecialWorkspaceGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/WorkspaceSwipeGesture.hpp"
@@ -942,6 +943,8 @@ static int hlGesture(lua_State* L) {
             result = g_pTrackpadGestures->addGesture(makeUnique<CResizeTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
         else if (action == "move")
             result = g_pTrackpadGestures->addGesture(makeUnique<CMoveTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
+        else if (action == "overview")
+            result = g_pTrackpadGestures->addGesture(makeUnique<COverviewTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
         else if (action == "special")
             result = g_pTrackpadGestures->addGesture(makeUnique<CSpecialWorkspaceGesture>(workspaceName), fingerCount, direction, modMask, deltaScale, disableInhibit);
         else if (action == "close")

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1285,6 +1285,18 @@ static int hlWorkspaceSwapMonitors(lua_State* L) {
     return 1;
 }
 
+static int dsp_toggleOverview(lua_State* L) {
+    return Internal::checkResult(L, CA::overview(sc<CA::eTogglableAction>((int)lua_tonumber(L, lua_upvalueindex(1)))));
+}
+
+static int hlOverviewToggle(lua_State* L) {
+    const auto action = Internal::tableToggleAction(L, 1);
+
+    lua_pushnumber(L, (int)action);
+    lua_pushcclosure(L, dsp_toggleOverview, 1);
+    return 1;
+}
+
 void Internal::registerDispatcherBindings(lua_State* L) {
     lua_newtable(L);
     Internal::markDispatcherTable(L);
@@ -1340,6 +1352,11 @@ void Internal::registerDispatcherBindings(lua_State* L) {
         Internal::setFn(L, "swap_monitors", hlWorkspaceSwapMonitors);
         Internal::setFn(L, "toggle_special", hlWorkspaceToggleSpecial);
         lua_setfield(L, -2, "workspace");
+
+        lua_newtable(L);
+        Internal::markDispatcherTable(L);
+        Internal::setFn(L, "toggle", hlOverviewToggle);
+        lua_setfield(L, -2, "overview");
 
         Internal::setFn(L, "exec_cmd", hlExecCmd);
         Internal::setFn(L, "exec_raw", hlExecRaw);

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1286,14 +1286,49 @@ static int hlWorkspaceSwapMonitors(lua_State* L) {
 }
 
 static int dsp_toggleOverview(lua_State* L) {
-    return Internal::checkResult(L, CA::overview(sc<CA::eTogglableAction>((int)lua_tonumber(L, lua_upvalueindex(1)))));
+    size_t      queryLength = 0;
+    const auto* query       = lua_tolstring(L, lua_upvalueindex(2), &queryLength);
+    return Internal::checkResult(L, CA::overview(sc<CA::eTogglableAction>((int)lua_tonumber(L, lua_upvalueindex(1))), std::string{query, queryLength}));
 }
 
 static int hlOverviewToggle(lua_State* L) {
-    const auto action = Internal::tableToggleAction(L, 1);
+    const auto  action = Internal::tableToggleAction(L, 1);
+    std::string query;
+
+    if (lua_istable(L, 1)) {
+        lua_getfield(L, 1, "query");
+        if (!lua_isnil(L, -1)) {
+            if (lua_type(L, -1) != LUA_TSTRING)
+                return Internal::configError(L, "hl.dsp.overview.toggle: option 'query': expected string, got {}", luaL_typename(L, -1));
+
+            size_t      queryLength = 0;
+            const auto* queryValue  = lua_tolstring(L, -1, &queryLength);
+            query.assign(queryValue, queryLength);
+        }
+        lua_pop(L, 1);
+    }
 
     lua_pushnumber(L, (int)action);
-    lua_pushcclosure(L, dsp_toggleOverview, 1);
+    lua_pushlstring(L, query.data(), query.size());
+    lua_pushcclosure(L, dsp_toggleOverview, 2);
+    return 1;
+}
+
+static int dsp_overviewMoveLeft(lua_State* L) {
+    return Internal::checkResult(L, CA::overviewMoveLeft());
+}
+
+static int hlOverviewMoveLeft(lua_State* L) {
+    lua_pushcclosure(L, dsp_overviewMoveLeft, 0);
+    return 1;
+}
+
+static int dsp_overviewMoveRight(lua_State* L) {
+    return Internal::checkResult(L, CA::overviewMoveRight());
+}
+
+static int hlOverviewMoveRight(lua_State* L) {
+    lua_pushcclosure(L, dsp_overviewMoveRight, 0);
     return 1;
 }
 
@@ -1356,6 +1391,8 @@ void Internal::registerDispatcherBindings(lua_State* L) {
         lua_newtable(L);
         Internal::markDispatcherTable(L);
         Internal::setFn(L, "toggle", hlOverviewToggle);
+        Internal::setFn(L, "move_left", hlOverviewMoveLeft);
+        Internal::setFn(L, "move_right", hlOverviewMoveRight);
         lua_setfield(L, -2, "overview");
 
         Internal::setFn(L, "exec_cmd", hlExecCmd);

--- a/src/config/lua/bindings/LuaBindingsQuery.cpp
+++ b/src/config/lua/bindings/LuaBindingsQuery.cpp
@@ -13,6 +13,7 @@
 #include "../../../desktop/view/LayerSurface.hpp"
 #include "../../../desktop/view/window/Window.hpp"
 #include "../../../managers/input/InputManager.hpp"
+#include "../../../overview/Overview.hpp"
 #include "../../../state/MonitorState.hpp"
 #include "../../../state/WorkspaceState.hpp"
 
@@ -412,6 +413,31 @@ static int hlGetCurrentSubmap(lua_State* L) {
     return 1;
 }
 
+static int hlGetOverview(lua_State* L) {
+    const auto OVERVIEW = Overview::overview().get();
+    const auto state    = Overview::state(OVERVIEW);
+
+    lua_createtable(L, 0, 4);
+    lua_pushboolean(L, state.open);
+    lua_setfield(L, -2, "open");
+
+    if (state.monitor)
+        Objects::CLuaMonitor::push(L, state.monitor);
+    else
+        lua_pushnil(L);
+    lua_setfield(L, -2, "monitor");
+
+    if (state.workspace)
+        Objects::CLuaWorkspace::push(L, state.workspace);
+    else
+        lua_pushnil(L);
+    lua_setfield(L, -2, "workspace");
+
+    lua_pushlstring(L, state.query.data(), state.query.size());
+    lua_setfield(L, -2, "query");
+    return 1;
+}
+
 void Internal::registerQueryBindings(lua_State* L) {
     Internal::setFn(L, "get_windows", hlGetWindows);
     Internal::setFn(L, "get_window", hlGetWindow);
@@ -432,4 +458,5 @@ void Internal::registerQueryBindings(lua_State* L) {
     Internal::setFn(L, "get_last_window", hlGetLastWindow);
     Internal::setFn(L, "get_last_workspace", hlGetLastWorkspace);
     Internal::setFn(L, "get_current_submap", hlGetCurrentSubmap);
+    Internal::setFn(L, "get_overview", hlGetOverview);
 }

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1807,15 +1807,41 @@ ActionResult Actions::releaseInputCapture() {
     return {};
 }
 
-ActionResult Actions::overview(eTogglableAction action) {
-    const bool target = action == TOGGLE_ACTION_TOGGLE ? !Overview::overview()->isOpen() : action == TOGGLE_ACTION_ENABLE;
-    if (target == Overview::overview()->isOpen())
+ActionResult Actions::overview(eTogglableAction action, const std::string& query) {
+    const auto OVERVIEW = Overview::overview().get();
+    if (!OVERVIEW)
+        return actionError("Overview is unavailable", eActionErrorLevel::WARNING, eActionErrorCode::UNAVAILABLE);
+
+    const bool target = action == TOGGLE_ACTION_TOGGLE ? !OVERVIEW->isOpen() : action == TOGGLE_ACTION_ENABLE;
+    if (target == OVERVIEW->isOpen())
         return {};
 
     if (target)
-        Overview::overview()->open(Desktop::focusState()->monitor());
+        Overview::openWithQuery(OVERVIEW, Desktop::focusState()->monitor(), query);
     else
-        Overview::overview()->close();
+        OVERVIEW->close();
 
     return {};
+}
+
+static ActionResult moveOverview(bool left) {
+    const auto OVERVIEW = Overview::overview().get();
+    if (!OVERVIEW)
+        return actionError("Overview is unavailable", eActionErrorLevel::WARNING, eActionErrorCode::UNAVAILABLE);
+    if (!OVERVIEW->isOpen())
+        return actionError("Overview is not open", eActionErrorLevel::WARNING, eActionErrorCode::INVALID_STATE);
+
+    const auto MOVED = left ? Overview::moveLeft(OVERVIEW) : Overview::moveRight(OVERVIEW);
+    if (!MOVED)
+        return actionError("Overview does not support navigation", eActionErrorLevel::WARNING, eActionErrorCode::UNAVAILABLE);
+
+    return {};
+}
+
+ActionResult Actions::overviewMoveLeft() {
+    return moveOverview(true);
+}
+
+ActionResult Actions::overviewMoveRight() {
+    return moveOverview(false);
 }

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -36,6 +36,7 @@
 #include "../../../state/WorkspacePlacementController.hpp"
 #include "../../../state/WorkspaceState.hpp"
 #include "../../../helpers/math/Expression.hpp"
+#include "../../../overview/Overview.hpp"
 
 #include <numbers>
 #include <utility>
@@ -1800,5 +1801,18 @@ ActionResult Actions::moveIntoOrCreateGroup(Math::eDirection dir, std::optional<
 
 ActionResult Actions::releaseInputCapture() {
     PROTO::inputCapture->forceRelease();
+    return {};
+}
+
+ActionResult Actions::overview(eTogglableAction action) {
+    const bool target = action == TOGGLE_ACTION_TOGGLE ? !Overview::overview()->isOpen() : action == TOGGLE_ACTION_ENABLE;
+    if (target == Overview::overview()->isOpen())
+        return {};
+
+    if (target)
+        Overview::overview()->open(Desktop::focusState()->monitor());
+    else
+        Overview::overview()->close();
+
     return {};
 }

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1681,8 +1681,11 @@ ActionResult Actions::mouse(const std::string& action) {
         }
     }
 
-    const auto      MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-    const PHLWINDOW PWINDOW = Desktop::viewState()->hitTest().windowAt(MOUSECOORDS, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
+    const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+    const auto WORKSPACE   = Overview::overview()->inputWorkspace();
+    const auto PWINDOW     = WORKSPACE ?
+        Desktop::viewState()->hitTest().windowAtWorkspace(MOUSECOORDS, WORKSPACE, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING) :
+        Desktop::viewState()->hitTest().windowAt(MOUSECOORDS, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
 
     if (!PWINDOW)
         return SActionResult{.passEvent = true};

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1683,8 +1683,11 @@ ActionResult Actions::mouse(const std::string& action) {
         }
     }
 
-    const auto      MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-    const PHLWINDOW PWINDOW = Desktop::viewState()->hitTest().windowAt(MOUSECOORDS, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
+    const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+    const auto WORKSPACE   = Overview::overview()->inputWorkspace();
+    const auto PWINDOW     = WORKSPACE ?
+        Desktop::viewState()->hitTest().windowAtWorkspace(MOUSECOORDS, WORKSPACE, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING) :
+        Desktop::viewState()->hitTest().windowAt(MOUSECOORDS, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
 
     if (!PWINDOW)
         return SActionResult{.passEvent = true};

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -36,6 +36,7 @@
 #include "../../../state/WorkspacePlacementController.hpp"
 #include "../../../state/WorkspaceState.hpp"
 #include "../../../helpers/math/Expression.hpp"
+#include "../../../overview/Overview.hpp"
 
 #include <numbers>
 #include <utility>
@@ -1798,5 +1799,18 @@ ActionResult Actions::moveIntoOrCreateGroup(Math::eDirection dir, std::optional<
 
 ActionResult Actions::releaseInputCapture() {
     PROTO::inputCapture->forceRelease();
+    return {};
+}
+
+ActionResult Actions::overview(eTogglableAction action) {
+    const bool target = action == TOGGLE_ACTION_TOGGLE ? !Overview::overview()->isOpen() : action == TOGGLE_ACTION_ENABLE;
+    if (target == Overview::overview()->isOpen())
+        return {};
+
+    if (target)
+        Overview::overview()->open(Desktop::focusState()->monitor());
+    else
+        Overview::overview()->close();
+
     return {};
 }

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -84,6 +84,8 @@ namespace Config::Actions {
 
     ActionResult layoutMessage(const std::string& msg);
 
+    ActionResult overview(eTogglableAction action);
+
     ActionResult moveCursor(const Vector2D& pos);
     ActionResult exit();
     ActionResult forceRendererReload();

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -84,7 +84,9 @@ namespace Config::Actions {
 
     ActionResult layoutMessage(const std::string& msg);
 
-    ActionResult overview(eTogglableAction action);
+    ActionResult overview(eTogglableAction action, const std::string& query = {});
+    ActionResult overviewMoveLeft();
+    ActionResult overviewMoveRight();
 
     ActionResult moveCursor(const Vector2D& pos);
     ActionResult exit();

--- a/src/config/shared/animation/AnimationTree.cpp
+++ b/src/config/shared/animation/AnimationTree.cpp
@@ -24,6 +24,7 @@ void CAnimationTreeController::reset() {
     m_animationTree.createNode("shadowangle", "global");
     m_animationTree.createNode("glowangle", "global");
     m_animationTree.createNode("workspaces", "global");
+    m_animationTree.createNode("overview", "global");
     m_animationTree.createNode("zoomFactor", "global");
     m_animationTree.createNode("monitorAdded", "global");
 
@@ -57,6 +58,12 @@ void CAnimationTreeController::reset() {
     m_animationTree.createNode("specialWorkspace", "workspaces");
     m_animationTree.createNode("specialWorkspaceIn", "specialWorkspace");
     m_animationTree.createNode("specialWorkspaceOut", "specialWorkspace");
+
+    // overview
+    m_animationTree.createNode("overviewIn", "overview");
+    m_animationTree.createNode("overviewOut", "overview");
+    m_animationTree.createNode("overviewMove", "overview");
+    m_animationTree.createNode("overviewFade", "overview");
 
     // init the root nodes
     m_animationTree.setConfigForNode("global", 1, 8.f, "default");

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -199,6 +199,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
 
         MS<Color>("overview:col.active_border", "border color for the workspace selected in overview", 0xffffffff),
         MS<Color>("overview:col.inactive_border", "border color for unselected workspaces in overview", 0xff444444),
+        MS<Bool>("overview:only_current_monitor", "Only show workspaces on the current monitor the overview is on", false),
 
         /*
          * decoration:

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -200,6 +200,9 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Color>("overview:col.active_border", "border color for the workspace selected in overview", 0xffffffff),
         MS<Color>("overview:col.inactive_border", "border color for unselected workspaces in overview", 0xff444444),
         MS<Bool>("overview:only_current_monitor", "Only show workspaces on the current monitor the overview is on", false),
+        MS<String>("overview:search:window_prefix", "single-character prefix for window queries", "/", {.validator = singleCharacter()}),
+        MS<String>("overview:search:workspace_prefix", "single-character prefix for workspace queries", ".", {.validator = singleCharacter()}),
+        MS<Int>("overview:search:default_mode", "query mode used without a prefix", 0, {.min = 0, .max = 2, .map = OptionMap{{"all", 0}, {"window", 1}, {"workspace", 2}}}),
 
         /*
          * decoration:

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -194,6 +194,13 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<String>("general:locale", "overrides the system locale", ""),
 
         /*
+         * overview:
+         */
+
+        MS<Color>("overview:col.active_border", "border color for the workspace selected in overview", 0xffffffff),
+        MS<Color>("overview:col.inactive_border", "border color for unselected workspaces in overview", 0xff444444),
+
+        /*
          * decoration:
          */
 

--- a/src/config/values/ConfigValues.hpp
+++ b/src/config/values/ConfigValues.hpp
@@ -46,6 +46,14 @@ namespace Config::Values {
         };
     }
 
+    inline auto singleCharacter() {
+        return [](const Config::STRING& v) -> std::expected<void, std::string> {
+            if (v.size() != 1)
+                return std::unexpected("value must be a single character");
+            return {};
+        };
+    }
+
     using Bool       = CBoolValue;
     using Color      = CColorValue;
     using CssGap     = CCssGapValue;

--- a/src/debug/Overlay.cpp
+++ b/src/debug/Overlay.cpp
@@ -67,14 +67,14 @@ static SFPSGraphLayout fpsGraphLayout() {
     };
 }
 
-static SFPSGraphDrawResult drawFPSGraph(float x, float y, float idealFPS, const std::deque<float>& fpsHistory) {
+static SFPSGraphDrawResult drawFPSGraph(Render::CRenderingContext& context, float x, float y, float idealFPS, const std::deque<float>& fpsHistory) {
     const auto                  LAYOUT = fpsGraphLayout();
 
     CRectPassElement::SRectData bgData;
     bgData.box   = {x, y, LAYOUT.width, LAYOUT.height};
     bgData.color = CHyprColor{0.F, 0.F, 0.F, OVERLAY_FPS_GRAPH_BG_ALPHA};
     bgData.round = 2;
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(bgData));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(bgData));
 
     const size_t BARCOUNT         = std::min(fpsHistory.size(), sc<size_t>(OVERLAY_FPS_GRAPH_HISTORY_SEC));
     const size_t LEADINGBLANKBARS = sc<size_t>(OVERLAY_FPS_GRAPH_HISTORY_SEC) - BARCOUNT;
@@ -89,7 +89,7 @@ static SFPSGraphDrawResult drawFPSGraph(float x, float y, float idealFPS, const 
         CRectPassElement::SRectData barData;
         barData.box   = {BARX, BARY, sc<float>(OVERLAY_FPS_GRAPH_BAR_WIDTH), BARHEIGHT};
         barData.color = fpsBarColor(NORMALIZEDFPS);
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(barData));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(barData));
     }
 
     return {
@@ -271,7 +271,7 @@ void CMonitorOverlay::rebuildCache() {
     m_cachedLines.resize(idx);
 }
 
-int CMonitorOverlay::draw(int offset, bool& cacheUpdated) {
+int CMonitorOverlay::draw(Render::CRenderingContext& context, int offset, bool& cacheUpdated) {
     cacheUpdated   = false;
     m_lastDrawnBox = {};
 
@@ -300,13 +300,13 @@ int CMonitorOverlay::draw(int offset, bool& cacheUpdated) {
         data.tex = line.texture;
         data.box = {OVERLAY_MARGIN_LEFT + OVERLAY_BOX_MARGIN, y, line.texture->m_size.x, line.texture->m_size.y};
         data.a   = 1.F;
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
 
         maxTextW = std::max(maxTextW, sc<float>(line.texture->m_size.x));
         y += line.texture->m_size.y + OVERLAY_LINE_GAP;
 
         if (i == 1) {
-            const auto GRAPHDRAW = drawFPSGraph(OVERLAY_MARGIN_LEFT + OVERLAY_BOX_MARGIN, y + OVERLAY_FPS_GRAPH_GAP_TOP, IDEALFPS, m_lastFPSPerSecond);
+            const auto GRAPHDRAW = drawFPSGraph(context, OVERLAY_MARGIN_LEFT + OVERLAY_BOX_MARGIN, y + OVERLAY_FPS_GRAPH_GAP_TOP, IDEALFPS, m_lastFPSPerSecond);
 
             maxTextW = std::max(maxTextW, GRAPHDRAW.width);
             y        = GRAPHDRAW.bottomY + OVERLAY_LINE_GAP;
@@ -374,7 +374,7 @@ void COverlay::createWarningTexture(float maxW) {
     });
 }
 
-void COverlay::draw() {
+void COverlay::draw(Render::CRenderingContext& context) {
     if (State::monitorState()->monitors().empty())
         return;
 
@@ -424,7 +424,7 @@ void COverlay::draw() {
             data.color = CHyprColor{0.1F, 0.1F, 0.1F, 0.6F};
             data.round = 10;
             data.blur  = true;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(std::move(data)));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(std::move(data)));
 
             createWarningTexture(fullSize.x);
         }
@@ -432,7 +432,7 @@ void COverlay::draw() {
 
     for (auto const& monitor : State::monitorState()->monitors()) {
         bool monitorUpdated = false;
-        offsetY += m_monitorOverlays[monitor].draw(offsetY, monitorUpdated);
+        offsetY += m_monitorOverlays[monitor].draw(context, offsetY, monitorUpdated);
         cacheUpdated = cacheUpdated || monitorUpdated;
 
         const auto& BOX = m_monitorOverlays[monitor].lastDrawnBox();
@@ -470,7 +470,7 @@ void COverlay::draw() {
             data.color = CHyprColor{0.1F, 0.1F, 0.1F, 0.6F};
             data.round = 10;
             data.blur  = true;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(std::move(data)));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(std::move(data)));
         }
 
         {
@@ -479,7 +479,7 @@ void COverlay::draw() {
                 Vector2D{OVERLAY_MARGIN_LEFT + ((maxWidth - m_warningTexture->m_size.x) / 2.F), sc<float>(offsetY) + (OVERLAY_MARGIN_TOP * 2) + (OVERLAY_BOX_MARGIN * 2)}.round(),
                 m_warningTexture->m_size};
             data.tex = m_warningTexture;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 

--- a/src/debug/Overlay.hpp
+++ b/src/debug/Overlay.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 namespace Render {
+    class CRenderingContext;
     class IHyprRenderer;
     class ITexture;
 }
@@ -17,7 +18,7 @@ namespace Debug {
 
     class CMonitorOverlay {
       public:
-        int         draw(int offset, bool& cacheUpdated);
+        int         draw(Render::CRenderingContext&, int offset, bool& cacheUpdated);
         const CBox& lastDrawnBox() const;
 
         void        renderData(PHLMONITOR pMonitor, float durationUs);
@@ -66,7 +67,7 @@ namespace Debug {
     class COverlay {
       public:
         COverlay();
-        void draw();
+        void draw(Render::CRenderingContext&);
         void renderData(PHLMONITOR, float durationUs);
         void renderDataNoOverlay(PHLMONITOR, float durationUs);
         void frameData(PHLMONITOR);

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -42,11 +42,6 @@ CWorkspace::CWorkspace(WORKSPACEID id, PHLMONITOR monitor, std::string name, boo
 void CWorkspace::init(PHLWORKSPACE self) {
     m_self = self;
 
-    Animation::mgr()->createAnimation(Vector2D(0, 0), m_renderOffset,
-                                      Config::animationTree()->getAnimationPropertyConfig(m_isSpecialWorkspace ? "specialWorkspaceIn" : "workspacesIn"), self, AVARDAMAGE_ENTIRE);
-    Animation::mgr()->createAnimation(1.f, m_alpha, Config::animationTree()->getAnimationPropertyConfig(m_isSpecialWorkspace ? "specialWorkspaceIn" : "workspacesIn"), self,
-                                      AVARDAMAGE_ENTIRE);
-
     const auto RULEFORTHIS = Config::workspaceRuleMgr()->getWorkspaceRuleFor(self).value_or(Config::CWorkspaceRule{});
     if (RULEFORTHIS.m_defaultName.has_value())
         m_name = RULEFORTHIS.m_defaultName.value();

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -538,6 +538,7 @@ void CWorkspace::rename(const std::string& name) {
 
     IPC::Socket2::sock()->postEvent({.event = "renameworkspace", .data = std::format("{},{}", m_id, m_name)});
     m_events.renamed.emit();
+    Event::bus()->m_events.workspace.renamed.emit(m_self);
 }
 
 void CWorkspace::changeID(int64_t id) {

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../helpers/AnimatedVariable.hpp"
 #include <string>
+#include <optional>
 #include <unordered_set>
 #include "DesktopTypes.hpp"
 #include "../helpers/MiscFunctions.hpp"
@@ -29,9 +29,6 @@ class CWorkspace {
     PHLMONITORREF m_monitor;
 
     // for animations
-    PHLANIMVAR<Vector2D>       m_renderOffset;
-    PHLANIMVAR<float>          m_alpha;
-    bool                       m_forceRendering = false;
     std::optional<std::string> m_animationStyle;
 
     // allows damage to propagate.

--- a/src/desktop/state/ViewHitTester.cpp
+++ b/src/desktop/state/ViewHitTester.cpp
@@ -1,6 +1,7 @@
 #include "ViewHitTester.hpp"
 #include "FocusState.hpp"
 #include "ViewStateTracker.hpp"
+#include "../Workspace.hpp"
 #include "../view/LayerSurface.hpp"
 #include "../view/WLSurface.hpp"
 #include "../view/window/Window.hpp"
@@ -25,7 +26,15 @@ CViewHitTester::CViewHitTester(const IViewStateTracker& tracker) : m_tracker(tra
 }
 
 PHLWINDOW CViewHitTester::windowAt(const Vector2D& pos, uint16_t properties, PHLWINDOW ignoreWindow) const {
-    const auto PMONITOR = State::monitorState()->query().vec(pos).run();
+    return windowAtInternal(pos, properties, ignoreWindow, nullptr);
+}
+
+PHLWINDOW CViewHitTester::windowAtWorkspace(const Vector2D& pos, PHLWORKSPACE workspace, uint16_t properties, PHLWINDOW ignoreWindow) const {
+    return windowAtInternal(pos, properties, ignoreWindow, workspace);
+}
+
+PHLWINDOW CViewHitTester::windowAtInternal(const Vector2D& pos, uint16_t properties, PHLWINDOW ignoreWindow, PHLWORKSPACE workspace) const {
+    const auto PMONITOR = workspace ? workspace->m_monitor.lock() : State::monitorState()->query().vec(pos).run();
     if (!PMONITOR)
         return nullptr;
 
@@ -89,7 +98,8 @@ PHLWINDOW CViewHitTester::windowAt(const Vector2D& pos, uint16_t properties, PHL
                         continue;
                 }
 
-                if (w->isFloating() && w->mapped() && w->m_workspace->isVisible() && w->acceptsInput() && !(w->m_state & WINDOW_STATE_PINNED) &&
+                const bool ON_WORKSPACE = workspace ? w->m_workspace == workspace : w->m_workspace->isVisible();
+                if (w->isFloating() && w->mapped() && ON_WORKSPACE && w->acceptsInput() && !(w->m_state & WINDOW_STATE_PINNED) &&
                     !w->m_ruleApplicator->noFocus().valueOrDefault() && w != ignoreWindow && (!aboveFullscreen || w->isAllowedOverFullscreen()) && !isShadowedByModal(w)) {
                     // OR windows should add focus to parent
                     if (w->shouldntFocus() && !w->backend().traits().overrideRedirect)
@@ -132,8 +142,8 @@ PHLWINDOW CViewHitTester::windowAt(const Vector2D& pos, uint16_t properties, PHL
         if (properties & FLOATING_ONLY)
             return floating(false);
 
-        const WORKSPACEID WSPID      = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
-        const auto        PWORKSPACE = State::workspaceState()->query().id(WSPID).run();
+        const WORKSPACEID WSPID      = workspace ? workspace->m_id : (special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID());
+        const auto        PWORKSPACE = workspace ? workspace : State::workspaceState()->query().id(WSPID).run();
 
         if (Fullscreen::controller()->hasFullscreen(PWORKSPACE) && !(properties & SKIP_FULLSCREEN_PRIORITY) && !ONLY_PRIORITY) {
             const auto FS_WINDOW = Fullscreen::controller()->getFullscreenWindow(PWORKSPACE);
@@ -238,6 +248,9 @@ PHLWINDOW CViewHitTester::windowAt(const Vector2D& pos, uint16_t properties, PHL
 
         return nullptr;
     };
+
+    if (workspace)
+        return windowForWorkspace(State::workspaceState()->isSpecial(workspace->m_id));
 
     // special workspace
     if (PMONITOR->m_activeSpecialWorkspace && !*PSPECIALFALLTHRU)

--- a/src/desktop/state/ViewHitTester.hpp
+++ b/src/desktop/state/ViewHitTester.hpp
@@ -20,6 +20,7 @@ namespace Desktop {
         CViewHitTester(CViewHitTester&&)      = delete;
 
         PHLWINDOW              windowAt(const Vector2D& pos, uint16_t properties, PHLWINDOW ignoreWindow = nullptr) const;
+        PHLWINDOW              windowAtWorkspace(const Vector2D& pos, PHLWORKSPACE workspace, uint16_t properties, PHLWINDOW ignoreWindow = nullptr) const;
         SP<CWLSurfaceResource> windowSurfaceAt(const Vector2D& pos, PHLWINDOW window, Vector2D& surfaceLocal) const;
         Vector2D               surfaceLocalAt(const Vector2D& pos, PHLWINDOW window, SP<CWLSurfaceResource> surface) const;
         SP<CWLSurfaceResource> layerPopupSurfaceAt(const Vector2D& pos, PHLMONITOR monitor, Vector2D* surfaceCoords, PHLLS* layerFound) const;
@@ -27,6 +28,7 @@ namespace Desktop {
                                               bool aboveLockscreen = false) const;
 
       private:
+        PHLWINDOW                windowAtInternal(const Vector2D& pos, uint16_t properties, PHLWINDOW ignoreWindow, PHLWORKSPACE workspace) const;
         const IViewStateTracker& m_tracker;
     };
 }

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -15,6 +15,7 @@
 #include "../../render/Renderer.hpp"
 #include "../../render/OpenGL.hpp"
 #include "../../output/Monitor.hpp"
+#include "../../overview/Overview.hpp"
 #include "../../state/MonitorState.hpp"
 #include <array>
 #include <ranges>
@@ -314,7 +315,8 @@ void CPopup::onCommit(bool ignoreSiblings) {
         return;
     }
 
-    if (!m_windowOwner.expired() && (!m_windowOwner->mapped() || !m_windowOwner->m_workspace->m_visible)) {
+    const auto WINDOW_OWNER = m_windowOwner.lock();
+    if (WINDOW_OWNER && (!WINDOW_OWNER->mapped() || (!WINDOW_OWNER->m_workspace->m_visible && !Overview::overview()->shouldRenderWorkspace(WINDOW_OWNER->m_workspace)))) {
         const auto PREV_SIZE = m_lastSize;
         m_lastSize           = m_backend->surfaceSize();
 
@@ -323,7 +325,7 @@ void CPopup::onCommit(bool ignoreSiblings) {
 
         static auto PLOGDAMAGE = CConfigValue<Config::INTEGER>("debug:log_damage");
         if (*PLOGDAMAGE)
-            Log::logger->log(Log::DEBUG, "Refusing to commit damage from a subsurface of {} because it's invisible.", m_windowOwner.lock());
+            Log::logger->log(Log::DEBUG, "Refusing to commit damage from a subsurface of {} because it's invisible.", WINDOW_OWNER);
         return;
     }
 

--- a/src/desktop/view/Subsurface.cpp
+++ b/src/desktop/view/Subsurface.cpp
@@ -6,6 +6,7 @@
 #include "../../protocols/core/Subcompositor.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../managers/input/InputManager.hpp"
+#include "../../overview/Overview.hpp"
 #include "../../output/Monitor.hpp"
 
 using namespace Desktop;
@@ -185,12 +186,13 @@ void CSubsurface::recheckDamageForSubsurfaces(int depth) {
 
 void CSubsurface::onCommit() {
     // no damaging if it's not visible
-    if (!m_windowParent.expired() && (!m_windowParent->mapped() || !m_windowParent->m_workspace->m_visible)) {
+    const auto WINDOW_PARENT = m_windowParent.lock();
+    if (WINDOW_PARENT && (!WINDOW_PARENT->mapped() || (!WINDOW_PARENT->m_workspace->m_visible && !Overview::overview()->shouldRenderWorkspace(WINDOW_PARENT->m_workspace)))) {
         m_lastSize = m_wlSurface->resource()->m_current.size;
 
         static auto PLOGDAMAGE = CConfigValue<Config::INTEGER>("debug:log_damage");
         if (*PLOGDAMAGE)
-            Log::logger->log(Log::DEBUG, "Refusing to commit damage from a subsurface of {} because it's invisible.", m_windowParent.lock());
+            Log::logger->log(Log::DEBUG, "Refusing to commit damage from a subsurface of {} because it's invisible.", WINDOW_PARENT);
         return;
     }
 

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -52,6 +52,7 @@
 #include "../../../protocols/LayerShell.hpp"
 #include "../../../helpers/Color.hpp"
 #include "../../../helpers/math/Expression.hpp"
+#include "../../../overview/Overview.hpp"
 #include "../../../render/Renderer.hpp"
 #include "../../../ipc/s2/S2.hpp"
 #include "../../../managers/input/InputManager.hpp"
@@ -1752,7 +1753,7 @@ void CWindow::commitWindow(bool initialCommit) {
             g_pHyprRenderer->damageWindow(m_self.lock());
     }
 
-    if (!m_workspace->m_visible)
+    if (!m_workspace->m_visible && !Overview::overview()->shouldRenderWorkspace(m_workspace))
         return;
 
     const auto PMONITOR = m_monitor.lock();

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -52,6 +52,7 @@
 #include "../../../protocols/LayerShell.hpp"
 #include "../../../helpers/Color.hpp"
 #include "../../../helpers/math/Expression.hpp"
+#include "../../../overview/Overview.hpp"
 #include "../../../render/Renderer.hpp"
 #include "../../../ipc/s2/S2.hpp"
 #include "../../../managers/input/InputManager.hpp"
@@ -1742,7 +1743,7 @@ void CWindow::commitWindow(bool initialCommit) {
             g_pHyprRenderer->damageWindow(m_self.lock());
     }
 
-    if (!m_workspace->m_visible)
+    if (!m_workspace->m_visible && !Overview::overview()->shouldRenderWorkspace(m_workspace))
         return;
 
     const auto PMONITOR = m_monitor.lock();

--- a/src/desktop/view/window/WindowEffectsController.cpp
+++ b/src/desktop/view/window/WindowEffectsController.cpp
@@ -153,12 +153,12 @@ CBox CWindowEffectsController::transformBoxForDamage(const CBox& currentBox) con
     return m_transformers->transformBoxForDamage(currentBox);
 }
 
-void CWindowEffectsController::preWindowRender(CSurfacePassElement::SRenderData* renderData) const {
-    m_transformers->preWindowRender(renderData);
+void CWindowEffectsController::preWindowRender(Render::CRenderingContext& context, CSurfacePassElement::SRenderData* renderData) const {
+    m_transformers->preWindowRender(context, renderData);
 }
 
-void CWindowEffectsController::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* motionBlurData) const {
-    m_transformers->amendTransformedRenderData(currentBox, motionBlurData);
+void CWindowEffectsController::amendTransformedRenderData(Render::CRenderingContext& context, const CBox& currentBox, SMotionBlurData* motionBlurData) const {
+    m_transformers->amendTransformedRenderData(context, currentBox, motionBlurData);
 }
 
 const UP<Render::CWindowTransformerList>& CWindowEffectsController::transformers() const {

--- a/src/desktop/view/window/WindowEffectsController.hpp
+++ b/src/desktop/view/window/WindowEffectsController.hpp
@@ -36,8 +36,8 @@ namespace Desktop::View {
         bool                                      blocksDirectScanout() const;
         CBox                                      transformedExtents(const CBox& currentBox) const;
         CBox                                      transformBoxForDamage(const CBox& currentBox) const;
-        void                                      preWindowRender(CSurfacePassElement::SRenderData* renderData) const;
-        void                                      amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* motionBlurData) const;
+        void                                      preWindowRender(Render::CRenderingContext&, CSurfacePassElement::SRenderData* renderData) const;
+        void                                      amendTransformedRenderData(Render::CRenderingContext&, const CBox& currentBox, SMotionBlurData* motionBlurData) const;
         const UP<Render::CWindowTransformerList>& transformers() const;
 
       private:

--- a/src/desktop/view/window/WindowPresentation.cpp
+++ b/src/desktop/view/window/WindowPresentation.cpp
@@ -7,6 +7,7 @@
 #include "../../../layout/target/Target.hpp"
 #include "../../../managers/fullscreen/FullscreenController.hpp"
 #include "../../../output/Monitor.hpp"
+#include "../../../output/WorkspaceTransition.hpp"
 #include "../../../protocols/core/Compositor.hpp"
 #include "../../../render/decorations/CHyprBorderDecoration.hpp"
 #include "../../../render/decorations/CHyprDropShadowDecoration.hpp"
@@ -220,11 +221,12 @@ bool CWindowPresentation::opaque() const {
         return false;
 
     const auto PWORKSPACE = m_window.m_workspace;
+    const auto PMONITOR   = m_window.m_monitor;
 
     if (m_window.wlSurface()->small() && !m_window.wlSurface()->m_fillIgnoreSmall)
         return false;
 
-    if (PWORKSPACE && PWORKSPACE->m_alpha->value() != 1.f)
+    if (PMONITOR && PMONITOR->m_workspaceTransition->alphaValue(PWORKSPACE) != 1.F)
         return false;
 
     auto solitaryResource = m_window.getSolitaryResource();
@@ -391,16 +393,17 @@ void CWindowPresentation::onWorkspaceAnimUpdate() {
         return;
 
     Vector2D   offset;
-    const auto WINDOW_BOX = m_window.getFullWindowBoundingBox();
-    if (WORKSPACE->m_renderOffset->value().x != 0) {
-        const auto PROGRESS = WORKSPACE->m_renderOffset->value().x / MONITOR->m_size.x;
+    const auto WORKSPACEOFFSET = MONITOR->m_workspaceTransition->offsetValue(WORKSPACE);
+    const auto WINDOW_BOX      = m_window.getFullWindowBoundingBox();
+    if (WORKSPACEOFFSET.x != 0) {
+        const auto PROGRESS = WORKSPACEOFFSET.x / MONITOR->m_size.x;
 
         if (WINDOW_BOX.x < MONITOR->m_position.x)
             offset.x += (MONITOR->m_position.x - WINDOW_BOX.x) * PROGRESS;
         if (WINDOW_BOX.x + WINDOW_BOX.width > MONITOR->m_position.x + MONITOR->m_size.x)
             offset.x += (WINDOW_BOX.x + WINDOW_BOX.width - MONITOR->m_position.x - MONITOR->m_size.x) * PROGRESS;
-    } else if (WORKSPACE->m_renderOffset->value().y != 0) {
-        const auto PROGRESS = WORKSPACE->m_renderOffset->value().y / MONITOR->m_size.y;
+    } else if (WORKSPACEOFFSET.y != 0) {
+        const auto PROGRESS = WORKSPACEOFFSET.y / MONITOR->m_size.y;
 
         if (WINDOW_BOX.y < MONITOR->m_position.y)
             offset.y += (MONITOR->m_position.y - WINDOW_BOX.y) * PROGRESS;

--- a/src/errorOverlay/Overlay.cpp
+++ b/src/errorOverlay/Overlay.cpp
@@ -176,7 +176,7 @@ void COverlay::updateReservedArea(PHLMONITOR monitor) {
     }
 }
 
-void COverlay::draw() {
+void COverlay::draw(Render::CRenderingContext& context) {
     if (!m_isCreated || !m_queued.empty()) {
         if (!m_queued.empty())
             createQueued();
@@ -204,7 +204,7 @@ void COverlay::draw() {
         }
     }
 
-    const auto PMONITOR = g_pHyprRenderer->m_renderData.pMonitor;
+    const auto PMONITOR = context.sceneMonitor;
     if (!PMONITOR)
         return;
 
@@ -231,7 +231,7 @@ void COverlay::draw() {
     bgData.box   = barBox;
     bgData.color = CHyprColor(0.06, 0.06, 0.06, opacity);
     bgData.round = sc<int>(std::round(m_radius));
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(std::move(bgData)));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(std::move(bgData)));
 
     CBorderPassElement::SBorderData borderData;
     borderData.box        = barBox;
@@ -240,7 +240,7 @@ void COverlay::draw() {
     borderData.outerRound = sc<int>(std::round(m_radius));
     borderData.borderSize = 2;
     borderData.a          = opacity;
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(std::move(borderData)));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CBorderPassElement>(std::move(borderData)));
 
     if (m_textTexture) {
         CTexPassElement::SRenderData textData;
@@ -249,7 +249,7 @@ void COverlay::draw() {
         textData.a          = opacity;
         textData.clipRegion = CRegion(barBox.copy().expand(-1));
 
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(textData)));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(textData)));
     }
 }
 

--- a/src/errorOverlay/Overlay.hpp
+++ b/src/errorOverlay/Overlay.hpp
@@ -7,6 +7,10 @@
 #include "../helpers/AnimatedVariable.hpp"
 #include "../config/shared/complex/ComplexDataTypes.hpp"
 
+namespace Render {
+    class CRenderingContext;
+}
+
 namespace ErrorOverlay {
 
     namespace Colors {
@@ -24,7 +28,7 @@ namespace ErrorOverlay {
         void  queueCreate(std::string message, const CHyprColor& color);
         void  queueCreate(std::string message, const Config::CGradientValueData& gradient);
         void  queueError(std::string err);
-        void  draw();
+        void  draw(Render::CRenderingContext&);
         void  destroy();
 
         bool  active();

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -112,9 +112,9 @@ namespace Event {
                 } mouse;
 
                 struct {
-                    Cancellable<IKeyboard::SKeyEvent>        key;
-                    Event<SP<IKeyboard>, const std::string&> layout;
-                    Event<SP<CWLSurfaceResource>>            focus;
+                    Cancellable<IKeyboard::SKeyEvent, SP<IKeyboard>> key;
+                    Event<SP<IKeyboard>, const std::string&>         layout;
+                    Event<SP<CWLSurfaceResource>>                    focus;
                 } keyboard;
 
                 struct {

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -176,6 +176,7 @@ namespace Event {
                 Event<PHLWORKSPACE, PHLMONITOR> specialActive;
                 Event<PHLWORKSPACEREF>          created;
                 Event<PHLWORKSPACEREF>          removed;
+                Event<PHLWORKSPACEREF>          renamed;
             } workspace;
 
             struct {

--- a/src/helpers/cm/ColorManagement.cpp
+++ b/src/helpers/cm/ColorManagement.cpp
@@ -489,10 +489,9 @@ static RGBAColor tonemap(RGBAColor color, std::array<std::array<double, 3>, 3> d
     return color;
 }
 
-RGBAColor NColorManagement::convertColor(RGBAColor color, PImageDescription srcDesc, PImageDescription dstDesc) {
-    const auto settings =
-        g_pHyprRenderer->getCMSettings(srcDesc, dstDesc, nullptr, true, g_pHyprRenderer->m_renderData.pMonitor ? g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance : -1,
-                                       g_pHyprRenderer->m_renderData.pMonitor ? g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance : -1);
+RGBAColor NColorManagement::convertColor(const Render::CRenderingContext& context, RGBAColor color, PImageDescription srcDesc, PImageDescription dstDesc) {
+    const auto settings = g_pHyprRenderer->getCMSettings(context, srcDesc, dstDesc, nullptr, true, context.sceneMonitor ? context.sceneMonitor->m_sdrMinLuminance : -1,
+                                                         context.sceneMonitor ? context.sceneMonitor->m_sdrMaxLuminance : -1);
 
     color /= std::max(color.c.a, 0.001);
     color = toLinearRGB(color, srcDesc->value().transferFunction);
@@ -520,8 +519,8 @@ RGBAColor NColorManagement::convertColor(RGBAColor color, PImageDescription srcD
     return color;
 }
 
-CHyprColor NColorManagement::convertColor(const CHyprColor& color, PImageDescription srcDesc, PImageDescription dstDesc) {
-    const auto& converted = convertColor(RGBAColor{{.r = color.r, .g = color.g, .b = color.b, .a = color.a}}, srcDesc, dstDesc);
+CHyprColor NColorManagement::convertColor(const Render::CRenderingContext& context, const CHyprColor& color, PImageDescription srcDesc, PImageDescription dstDesc) {
+    const auto& converted = convertColor(context, RGBAColor{{.r = color.r, .g = color.g, .b = color.b, .a = color.a}}, srcDesc, dstDesc);
     return CHyprColor(converted.c.r, converted.c.g, converted.c.b, converted.c.a);
 }
 

--- a/src/helpers/cm/ColorManagement.hpp
+++ b/src/helpers/cm/ColorManagement.hpp
@@ -22,6 +22,7 @@
 #define HLG_MAX_LUMINANCE 1000.0f
 
 namespace Render {
+    class CRenderingContext;
     class ITexture;
 }
 
@@ -381,8 +382,8 @@ namespace NColorManagement {
 
     using PImageDescription = WP<const CImageDescription>;
 
-    RGBAColor         convertColor(RGBAColor color, PImageDescription srcDesc, PImageDescription dstDesc);
-    CHyprColor        convertColor(const CHyprColor& color, PImageDescription srcDesc, PImageDescription dstDesc);
+    RGBAColor         convertColor(const Render::CRenderingContext&, RGBAColor color, PImageDescription srcDesc, PImageDescription dstDesc);
+    CHyprColor        convertColor(const Render::CRenderingContext&, const CHyprColor& color, PImageDescription srcDesc, PImageDescription dstDesc);
 
     PImageDescription getDefaultImageDescription();
 

--- a/src/hyprtoolkit/embedded/EmbeddedToolkitManager.cpp
+++ b/src/hyprtoolkit/embedded/EmbeddedToolkitManager.cpp
@@ -1,0 +1,234 @@
+#include "EmbeddedToolkitManager.hpp"
+
+#include "../../Compositor.hpp"
+#include "../../debug/log/Logger.hpp"
+#include "../../managers/eventLoop/EventLoopManager.hpp"
+#include "../../render/OpenGL.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include <hyprutils/os/FileDescriptor.hpp>
+#include <hyprtoolkit/core/EmbeddedBackend.hpp>
+#include <hyprtoolkit/core/Timer.hpp>
+#include <hyprtoolkit/window/EmbeddedSurface.hpp>
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <wayland-server-core.h>
+
+using namespace Hyprutils::Memory;
+using namespace Hyprutils::OS;
+
+namespace EmbeddedToolkit {
+    class CEventLoop final : public Hyprtoolkit::IEventLoop {
+      public:
+        CEventLoop() {
+            if (!g_pCompositor || !g_pCompositor->m_wlEventLoop)
+                return;
+
+            m_idleFD     = CFileDescriptor{eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)};
+            m_idleSource = wl_event_loop_add_fd(
+                g_pCompositor->m_wlEventLoop, m_idleFD.get(), WL_EVENT_READABLE,
+                [](int fd, uint32_t mask, void* data) {
+                    if (mask & (WL_EVENT_READABLE | WL_EVENT_HANGUP | WL_EVENT_ERROR))
+                        sc<CEventLoop*>(data)->dispatchIdles(fd);
+                    return 0;
+                },
+                this);
+        }
+
+        virtual ~CEventLoop() override {
+            cancelPending();
+            if (m_idleSource)
+                wl_event_source_remove(m_idleSource);
+        }
+
+        virtual void addFd(int fd, std::function<void()>&& callback) override {
+            removeFd(fd);
+            if (!g_pCompositor || !g_pCompositor->m_wlEventLoop)
+                return;
+
+            auto source      = makeUnique<SFdSource>();
+            source->callback = std::move(callback);
+            source->source   = wl_event_loop_add_fd(
+                g_pCompositor->m_wlEventLoop, fd, WL_EVENT_READABLE,
+                [](int, uint32_t mask, void* data) {
+                    const auto SOURCE = sc<SFdSource*>(data);
+                    if (SOURCE && SOURCE->callback && (mask & (WL_EVENT_READABLE | WL_EVENT_HANGUP | WL_EVENT_ERROR)))
+                        SOURCE->callback();
+                    return 0;
+                },
+                source.get());
+
+            if (!source->source)
+                return;
+
+            m_fds.emplace(fd, std::move(source));
+        }
+
+        virtual void removeFd(int fd) override {
+            const auto IT = m_fds.find(fd);
+            if (IT == m_fds.end())
+                return;
+
+            if (IT->second->source)
+                wl_event_source_remove(IT->second->source);
+            m_fds.erase(IT);
+        }
+
+        virtual CAtomicSharedPointer<Hyprtoolkit::CTimer> addTimer(const Hyprtoolkit::TimerDuration&                                               timeout,
+                                                                   std::function<void(CAtomicSharedPointer<Hyprtoolkit::CTimer> self, void* data)> callback, void* data,
+                                                                   bool force) override {
+            auto timer = makeAtomicShared<Hyprtoolkit::CTimer>(timeout, std::move(callback), data, force);
+            if (!g_pEventLoopManager)
+                return timer;
+
+            auto hostTimer = makeShared<CEventLoopTimer>(
+                timeout,
+                [this, timer](SP<CEventLoopTimer> self, void*) {
+                    if (timer->cancelled()) {
+                        removeTimer(timer);
+                        return;
+                    }
+
+                    if (!timer->passed()) {
+                        self->updateTimeout(std::chrono::duration_cast<Time::steady_dur>(std::chrono::duration<float, std::milli>(std::max(timer->leftMs(), 1.F))));
+                        return;
+                    }
+
+                    timer->call(timer);
+                    removeTimer(timer);
+                },
+                nullptr);
+
+            m_timers.emplace_back(STimer{.timer = timer, .host = hostTimer});
+            g_pEventLoopManager->addTimer(hostTimer);
+            return timer;
+        }
+
+        virtual void addIdle(const std::function<void()>& callback) override {
+            if (m_stopping || !m_idleFD.isValid() || !m_idleSource)
+                return;
+
+            {
+                std::lock_guard<std::mutex> lock(m_idleMutex);
+                if (m_stopping)
+                    return;
+                m_idles.emplace_back(callback);
+            }
+
+            constexpr uint64_t WAKE   = 1;
+            ssize_t            result = 0;
+            do {
+                result = write(m_idleFD.get(), &WAKE, sizeof(WAKE));
+            } while (result < 0 && errno == EINTR);
+            if (result < 0 && errno != EAGAIN)
+                Log::logger->log(Log::ERR, "Failed to wake the embedded hyprtoolkit event loop: {}", strerror(errno));
+        }
+
+        virtual void cancelPending() override {
+            m_stopping = true;
+
+            for (const auto& [_, source] : m_fds) {
+                if (source->source)
+                    wl_event_source_remove(source->source);
+            }
+            m_fds.clear();
+
+            for (const auto& timer : m_timers)
+                timer.host->cancel();
+            m_timers.clear();
+
+            std::lock_guard<std::mutex> lock(m_idleMutex);
+            m_idles.clear();
+        }
+
+        virtual void enterLoop() override {
+            ;
+        }
+
+      private:
+        struct SFdSource {
+            wl_event_source*      source = nullptr;
+            std::function<void()> callback;
+        };
+
+        struct STimer {
+            CAtomicSharedPointer<Hyprtoolkit::CTimer> timer;
+            SP<CEventLoopTimer>                       host;
+        };
+
+        void removeTimer(const CAtomicSharedPointer<Hyprtoolkit::CTimer>& timer) {
+            std::erase_if(m_timers, [&timer](const auto& candidate) { return candidate.timer == timer; });
+        }
+
+        void dispatchIdles(int fd) {
+            uint64_t wakeCount = 0;
+            while (read(fd, &wakeCount, sizeof(wakeCount)) > 0) {
+                ;
+            }
+
+            std::vector<std::function<void()>> idles;
+            {
+                std::lock_guard<std::mutex> lock(m_idleMutex);
+                idles.swap(m_idles);
+            }
+
+            for (const auto& idle : idles) {
+                if (!m_stopping && idle)
+                    idle();
+            }
+        }
+
+        std::map<int, UP<SFdSource>>       m_fds;
+        std::vector<STimer>                m_timers;
+        CFileDescriptor                    m_idleFD;
+        wl_event_source*                   m_idleSource = nullptr;
+        std::mutex                         m_idleMutex;
+        std::vector<std::function<void()>> m_idles;
+        std::atomic<bool>                  m_stopping = false;
+    };
+
+    CManager::CManager() {
+        if (!Render::GL::g_pHyprOpenGL || !g_pEventLoopManager)
+            return;
+
+        Render::GL::g_pHyprOpenGL->makeEGLCurrent();
+        m_eventLoop = makeShared<CEventLoop>();
+
+        Hyprtoolkit::IEmbeddedBackend::SCreationData creationData;
+        creationData.eventLoop = m_eventLoop;
+        m_backend              = Hyprtoolkit::IEmbeddedBackend::create(creationData);
+        if (!m_backend)
+            Log::logger->log(Log::ERR, "Failed to initialize the embedded hyprtoolkit backend");
+    }
+
+    CManager::~CManager() {
+        if (!m_backend)
+            return;
+
+        if (Render::GL::g_pHyprOpenGL)
+            Render::GL::g_pHyprOpenGL->makeEGLCurrent();
+        m_backend->destroy();
+        m_backend.reset();
+        m_eventLoop.reset();
+    }
+
+    SP<Hyprtoolkit::IEmbeddedSurface> CManager::createSurface() const {
+        return m_backend ? m_backend->createSurface() : nullptr;
+    }
+
+    bool CManager::available() const {
+        return !!m_backend;
+    }
+
+    UP<CManager>& manager() {
+        static UP<CManager> mgr;
+        return mgr;
+    }
+}

--- a/src/hyprtoolkit/embedded/EmbeddedToolkitManager.hpp
+++ b/src/hyprtoolkit/embedded/EmbeddedToolkitManager.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "../../helpers/memory/Memory.hpp"
+
+namespace Hyprtoolkit {
+    class IEmbeddedBackend;
+    class IEmbeddedSurface;
+    class IEventLoop;
+}
+
+namespace EmbeddedToolkit {
+    class CManager {
+      public:
+        CManager();
+        ~CManager();
+
+        SP<Hyprtoolkit::IEmbeddedSurface> createSurface() const;
+        bool                              available() const;
+
+      private:
+        SP<Hyprtoolkit::IEventLoop>       m_eventLoop;
+        SP<Hyprtoolkit::IEmbeddedBackend> m_backend;
+    };
+
+    UP<CManager>& manager();
+}

--- a/src/keybinds/Manager.cpp
+++ b/src/keybinds/Manager.cpp
@@ -570,7 +570,7 @@ SBindResult CKeybindManager::processEvent(const SBindEventContext& context, cons
     if (!repeatHits.empty())
         scheduleRepeat(repeatHits, context, keyboard, pressedInput != nullptr);
 
-    if (!PROTO::inputCapture->isCaptured())
+    if (!PROTO::inputCapture->isCaptured() && !g_layoutManager->dragController()->target())
         g_layoutManager->dragController()->resetDragThresholdReached();
     aggregate.passEvent = !claimed;
     if (!claimed && INHIBITED) {

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -160,6 +160,7 @@ void CDragStateController::dragBegin(SP<ITarget> target, eMouseBindMode mode, st
     m_forcedGrabbedCorner = forcedEdge;
     m_exclusiveDeviceGrab = exclusiveDeviceGrab;
     m_grabbedCorner       = CORNER_NONE;
+    m_overriddenWorkspaceTarget.reset();
 
     const auto  DRAGGINGTARGET = m_target.lock();
     static auto PDRAGTHRESHOLD = CConfigValue<Config::INTEGER>("binds:drag_threshold");
@@ -251,6 +252,19 @@ bool CDragStateController::dragEnd() {
 
     if (!draggingTarget)
         return false;
+
+    // get middle point
+    Vector2D middle = draggingTarget->position().middle();
+
+    // and check its monitor
+    const auto PMONITOR = State::monitorState()->query().vec(middle).run();
+
+    if (m_overriddenWorkspaceTarget)
+        draggingTarget->assignToSpace(m_overriddenWorkspaceTarget->m_space);
+    else if (PMONITOR && PMONITOR->m_activeWorkspace) {
+        const auto WS = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;
+        draggingTarget->assignToSpace(WS->m_space);
+    }
 
     m_mouseMoveEventCount = 1;
 
@@ -473,16 +487,9 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
     if (TRACKMOTION)
         MOTIONWINDOW->effects().onPositionUpdate(previousFull, MOTIONWINDOW->getFullWindowBoundingBox(), Desktop::View::WINDOW_UPDATE_MOUSE);
 
-    // get middle point
-    Vector2D middle = DRAGGINGTARGET->position().middle();
-
-    // and check its monitor
-    const auto PMONITOR = State::monitorState()->query().vec(middle).run();
-
-    if (PMONITOR && PMONITOR->m_activeWorkspace && DRAGGINGTARGET->floating() /* If we're resizing a tiled target, don't do this */) {
-        const auto WS = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;
-        DRAGGINGTARGET->assignToSpace(WS->m_space);
-    }
-
     DRAGGINGTARGET->damageEntire();
+}
+
+void CDragStateController::overrideDragWindowTargetWS(PHLWORKSPACE ws) {
+    m_overriddenWorkspaceTarget = ws;
 }

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -18,6 +18,7 @@
 #include "../../state/MonitorState.hpp"
 
 #include <string_view>
+#include <hyprutils/utils/ScopeGuard.hpp>
 
 using namespace Layout;
 using namespace Layout::Supplementary;
@@ -253,6 +254,8 @@ bool CDragStateController::dragEnd() {
     if (!draggingTarget)
         return false;
 
+    Hyprutils::Utils::CScopeGuard notifyEnded([this] { m_events.ended.emit(); });
+
     // get middle point
     Vector2D middle = draggingTarget->position().middle();
 
@@ -362,6 +365,7 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
         m_dragThresholdReached = true;
         if (updateDragWindow())
             return;
+        m_events.motion.emit();
     }
 
     static auto TIMER = std::chrono::high_resolution_clock::now(), MSTIMER = TIMER;
@@ -488,6 +492,7 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
         MOTIONWINDOW->effects().onPositionUpdate(previousFull, MOTIONWINDOW->getFullWindowBoundingBox(), Desktop::View::WINDOW_UPDATE_MOUSE);
 
     DRAGGINGTARGET->damageEntire();
+    m_events.motion.emit();
 }
 
 void CDragStateController::overrideDragWindowTargetWS(PHLWORKSPACE ws) {

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -14,6 +14,7 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../desktop/state/WindowState.hpp"
 #include "../../desktop/view/Group.hpp"
+#include "../../overview/Overview.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../state/MonitorState.hpp"
 
@@ -292,7 +293,10 @@ bool CDragStateController::dragEnd() {
         const auto DRAGGING_WINDOW = draggingTarget->window();
 
         const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-        PHLWINDOW  pWindow =
+        const auto WORKSPACE   = Overview::overview()->inputWorkspace();
+        PHLWINDOW  pWindow     = WORKSPACE ?
+            Desktop::viewState()->hitTest().windowAtWorkspace(MOUSECOORDS, WORKSPACE,
+                                                              Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING, DRAGGING_WINDOW) :
             Desktop::viewState()->hitTest().windowAt(MOUSECOORDS, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING, DRAGGING_WINDOW);
 
         if (pWindow) {
@@ -497,4 +501,8 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
 
 void CDragStateController::overrideDragWindowTargetWS(PHLWORKSPACE ws) {
     m_overriddenWorkspaceTarget = ws;
+}
+
+void CDragStateController::clearDragWindowTargetWS() {
+    m_overriddenWorkspaceTarget.reset();
 }

--- a/src/layout/supplementary/DragController.hpp
+++ b/src/layout/supplementary/DragController.hpp
@@ -31,6 +31,7 @@ namespace Layout::Supplementary {
         bool           draggingTiled() const;
         bool           exclusiveDeviceGrab() const;
         void           overrideDragWindowTargetWS(PHLWORKSPACE ws);
+        void           clearDragWindowTargetWS();
 
         /*
             Called to try to pick up window for dragging.

--- a/src/layout/supplementary/DragController.hpp
+++ b/src/layout/supplementary/DragController.hpp
@@ -2,6 +2,7 @@
 
 #include "../target/Target.hpp"
 #include "../../managers/input/InputManager.hpp"
+#include "desktop/DesktopTypes.hpp"
 
 #include <optional>
 
@@ -28,6 +29,7 @@ namespace Layout::Supplementary {
         void           resetDragThresholdReached();
         bool           draggingTiled() const;
         bool           exclusiveDeviceGrab() const;
+        void           overrideDragWindowTargetWS(PHLWORKSPACE ws);
 
         /*
             Called to try to pick up window for dragging.
@@ -56,5 +58,6 @@ namespace Layout::Supplementary {
         Vector2D                           m_draggingWindowOriginalFloatSize;
         Layout::eRectCorner                m_grabbedCorner = sc<Layout::eRectCorner>(0) /* CORNER_NONE */;
         std::optional<Layout::eRectCorner> m_forcedGrabbedCorner;
+        PHLWORKSPACEREF                    m_overriddenWorkspaceTarget;
     };
 };

--- a/src/layout/supplementary/DragController.hpp
+++ b/src/layout/supplementary/DragController.hpp
@@ -2,6 +2,7 @@
 
 #include "../target/Target.hpp"
 #include "../../managers/input/InputManager.hpp"
+#include "../../helpers/signal/Signal.hpp"
 #include "desktop/DesktopTypes.hpp"
 
 #include <optional>
@@ -39,6 +40,11 @@ namespace Layout::Supplementary {
         bool        updateDragWindow();
 
         SP<ITarget> target() const;
+
+        struct {
+            CSignalT<> motion;
+            CSignalT<> ended;
+        } m_events;
 
       private:
         WP<ITarget>                        m_target;

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -31,6 +31,62 @@ static bool surfaceInTree(SP<CWLSurfaceResource> root, SP<CWLSurfaceResource> su
     return !!root->findFirstPreorder([surface](SP<CWLSurfaceResource> candidate) { return candidate == surface; });
 }
 
+void CKeyboardEventHandlerStack::push(WP<IKeyboardEventHandler> handler) {
+    if (handler.expired())
+        return;
+
+    std::erase_if(m_handlers, [&handler](const auto& candidate) { return candidate.expired() || candidate == handler; });
+    m_handlers.emplace_back(std::move(handler));
+}
+
+bool CKeyboardEventHandlerStack::remove(WP<IKeyboardEventHandler> handler) {
+    bool removed = false;
+    std::erase_if(m_handlers, [&handler, &removed](const auto& candidate) {
+        if (candidate == handler)
+            removed = true;
+        return candidate.expired() || candidate == handler;
+    });
+    return removed;
+}
+
+bool CKeyboardEventHandlerStack::dispatch(const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard, bool allowNewPress) {
+    const auto OWNED = std::ranges::find_if(m_ownedKeys, [&event, &keyboard](const auto& key) { return key.keyboard == keyboard && key.keycode == event.keycode; });
+
+    if (OWNED != m_ownedKeys.end()) {
+        const auto HANDLER = OWNED->handler;
+        if (event.state == WL_KEYBOARD_KEY_STATE_RELEASED)
+            m_ownedKeys.erase(OWNED);
+
+        if (!HANDLER.expired())
+            HANDLER->onKeyboardKey(event, keyboard);
+        return true;
+    }
+
+    if (!allowNewPress || event.state != WL_KEYBOARD_KEY_STATE_PRESSED)
+        return false;
+
+    pruneHandlers();
+    if (m_handlers.empty())
+        return false;
+
+    const auto HANDLER = m_handlers.back();
+    m_ownedKeys.emplace_back(SOwnedKey{
+        .keyboard = keyboard,
+        .keycode  = event.keycode,
+        .handler  = HANDLER,
+    });
+    HANDLER->onKeyboardKey(event, keyboard);
+    return true;
+}
+
+void CKeyboardEventHandlerStack::onKeyboardRemoved(SP<IKeyboard> keyboard) {
+    std::erase_if(m_ownedKeys, [&keyboard](const auto& key) { return key.keyboard.expired() || key.keyboard == keyboard; });
+}
+
+void CKeyboardEventHandlerStack::pruneHandlers() {
+    std::erase_if(m_handlers, [](const auto& handler) { return handler.expired(); });
+}
+
 CSeatManager::CSeatManager() {
     m_listeners.newSeatResource = PROTO::seat->m_events.newSeatResource.listen([this](const auto& resource) { onNewSeatResource(resource); });
 }

--- a/src/managers/SeatManager.hpp
+++ b/src/managers/SeatManager.hpp
@@ -5,6 +5,7 @@
 #include "../helpers/signal/Signal.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../protocols/types/DataDevice.hpp"
+#include "../devices/IKeyboard.hpp"
 #include <vector>
 
 constexpr size_t MAX_SERIAL_STORE_LEN = 100;
@@ -12,7 +13,34 @@ constexpr size_t MAX_SERIAL_STORE_LEN = 100;
 class CWLSurfaceResource;
 class CWLSeatResource;
 class IPointer;
-class IKeyboard;
+
+class IKeyboardEventHandler {
+  public:
+    virtual ~IKeyboardEventHandler() = default;
+
+    virtual void onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard) = 0;
+};
+
+class CKeyboardEventHandlerStack {
+  public:
+    void push(WP<IKeyboardEventHandler> handler);
+    bool remove(WP<IKeyboardEventHandler> handler);
+
+    bool dispatch(const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard, bool allowNewPress);
+    void onKeyboardRemoved(SP<IKeyboard> keyboard);
+
+  private:
+    struct SOwnedKey {
+        WP<IKeyboard>             keyboard;
+        uint32_t                  keycode = 0;
+        WP<IKeyboardEventHandler> handler;
+    };
+
+    void                                   pruneHandlers();
+
+    std::vector<WP<IKeyboardEventHandler>> m_handlers;
+    std::vector<SOwnedKey>                 m_ownedKeys;
+};
 
 /*
     A seat grab defines a restricted set of surfaces that can be focused.
@@ -46,35 +74,37 @@ class CSeatManager {
   public:
     CSeatManager();
 
-    void     updateCapabilities(uint32_t capabilities); // in IHID caps
+    void                       updateCapabilities(uint32_t capabilities); // in IHID caps
 
-    void     setMouse(SP<IPointer> mouse);
-    void     setKeyboard(SP<IKeyboard> keeb);
-    void     updateActiveKeyboardData(); // updates the clients with the keymap and repeat info
+    void                       setMouse(SP<IPointer> mouse);
+    void                       setKeyboard(SP<IKeyboard> keeb);
+    void                       updateActiveKeyboardData(); // updates the clients with the keymap and repeat info
 
-    void     setKeyboardFocus(SP<CWLSurfaceResource> surf);
-    void     sendKeyboardKey(uint32_t timeMs, uint32_t key, wl_keyboard_key_state state);
-    void     sendKeyboardMods(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
+    void                       setKeyboardFocus(SP<CWLSurfaceResource> surf);
+    void                       sendKeyboardKey(uint32_t timeMs, uint32_t key, wl_keyboard_key_state state);
+    void                       sendKeyboardMods(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
 
-    void     setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& local);
-    void     sendPointerMotion(uint32_t timeMs, const Vector2D& local);
-    void     sendPointerButton(uint32_t timeMs, uint32_t key, wl_pointer_button_state state);
-    void     sendPointerFrame();
-    void     sendPointerFrame(WP<CWLSeatResource> pResource);
-    void     sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double value, int32_t discrete, int32_t value120, wl_pointer_axis_source source,
-                             wl_pointer_axis_relative_direction relative);
+    CKeyboardEventHandlerStack m_keyboardEventHandlers;
 
-    void     sendTouchDown(SP<CWLSurfaceResource> surf, uint32_t timeMs, int32_t id, const Vector2D& local);
-    void     sendTouchUp(uint32_t timeMs, int32_t id);
-    void     sendTouchMotion(uint32_t timeMs, int32_t id, const Vector2D& local);
-    void     sendTouchFrame();
-    void     sendTouchCancel();
-    void     sendTouchShape(int32_t id, const Vector2D& shape);
-    void     sendTouchOrientation(int32_t id, double angle);
+    void                       setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& local);
+    void                       sendPointerMotion(uint32_t timeMs, const Vector2D& local);
+    void                       sendPointerButton(uint32_t timeMs, uint32_t key, wl_pointer_button_state state);
+    void                       sendPointerFrame();
+    void                       sendPointerFrame(WP<CWLSeatResource> pResource);
+    void                       sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double value, int32_t discrete, int32_t value120, wl_pointer_axis_source source,
+                                               wl_pointer_axis_relative_direction relative);
 
-    void     resendEnterEvents();
+    void                       sendTouchDown(SP<CWLSurfaceResource> surf, uint32_t timeMs, int32_t id, const Vector2D& local);
+    void                       sendTouchUp(uint32_t timeMs, int32_t id);
+    void                       sendTouchMotion(uint32_t timeMs, int32_t id, const Vector2D& local);
+    void                       sendTouchFrame();
+    void                       sendTouchCancel();
+    void                       sendTouchShape(int32_t id, const Vector2D& shape);
+    void                       sendTouchOrientation(int32_t id, double angle);
 
-    uint32_t nextSerial(SP<CWLSeatResource> seatResource, bool enter = false);
+    void                       resendEnterEvents();
+
+    uint32_t                   nextSerial(SP<CWLSeatResource> seatResource, bool enter = false);
     // pops the serial if it was valid, meaning it is consumed.
     bool                serialValid(SP<CWLSeatResource> seatResource, uint32_t serial, bool erase = true);
     void                recordPointerButtonSerial(SP<CWLSeatResource> seatResource, uint32_t serial, SP<CWLSurfaceResource> surface, uint32_t button);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1546,6 +1546,7 @@ void CInputManager::destroyKeyboard(SP<IKeyboard> pKeyboard) {
     Log::logger->log(Log::DEBUG, "Keyboard at {:x} removed", rc<uintptr_t>(pKeyboard.get()));
 
     Keybinds::mgr()->onDeviceRemoved(pKeyboard);
+    g_pSeatManager->m_keyboardEventHandlers.onKeyboardRemoved(pKeyboard);
     std::erase_if(m_keyboards, [pKeyboard](const auto& other) { return other == pKeyboard; });
 
     if (!m_keyboards.empty()) {
@@ -1721,48 +1722,52 @@ void CInputManager::onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboar
     if (!DISALLOWACTION)
         passEvent = Keybinds::mgr()->onKeyEvent(event, pKeyboard) && !PROTO::inputCapture->isCaptured();
 
-    if (passEvent) {
-        auto state   = event.state;
-        auto pressed = state == WL_KEYBOARD_KEY_STATE_PRESSED;
+    if (g_pSeatManager->m_keyboardEventHandlers.dispatch(event, pKeyboard, passEvent))
+        return;
 
-        // use merged keys states when sending to ime or when sending to seat with no ime
-        // if passing from ime, send keys directly without merging
-        if (USEIME || !HASIME) {
-            const auto ANYPRESSED = shareKeyFromAllKBs(event.keycode, pressed);
+    if (!passEvent)
+        return;
 
-            // do not turn released event into pressed event (when one keyboard has a key released but some
-            // other keyboard still has the key pressed)
-            // maybe we should keep track of pressed keys for inputs like m_pressed for seat outputs below,
-            // to avoid duplicate pressed events, but this should work well enough
-            if (!pressed && ANYPRESSED)
-                return;
+    auto state   = event.state;
+    auto pressed = state == WL_KEYBOARD_KEY_STATE_PRESSED;
 
-            pressed = ANYPRESSED;
-            state   = pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED;
-        }
+    // use merged keys states when sending to ime or when sending to seat with no ime
+    // if passing from ime, send keys directly without merging
+    if (USEIME || !HASIME) {
+        const auto ANYPRESSED = shareKeyFromAllKBs(event.keycode, pressed);
 
-        if (USEIME) {
-            IME->setKeyboard(pKeyboard);
-            IME->sendKey(event.timeMs, event.keycode, state);
-        } else {
-            const auto CONTAINS = std::ranges::contains(m_pressed, event.keycode);
+        // do not turn released event into pressed event (when one keyboard has a key released but some
+        // other keyboard still has the key pressed)
+        // maybe we should keep track of pressed keys for inputs like m_pressed for seat outputs below,
+        // to avoid duplicate pressed events, but this should work well enough
+        if (!pressed && ANYPRESSED)
+            return;
 
-            if (CONTAINS && pressed)
-                return;
-            if (!CONTAINS && !pressed)
-                return;
-
-            if (CONTAINS)
-                std::erase(m_pressed, event.keycode);
-            else
-                m_pressed.emplace_back(event.keycode);
-
-            g_pSeatManager->setKeyboard(pKeyboard);
-            g_pSeatManager->sendKeyboardKey(event.timeMs, event.keycode, state);
-        }
-
-        updateKeyboardsLeds(pKeyboard);
+        pressed = ANYPRESSED;
+        state   = pressed ? WL_KEYBOARD_KEY_STATE_PRESSED : WL_KEYBOARD_KEY_STATE_RELEASED;
     }
+
+    if (USEIME) {
+        IME->setKeyboard(pKeyboard);
+        IME->sendKey(event.timeMs, event.keycode, state);
+    } else {
+        const auto CONTAINS = std::ranges::contains(m_pressed, event.keycode);
+
+        if (CONTAINS && pressed)
+            return;
+        if (!CONTAINS && !pressed)
+            return;
+
+        if (CONTAINS)
+            std::erase(m_pressed, event.keycode);
+        else
+            m_pressed.emplace_back(event.keycode);
+
+        g_pSeatManager->setKeyboard(pKeyboard);
+        g_pSeatManager->sendKeyboardKey(event.timeMs, event.keycode, state);
+    }
+
+    updateKeyboardsLeds(pKeyboard);
 }
 
 void CInputManager::onKeyboardMod(SP<IKeyboard> pKeyboard) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1704,7 +1704,7 @@ void CInputManager::onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboar
     const bool           USEIME = HASIME && !DISALLOWACTION;
 
     Event::SCallbackInfo info;
-    Event::bus()->m_events.input.keyboard.key.emit(event, info);
+    Event::bus()->m_events.input.keyboard.key.emit(event, pKeyboard, info);
     if (info.cancelled)
         return;
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1710,7 +1710,7 @@ void CInputManager::onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboar
     const bool           USEIME = HASIME && !DISALLOWACTION;
 
     Event::SCallbackInfo info;
-    Event::bus()->m_events.input.keyboard.key.emit(event, info);
+    Event::bus()->m_events.input.keyboard.key.emit(event, pKeyboard, info);
     if (info.cancelled)
         return;
 

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -6,6 +6,7 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../config/ConfigValue.hpp"
 #include "../../output/Monitor.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include "../../state/MonitorState.hpp"
 #include "../../devices/ITouch.hpp"
 #include "../../event/EventBus.hpp"
@@ -56,7 +57,7 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
         // TODO: Don't swipe if you touched a floating window.
     } else if (*PSWIPETOUCH && (m_foundLSToFocus.expired() || m_foundLSToFocus->m_layer <= 1) && !g_pSessionLockManager->isSessionLocked()) {
         const auto   PWORKSPACE  = PMONITOR->m_activeWorkspace;
-        const auto   STYLE       = PWORKSPACE->m_renderOffset->getStyle();
+        const auto   STYLE       = PMONITOR->m_workspaceTransition->style(PWORKSPACE);
         const bool   VERTANIMS   = STYLE == "slidevert" || STYLE.starts_with("slidefadevert");
         const double TARGETLEFT  = ((VERTANIMS ? gapsOut.m_top : gapsOut.m_left) + *PBORDERSIZE) / (VERTANIMS ? PMONITOR->m_size.y : PMONITOR->m_size.x);
         const double TARGETRIGHT = 1 - (((VERTANIMS ? gapsOut.m_bottom : gapsOut.m_right) + *PBORDERSIZE) / (VERTANIMS ? PMONITOR->m_size.y : PMONITOR->m_size.x));
@@ -157,7 +158,12 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
         if (e.touchID != g_pUnifiedWorkspaceSwipe->m_touchID)
             return;
 
-        const auto  ANIMSTYLE     = g_pUnifiedWorkspaceSwipe->m_workspaceBegin->m_renderOffset->getStyle();
+        if (!g_pUnifiedWorkspaceSwipe->m_monitor) {
+            g_pUnifiedWorkspaceSwipe->cancel();
+            return;
+        }
+
+        const auto  ANIMSTYLE     = g_pUnifiedWorkspaceSwipe->m_monitor->m_workspaceTransition->style(g_pUnifiedWorkspaceSwipe->m_workspaceBegin);
         const bool  VERTANIMS     = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
         static auto PSWIPEINVR    = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_touch_invert");
         static auto PSWIPEDIST    = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_distance");

--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
@@ -8,6 +8,43 @@
 #include "../../layout/space/Space.hpp"
 #include "../../layout/algorithm/Algorithm.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
+#include "../../output/WorkspaceTransition.hpp"
+
+void CUnifiedWorkspaceSwipeGesture::setForceRendering(PHLWORKSPACE workspace, bool force) {
+    if (!workspace)
+        return;
+
+    if (const auto MONITOR = workspace->m_monitor.lock(); MONITOR)
+        MONITOR->m_workspaceTransition->setForceRendering(workspace, force);
+
+    if (force) {
+        if (!std::ranges::contains(m_forcedWorkspaces, workspace))
+            m_forcedWorkspaces.emplace_back(workspace);
+    } else
+        std::erase(m_forcedWorkspaces, workspace);
+}
+
+void CUnifiedWorkspaceSwipeGesture::clearForcedWorkspaces() {
+    const auto FORCEDWORKSPACES = std::move(m_forcedWorkspaces);
+    m_forcedWorkspaces.clear();
+
+    for (const auto& weak : FORCEDWORKSPACES) {
+        const auto WORKSPACE = weak.lock();
+        const auto MONITOR   = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
+        if (!MONITOR)
+            continue;
+
+        MONITOR->m_workspaceTransition->setForceRendering(WORKSPACE, false);
+        g_pHyprRenderer->damageMonitor(MONITOR);
+    }
+}
+
+void CUnifiedWorkspaceSwipeGesture::cancel() {
+    clearForcedWorkspaces();
+    m_workspaceBegin.reset();
+    m_monitor.reset();
+    m_initialDirection = 0;
+}
 
 bool CUnifiedWorkspaceSwipeGesture::isGestureInProgress() {
     return !!m_workspaceBegin;
@@ -17,13 +54,16 @@ void CUnifiedWorkspaceSwipeGesture::begin() {
     if (isGestureInProgress())
         return;
 
-    const auto PWORKSPACE = Desktop::focusState()->monitor()->m_activeWorkspace;
+    m_monitor = Desktop::focusState()->monitor();
+    if (!m_monitor)
+        return;
+
+    const auto PWORKSPACE = m_monitor->m_activeWorkspace;
 
     Log::logger->log(Log::DEBUG, "CUnifiedWorkspaceSwipeGesture::begin: Starting a swipe from {}", PWORKSPACE->m_name);
 
     m_workspaceBegin = PWORKSPACE;
     m_delta          = 0;
-    m_monitor        = Desktop::focusState()->monitor();
     m_avgSpeed       = 0;
     m_speedPoints    = 0;
 
@@ -31,7 +71,7 @@ void CUnifiedWorkspaceSwipeGesture::begin() {
     const auto INTERNAL_FS_MODE = FSWINDOW ? Fullscreen::controller()->getFullscreenModes(FSWINDOW).internal : Fullscreen::FSMODE_NONE;
 
     if (INTERNAL_FS_MODE == Fullscreen::FSMODE_FULLSCREEN) {
-        for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
+        for (auto const& ls : m_monitor->m_layerSurfaceLayers[2]) {
             *ls->alpha()[Desktop::View::LS_ALPHA_FADE] = 1.F;
         }
     }
@@ -41,6 +81,11 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
     if (!isGestureInProgress())
         return;
 
+    if (!m_monitor || m_workspaceBegin->m_monitor != m_monitor) {
+        cancel();
+        return;
+    }
+
     static auto  PSWIPEDIST             = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_distance");
     static auto  PSWIPENEW              = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_create_new");
     static auto  PSWIPEDIRLOCK          = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_direction_lock");
@@ -49,13 +94,14 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
     static auto  PSWIPEUSER             = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_use_r");
     static auto  PWORKSPACEGAP          = CConfigValue<Config::INTEGER>("general:gaps_workspaces");
 
-    const auto   SWIPEDISTANCE = std::clamp(*PSWIPEDIST, sc<int64_t>(1LL), sc<int64_t>(UINT32_MAX));
-    const auto   XDISTANCE     = m_monitor->m_size.x + *PWORKSPACEGAP;
-    const auto   YDISTANCE     = m_monitor->m_size.y + *PWORKSPACEGAP;
-    const auto   ANIMSTYLE     = m_workspaceBegin->m_renderOffset->getStyle();
-    const bool   VERTANIMS     = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
-    const double d             = m_delta - delta;
-    m_delta                    = delta;
+    auto&        WORKSPACETRANSITION = *m_monitor->m_workspaceTransition;
+    const auto   SWIPEDISTANCE       = std::clamp(*PSWIPEDIST, sc<int64_t>(1LL), sc<int64_t>(UINT32_MAX));
+    const auto   XDISTANCE           = m_monitor->m_size.x + *PWORKSPACEGAP;
+    const auto   YDISTANCE           = m_monitor->m_size.y + *PWORKSPACEGAP;
+    const auto   ANIMSTYLE           = WORKSPACETRANSITION.style(m_workspaceBegin);
+    const bool   VERTANIMS           = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
+    const double d                   = m_delta - delta;
+    m_delta                          = delta;
 
     m_avgSpeed = (m_avgSpeed * m_speedPoints + abs(d)) / (m_speedPoints + 1);
     m_speedPoints++;
@@ -64,11 +110,11 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
     auto workspaceIDRight = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r+1" : "m+1")).id;
 
     if ((workspaceIDLeft == WORKSPACE_INVALID || workspaceIDRight == WORKSPACE_INVALID || workspaceIDLeft == m_workspaceBegin->m_id) && !*PSWIPENEW) {
-        m_workspaceBegin = nullptr; // invalidate the swipe
+        cancel();
         return;
     }
 
-    m_workspaceBegin->m_forceRendering = true;
+    setForceRendering(m_workspaceBegin, true);
 
     m_delta = std::clamp(m_delta, sc<double>(-SWIPEDISTANCE), sc<double>(SWIPEDISTANCE));
 
@@ -77,7 +123,7 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
 
         m_delta = 0;
         g_pHyprRenderer->damageMonitor(m_monitor.lock());
-        m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, 0.0));
+        WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(0.0, 0.0));
         return;
     }
 
@@ -96,9 +142,9 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
                 g_pHyprRenderer->damageMonitor(m_monitor.lock());
 
                 if (VERTANIMS)
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
+                    WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
                 else
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+                    WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
 
                 m_workspaceBegin->updateWindowDecos();
                 return;
@@ -107,24 +153,24 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
             return;
         }
 
-        PWORKSPACE->m_forceRendering = true;
-        PWORKSPACE->m_alpha->setValueAndWarp(1.f);
+        setForceRendering(PWORKSPACE, true);
+        WORKSPACETRANSITION.ensure(PWORKSPACE).alpha->setValueAndWarp(1.f);
 
         if (workspaceIDLeft != workspaceIDRight && workspaceIDRight != m_workspaceBegin->m_id) {
             const auto PWORKSPACER = State::workspaceState()->query().id(workspaceIDRight).run();
 
             if (PWORKSPACER) {
-                PWORKSPACER->m_forceRendering = false;
-                PWORKSPACER->m_alpha->setValueAndWarp(0.f);
+                setForceRendering(PWORKSPACER, false);
+                WORKSPACETRANSITION.ensure(PWORKSPACER).alpha->setValueAndWarp(0.f);
             }
         }
 
         if (VERTANIMS) {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE - YDISTANCE));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
+            WORKSPACETRANSITION.ensure(PWORKSPACE).offset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE - YDISTANCE));
+            WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
         } else {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE - XDISTANCE, 0.0));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+            WORKSPACETRANSITION.ensure(PWORKSPACE).offset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE - XDISTANCE, 0.0));
+            WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
         }
 
         PWORKSPACE->updateWindowDecos();
@@ -136,9 +182,9 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
                 g_pHyprRenderer->damageMonitor(m_monitor.lock());
 
                 if (VERTANIMS)
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
+                    WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
                 else
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+                    WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
 
                 m_workspaceBegin->updateWindowDecos();
                 return;
@@ -147,24 +193,24 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
             return;
         }
 
-        PWORKSPACE->m_forceRendering = true;
-        PWORKSPACE->m_alpha->setValueAndWarp(1.f);
+        setForceRendering(PWORKSPACE, true);
+        WORKSPACETRANSITION.ensure(PWORKSPACE).alpha->setValueAndWarp(1.f);
 
         if (workspaceIDLeft != workspaceIDRight && workspaceIDLeft != m_workspaceBegin->m_id) {
             const auto PWORKSPACEL = State::workspaceState()->query().id(workspaceIDLeft).run();
 
             if (PWORKSPACEL) {
-                PWORKSPACEL->m_forceRendering = false;
-                PWORKSPACEL->m_alpha->setValueAndWarp(0.f);
+                setForceRendering(PWORKSPACEL, false);
+                WORKSPACETRANSITION.ensure(PWORKSPACEL).alpha->setValueAndWarp(0.f);
             }
         }
 
         if (VERTANIMS) {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE + YDISTANCE));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
+            WORKSPACETRANSITION.ensure(PWORKSPACE).offset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE + YDISTANCE));
+            WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
         } else {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE + XDISTANCE, 0.0));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+            WORKSPACETRANSITION.ensure(PWORKSPACE).offset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE + XDISTANCE, 0.0));
+            WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
         }
 
         PWORKSPACE->updateWindowDecos();
@@ -186,14 +232,20 @@ void CUnifiedWorkspaceSwipeGesture::end() {
     if (!isGestureInProgress())
         return;
 
-    static auto PSWIPEPERC    = CConfigValue<Config::FLOAT>("gestures:workspace_swipe_cancel_ratio");
-    static auto PSWIPEDIST    = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_distance");
-    static auto PSWIPEFORC    = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_min_speed_to_force");
-    static auto PSWIPENEW     = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_create_new");
-    static auto PSWIPEUSER    = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_use_r");
-    static auto PWORKSPACEGAP = CConfigValue<Config::INTEGER>("general:gaps_workspaces");
-    const auto  ANIMSTYLE     = m_workspaceBegin->m_renderOffset->getStyle();
-    const bool  VERTANIMS     = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
+    if (!m_monitor || m_workspaceBegin->m_monitor != m_monitor) {
+        cancel();
+        return;
+    }
+
+    static auto PSWIPEPERC          = CConfigValue<Config::FLOAT>("gestures:workspace_swipe_cancel_ratio");
+    static auto PSWIPEDIST          = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_distance");
+    static auto PSWIPEFORC          = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_min_speed_to_force");
+    static auto PSWIPENEW           = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_create_new");
+    static auto PSWIPEUSER          = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_use_r");
+    static auto PWORKSPACEGAP       = CConfigValue<Config::INTEGER>("general:gaps_workspaces");
+    auto&       WORKSPACETRANSITION = *m_monitor->m_workspaceTransition;
+    const auto  ANIMSTYLE           = WORKSPACETRANSITION.style(m_workspaceBegin);
+    const bool  VERTANIMS           = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
 
     // commit
     auto       workspaceIDLeft  = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r-1" : "m-1")).id;
@@ -208,7 +260,7 @@ void CUnifiedWorkspaceSwipeGesture::end() {
     auto         PWORKSPACER = State::workspaceState()->query().id(workspaceIDRight).run(); // not guaranteed if PSWIPENEW || PSWIPENUMBER
     auto         PWORKSPACEL = State::workspaceState()->query().id(workspaceIDLeft).run();  // not guaranteed if PSWIPENUMBER
 
-    const auto   RENDEROFFSETMIDDLE = m_workspaceBegin->m_renderOffset->value();
+    const auto   RENDEROFFSETMIDDLE = WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->value();
     const auto   XDISTANCE          = m_monitor->m_size.x + *PWORKSPACEGAP;
     const auto   YDISTANCE          = m_monitor->m_size.y + *PWORKSPACEGAP;
 
@@ -218,35 +270,35 @@ void CUnifiedWorkspaceSwipeGesture::end() {
         // revert
         if (abs(m_delta) < 2) {
             if (PWORKSPACEL)
-                PWORKSPACEL->m_renderOffset->setValueAndWarp(Vector2D(0, 0));
+                WORKSPACETRANSITION.ensure(PWORKSPACEL).offset->setValueAndWarp(Vector2D(0, 0));
             if (PWORKSPACER)
-                PWORKSPACER->m_renderOffset->setValueAndWarp(Vector2D(0, 0));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0, 0));
+                WORKSPACETRANSITION.ensure(PWORKSPACER).offset->setValueAndWarp(Vector2D(0, 0));
+            WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValueAndWarp(Vector2D(0, 0));
         } else {
             if (m_delta < 0) {
                 // to left
 
                 if (PWORKSPACEL) {
                     if (VERTANIMS)
-                        *PWORKSPACEL->m_renderOffset = Vector2D{0.0, -YDISTANCE};
+                        *WORKSPACETRANSITION.ensure(PWORKSPACEL).offset = Vector2D{0.0, -YDISTANCE};
                     else
-                        *PWORKSPACEL->m_renderOffset = Vector2D{-XDISTANCE, 0.0};
+                        *WORKSPACETRANSITION.ensure(PWORKSPACEL).offset = Vector2D{-XDISTANCE, 0.0};
                 }
             } else if (PWORKSPACER) {
                 // to right
                 if (VERTANIMS)
-                    *PWORKSPACER->m_renderOffset = Vector2D{0.0, YDISTANCE};
+                    *WORKSPACETRANSITION.ensure(PWORKSPACER).offset = Vector2D{0.0, YDISTANCE};
                 else
-                    *PWORKSPACER->m_renderOffset = Vector2D{XDISTANCE, 0.0};
+                    *WORKSPACETRANSITION.ensure(PWORKSPACER).offset = Vector2D{XDISTANCE, 0.0};
             }
 
-            *m_workspaceBegin->m_renderOffset = Vector2D();
+            *WORKSPACETRANSITION.ensure(m_workspaceBegin).offset = Vector2D();
         }
 
         pSwitchedTo = m_workspaceBegin;
     } else if (m_delta < 0) {
         // switch to left
-        const auto RENDEROFFSET = PWORKSPACEL ? PWORKSPACEL->m_renderOffset->value() : Vector2D();
+        const auto RENDEROFFSET = PWORKSPACEL ? WORKSPACETRANSITION.ensure(PWORKSPACEL).offset->value() : Vector2D();
 
         if (PWORKSPACEL)
             m_monitor->changeWorkspace(workspaceIDLeft);
@@ -255,15 +307,15 @@ void CUnifiedWorkspaceSwipeGesture::end() {
             PWORKSPACEL = State::workspaceState()->query().id(workspaceIDLeft).run();
         }
 
-        PWORKSPACEL->m_renderOffset->setValue(RENDEROFFSET);
-        PWORKSPACEL->m_alpha->setValueAndWarp(1.f);
+        WORKSPACETRANSITION.ensure(PWORKSPACEL).offset->setValue(RENDEROFFSET);
+        WORKSPACETRANSITION.ensure(PWORKSPACEL).alpha->setValueAndWarp(1.f);
 
-        m_workspaceBegin->m_renderOffset->setValue(RENDEROFFSETMIDDLE);
+        WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValue(RENDEROFFSETMIDDLE);
         if (VERTANIMS)
-            *m_workspaceBegin->m_renderOffset = Vector2D(0.0, YDISTANCE);
+            *WORKSPACETRANSITION.ensure(m_workspaceBegin).offset = Vector2D(0.0, YDISTANCE);
         else
-            *m_workspaceBegin->m_renderOffset = Vector2D(XDISTANCE, 0.0);
-        m_workspaceBegin->m_alpha->setValueAndWarp(1.f);
+            *WORKSPACETRANSITION.ensure(m_workspaceBegin).offset = Vector2D(XDISTANCE, 0.0);
+        WORKSPACETRANSITION.ensure(m_workspaceBegin).alpha->setValueAndWarp(1.f);
 
         g_pInputManager->unconstrainMouse();
 
@@ -272,7 +324,7 @@ void CUnifiedWorkspaceSwipeGesture::end() {
         pSwitchedTo = PWORKSPACEL;
     } else {
         // switch to right
-        const auto RENDEROFFSET = PWORKSPACER ? PWORKSPACER->m_renderOffset->value() : Vector2D();
+        const auto RENDEROFFSET = PWORKSPACER ? WORKSPACETRANSITION.ensure(PWORKSPACER).offset->value() : Vector2D();
 
         if (PWORKSPACER)
             m_monitor->changeWorkspace(workspaceIDRight);
@@ -281,15 +333,15 @@ void CUnifiedWorkspaceSwipeGesture::end() {
             PWORKSPACER = State::workspaceState()->query().id(workspaceIDRight).run();
         }
 
-        PWORKSPACER->m_renderOffset->setValue(RENDEROFFSET);
-        PWORKSPACER->m_alpha->setValueAndWarp(1.f);
+        WORKSPACETRANSITION.ensure(PWORKSPACER).offset->setValue(RENDEROFFSET);
+        WORKSPACETRANSITION.ensure(PWORKSPACER).alpha->setValueAndWarp(1.f);
 
-        m_workspaceBegin->m_renderOffset->setValue(RENDEROFFSETMIDDLE);
+        WORKSPACETRANSITION.ensure(m_workspaceBegin).offset->setValue(RENDEROFFSETMIDDLE);
         if (VERTANIMS)
-            *m_workspaceBegin->m_renderOffset = Vector2D(0.0, -YDISTANCE);
+            *WORKSPACETRANSITION.ensure(m_workspaceBegin).offset = Vector2D(0.0, -YDISTANCE);
         else
-            *m_workspaceBegin->m_renderOffset = Vector2D(-XDISTANCE, 0.0);
-        m_workspaceBegin->m_alpha->setValueAndWarp(1.f);
+            *WORKSPACETRANSITION.ensure(m_workspaceBegin).offset = Vector2D(-XDISTANCE, 0.0);
+        WORKSPACETRANSITION.ensure(m_workspaceBegin).alpha->setValueAndWarp(1.f);
 
         g_pInputManager->unconstrainMouse();
 
@@ -300,11 +352,7 @@ void CUnifiedWorkspaceSwipeGesture::end() {
 
     g_pHyprRenderer->damageMonitor(m_monitor.lock());
 
-    if (PWORKSPACEL)
-        PWORKSPACEL->m_forceRendering = false;
-    if (PWORKSPACER)
-        PWORKSPACER->m_forceRendering = false;
-    m_workspaceBegin->m_forceRendering = false;
+    clearForcedWorkspaces();
 
     m_workspaceBegin   = nullptr;
     m_initialDirection = 0;
@@ -319,7 +367,7 @@ void CUnifiedWorkspaceSwipeGesture::end() {
             (!FSWINDOW || !Fullscreen::controller()->layoutManagedFS(FSWINDOW) ||
              (pSwitchedTo->m_space && pSwitchedTo->m_space->algorithm() && Fullscreen::controller()->hasFullscreen(pSwitchedTo, true)));
 
-        for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
+        for (auto const& ls : m_monitor->m_layerSurfaceLayers[2]) {
             *ls->alpha()[Desktop::View::LS_ALPHA_FADE] = HIDE ? 0.F : 1.F;
         }
     }

--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.hpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.hpp
@@ -3,6 +3,8 @@
 #include "../../helpers/memory/Memory.hpp"
 #include "../../desktop/DesktopTypes.hpp"
 
+#include <vector>
+
 class CUnifiedWorkspaceSwipeGesture {
   public:
     void begin();
@@ -12,14 +14,19 @@ class CUnifiedWorkspaceSwipeGesture {
     bool isGestureInProgress();
 
   private:
-    PHLWORKSPACE  m_workspaceBegin = nullptr;
-    PHLMONITORREF m_monitor;
+    void                         setForceRendering(PHLWORKSPACE workspace, bool force);
+    void                         clearForcedWorkspaces();
+    void                         cancel();
 
-    double        m_delta            = 0;
-    int           m_initialDirection = 0;
-    float         m_avgSpeed         = 0;
-    int           m_speedPoints      = 0;
-    int           m_touchID          = 0;
+    PHLWORKSPACE                 m_workspaceBegin = nullptr;
+    PHLMONITORREF                m_monitor;
+    std::vector<PHLWORKSPACEREF> m_forcedWorkspaces;
+
+    double                       m_delta            = 0;
+    int                          m_initialDirection = 0;
+    float                        m_avgSpeed         = 0;
+    int                          m_speedPoints      = 0;
+    int                          m_touchID          = 0;
 
     friend class CWorkspaceSwipeGesture;
     friend class CInputManager;

--- a/src/managers/input/trackpad/TrackpadGestures.cpp
+++ b/src/managers/input/trackpad/TrackpadGestures.cpp
@@ -227,7 +227,7 @@ void CTrackpadGestures::gestureUpdate(const IPointer::SPinchUpdateEvent& e) {
 
             m_activeGesture     = g;
             g->currentDirection = g->gesture->isDirectionSensitive() ? g->direction : direction;
-            m_activeGesture->gesture->begin({.pinch = &e, .direction = direction});
+            m_activeGesture->gesture->begin({.pinch = &e, .direction = direction, .scale = g->deltaScale});
             break;
         }
 
@@ -237,14 +237,14 @@ void CTrackpadGestures::gestureUpdate(const IPointer::SPinchUpdateEvent& e) {
         }
     }
 
-    m_activeGesture->gesture->update({.pinch = &e, .direction = m_activeGesture->currentDirection});
+    m_activeGesture->gesture->update({.pinch = &e, .direction = m_activeGesture->currentDirection, .scale = m_activeGesture->deltaScale});
 }
 
 void CTrackpadGestures::gestureEnd(const IPointer::SPinchEndEvent& e) {
     if (!m_activeGesture)
         return;
 
-    m_activeGesture->gesture->end({.pinch = &e, .direction = m_activeGesture->direction});
+    m_activeGesture->gesture->end({.pinch = &e, .direction = m_activeGesture->direction, .scale = m_activeGesture->deltaScale});
 
     m_activeGesture.reset();
 }

--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
@@ -2,7 +2,7 @@
 
 #include "../../../../Compositor.hpp"
 #include "../../../../output/Monitor.hpp"
-#include "../../../../managers/input/InputManager.hpp"
+#include "../../../../pointer/PointerManager.hpp"
 #include "../../../../state/MonitorState.hpp"
 #include <hyprutils/string/Numeric.hpp>
 
@@ -23,7 +23,7 @@ void CCursorZoomTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
         if (!e.pinch)
             return;
 
-        m_monitor = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
+        m_monitor = State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run();
         if (!m_monitor)
             return;
 
@@ -33,7 +33,7 @@ void CCursorZoomTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
 
         m_zoomBegin = std::clamp(PMONITOR->m_cursorZoom->goal(), 1.0F, 100.0F);
         PMONITOR->m_cursorZoom->setValueAndWarp(m_zoomBegin);
-        PMONITOR->m_zoomController.pinAnchor(g_pInputManager->getMouseCoordsInternal() - PMONITOR->m_position);
+        PMONITOR->m_zoomController.pinAnchor(Pointer::mgr()->untransformedPosition() - PMONITOR->m_position);
         return;
     }
 

--- a/src/managers/input/trackpad/gestures/OverviewGesture.cpp
+++ b/src/managers/input/trackpad/gestures/OverviewGesture.cpp
@@ -1,0 +1,63 @@
+#include "OverviewGesture.hpp"
+
+#include "../../../../desktop/state/FocusState.hpp"
+#include "../../../../overview/Overview.hpp"
+
+#include <algorithm>
+
+constexpr const float MAX_DISTANCE = 200.F;
+constexpr const float COMMIT_RATIO = 0.3F;
+
+void                  COverviewTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
+    ITrackpadGesture::begin(e);
+
+    m_distance = 0.F;
+    m_overview = Overview::overview().get();
+
+    const auto GESTURE = dynamic_cast<Overview::IOverviewGesture*>(Overview::overview().get());
+    m_interactive      = GESTURE;
+    m_active           = !GESTURE || GESTURE->beginGesture(Desktop::focusState()->monitor());
+    if (!m_active)
+        m_overview = nullptr;
+}
+
+void COverviewTrackpadGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
+    if (!m_active)
+        return;
+
+    m_distance += distance(e);
+
+    if (Overview::overview().get() != m_overview || !m_interactive)
+        return;
+
+    if (const auto GESTURE = dynamic_cast<Overview::IOverviewGesture*>(Overview::overview().get()))
+        GESTURE->updateGesture(std::clamp(m_distance / MAX_DISTANCE, 0.F, 1.F));
+}
+
+void COverviewTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
+    if (!m_active)
+        return;
+
+    m_active             = false;
+    const bool CANCELLED = (e.swipe && e.swipe->cancelled) || (e.pinch && e.pinch->cancelled);
+    const bool COMMITTED = !CANCELLED && m_distance / MAX_DISTANCE >= COMMIT_RATIO;
+
+    if (Overview::overview().get() != m_overview) {
+        m_overview = nullptr;
+        return;
+    }
+
+    m_overview = nullptr;
+    if (const auto GESTURE = m_interactive ? dynamic_cast<Overview::IOverviewGesture*>(Overview::overview().get()) : nullptr) {
+        GESTURE->endGesture(COMMITTED);
+        return;
+    }
+
+    if (!COMMITTED)
+        return;
+
+    if (Overview::overview()->isOpen())
+        Overview::overview()->close();
+    else
+        Overview::overview()->open(Desktop::focusState()->monitor());
+}

--- a/src/managers/input/trackpad/gestures/OverviewGesture.cpp
+++ b/src/managers/input/trackpad/gestures/OverviewGesture.cpp
@@ -14,9 +14,9 @@ void                  COverviewTrackpadGesture::begin(const ITrackpadGesture::ST
     m_distance = 0.F;
     m_overview = Overview::overview().get();
 
-    const auto GESTURE = dynamic_cast<Overview::IOverviewGesture*>(Overview::overview().get());
+    const auto GESTURE = dynamic_cast<Overview::IOverviewGestureOpenable*>(Overview::overview().get());
     m_interactive      = GESTURE;
-    m_active           = !GESTURE || GESTURE->beginGesture(Desktop::focusState()->monitor());
+    m_active           = !GESTURE || GESTURE->beginOpenGesture(Desktop::focusState()->monitor());
     if (!m_active)
         m_overview = nullptr;
 }
@@ -30,8 +30,8 @@ void COverviewTrackpadGesture::update(const ITrackpadGesture::STrackpadGestureUp
     if (Overview::overview().get() != m_overview || !m_interactive)
         return;
 
-    if (const auto GESTURE = dynamic_cast<Overview::IOverviewGesture*>(Overview::overview().get()))
-        GESTURE->updateGesture(std::clamp(m_distance / MAX_DISTANCE, 0.F, 1.F));
+    if (const auto GESTURE = dynamic_cast<Overview::IOverviewGestureOpenable*>(Overview::overview().get()))
+        GESTURE->updateOpenGesture(std::clamp(m_distance / MAX_DISTANCE, 0.F, 1.F));
 }
 
 void COverviewTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
@@ -48,8 +48,8 @@ void COverviewTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd& 
     }
 
     m_overview = nullptr;
-    if (const auto GESTURE = m_interactive ? dynamic_cast<Overview::IOverviewGesture*>(Overview::overview().get()) : nullptr) {
-        GESTURE->endGesture(COMMITTED);
+    if (const auto GESTURE = m_interactive ? dynamic_cast<Overview::IOverviewGestureOpenable*>(Overview::overview().get()) : nullptr) {
+        GESTURE->endOpenGesture(COMMITTED);
         return;
     }
 

--- a/src/managers/input/trackpad/gestures/OverviewGesture.hpp
+++ b/src/managers/input/trackpad/gestures/OverviewGesture.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ITrackpadGesture.hpp"
+
+namespace Overview {
+    class IOverview;
+}
+
+class COverviewTrackpadGesture : public ITrackpadGesture {
+  public:
+    COverviewTrackpadGesture()          = default;
+    virtual ~COverviewTrackpadGesture() = default;
+
+    virtual void begin(const ITrackpadGesture::STrackpadGestureBegin& e);
+    virtual void update(const ITrackpadGesture::STrackpadGestureUpdate& e);
+    virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
+
+  private:
+    const Overview::IOverview* m_overview    = nullptr;
+    float                      m_distance    = 0.F;
+    bool                       m_active      = false;
+    bool                       m_interactive = false;
+};

--- a/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.cpp
+++ b/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.cpp
@@ -4,6 +4,7 @@
 #include "../../../../state/WorkspaceState.hpp"
 #include "../../../../desktop/state/FocusState.hpp"
 #include "../../../../render/Renderer.hpp"
+#include "../../../../output/WorkspaceTransition.hpp"
 
 #include <cmath>
 
@@ -24,9 +25,20 @@ CSpecialWorkspaceGesture::CSpecialWorkspaceGesture(const std::string& workspaceN
     ;
 }
 
+CSpecialWorkspaceGesture::~CSpecialWorkspaceGesture() {
+    releaseForceRendering();
+}
+
+void CSpecialWorkspaceGesture::releaseForceRendering() {
+    const auto MONITOR = m_specialWorkspace ? m_specialWorkspace->m_monitor.lock() : nullptr;
+    if (MONITOR && MONITOR->m_workspaceTransition)
+        MONITOR->m_workspaceTransition->setForceRendering(m_specialWorkspace, false);
+}
+
 void CSpecialWorkspaceGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
     ITrackpadGesture::begin(e);
 
+    releaseForceRendering();
     m_specialWorkspace.reset();
     m_lastDelta = 0.F;
     m_monitor.reset();
@@ -59,38 +71,45 @@ void CSpecialWorkspaceGesture::begin(const ITrackpadGesture::STrackpadGestureBeg
     if (!m_specialWorkspace)
         return;
 
+    m_monitor->m_workspaceTransition->setForceRendering(m_specialWorkspace, true);
+    auto& TRANSITION      = m_monitor->m_workspaceTransition->ensure(m_specialWorkspace);
     m_monitorFadeFrom     = m_monitor->m_specialFade->begun();
     m_monitorFadeTo       = m_monitor->m_specialFade->goal();
     m_monitorDimFrom      = m_monitor->m_specialDim->begun();
     m_monitorDimTo        = m_monitor->m_specialDim->goal();
     m_monitorBlurFrom     = m_monitor->m_specialBlur->begun();
     m_monitorBlurTo       = m_monitor->m_specialBlur->goal();
-    m_workspaceAlphaFrom  = m_specialWorkspace->m_alpha->begun();
-    m_workspaceAlphaTo    = m_specialWorkspace->m_alpha->goal();
-    m_workspaceOffsetFrom = m_specialWorkspace->m_renderOffset->begun();
-    m_workspaceOffsetTo   = m_specialWorkspace->m_renderOffset->goal();
+    m_workspaceAlphaFrom  = TRANSITION.alpha->begun();
+    m_workspaceAlphaTo    = TRANSITION.alpha->goal();
+    m_workspaceOffsetFrom = TRANSITION.offset->begun();
+    m_workspaceOffsetTo   = TRANSITION.offset->goal();
 }
 
 void CSpecialWorkspaceGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
     if (!m_specialWorkspace || !m_monitor)
         return;
 
-    g_pHyprRenderer->damageMonitor(m_specialWorkspace->m_monitor.lock());
+    g_pHyprRenderer->damageMonitor(m_monitor.lock());
 
     m_lastDelta += distance(e);
 
     const auto FADEPERCENT = m_animatingOut ? 1.F - std::clamp(m_lastDelta / MAX_DISTANCE, 0.F, 1.F) : std::clamp(m_lastDelta / MAX_DISTANCE, 0.F, 1.F);
 
+    auto&      TRANSITION = m_monitor->m_workspaceTransition->ensure(m_specialWorkspace);
     m_monitor->m_specialFade->setValueAndWarp(std::lerp(m_monitorFadeFrom, m_monitorFadeTo, FADEPERCENT));
     m_monitor->m_specialDim->setValueAndWarp(std::lerp(m_monitorDimFrom, m_monitorDimTo, FADEPERCENT));
     m_monitor->m_specialBlur->setValueAndWarp(std::lerp(m_monitorBlurFrom, m_monitorBlurTo, FADEPERCENT));
-    m_specialWorkspace->m_alpha->setValueAndWarp(std::lerp(m_workspaceAlphaFrom, m_workspaceAlphaTo, FADEPERCENT));
-    m_specialWorkspace->m_renderOffset->setValueAndWarp(lerpVal(m_workspaceOffsetFrom, m_workspaceOffsetTo, FADEPERCENT));
+    TRANSITION.alpha->setValueAndWarp(std::lerp(m_workspaceAlphaFrom, m_workspaceAlphaTo, FADEPERCENT));
+    TRANSITION.offset->setValueAndWarp(lerpVal(m_workspaceOffsetFrom, m_workspaceOffsetTo, FADEPERCENT));
 }
 
 void CSpecialWorkspaceGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
-    if (!m_specialWorkspace || !m_monitor)
+    if (!m_specialWorkspace)
         return;
+    if (!m_monitor) {
+        releaseForceRendering();
+        return;
+    }
 
     const auto COMPLETION = std::clamp(m_lastDelta / MAX_DISTANCE, 0.F, 1.F);
 
@@ -108,34 +127,37 @@ void CSpecialWorkspaceGesture::end(const ITrackpadGesture::STrackpadGestureEnd& 
         }
     }
 
+    auto& TRANSITION = m_monitor->m_workspaceTransition->ensure(m_specialWorkspace);
     if (m_animatingOut) {
-        const auto CURR_WS_ALPHA  = m_specialWorkspace->m_alpha->value();
-        const auto CURR_WS_OFFSET = m_specialWorkspace->m_renderOffset->value();
+        const auto CURR_WS_ALPHA  = TRANSITION.alpha->value();
+        const auto CURR_WS_OFFSET = TRANSITION.offset->value();
         const auto CURR_MON_FADE  = m_monitor->m_specialFade->value();
         const auto CURR_MON_DIM   = m_monitor->m_specialDim->value();
         const auto CURR_MON_BLUR  = m_monitor->m_specialBlur->value();
 
         m_monitor->setSpecialWorkspace(nullptr);
 
-        const auto GOAL_WS_ALPHA  = m_specialWorkspace->m_alpha->goal();
-        const auto GOAL_WS_OFFSET = m_specialWorkspace->m_renderOffset->goal();
+        const auto GOAL_WS_ALPHA  = TRANSITION.alpha->goal();
+        const auto GOAL_WS_OFFSET = TRANSITION.offset->goal();
 
         m_monitor->m_specialFade->setValueAndWarp(CURR_MON_FADE);
         m_monitor->m_specialDim->setValueAndWarp(CURR_MON_DIM);
         m_monitor->m_specialBlur->setValueAndWarp(CURR_MON_BLUR);
-        m_specialWorkspace->m_alpha->setValueAndWarp(CURR_WS_ALPHA);
-        m_specialWorkspace->m_renderOffset->setValueAndWarp(CURR_WS_OFFSET);
+        TRANSITION.alpha->setValueAndWarp(CURR_WS_ALPHA);
+        TRANSITION.offset->setValueAndWarp(CURR_WS_OFFSET);
 
-        *m_monitor->m_specialFade           = 0.F;
-        *m_monitor->m_specialDim            = 0.F;
-        *m_monitor->m_specialBlur           = 0.F;
-        *m_specialWorkspace->m_alpha        = GOAL_WS_ALPHA;
-        *m_specialWorkspace->m_renderOffset = GOAL_WS_OFFSET;
+        *m_monitor->m_specialFade = 0.F;
+        *m_monitor->m_specialDim  = 0.F;
+        *m_monitor->m_specialBlur = 0.F;
+        *TRANSITION.alpha         = GOAL_WS_ALPHA;
+        *TRANSITION.offset        = GOAL_WS_OFFSET;
     } else {
-        *m_monitor->m_specialFade           = m_monitorFadeTo;
-        *m_monitor->m_specialDim            = m_monitorDimTo;
-        *m_monitor->m_specialBlur           = m_monitorBlurTo;
-        *m_specialWorkspace->m_renderOffset = m_workspaceOffsetTo;
-        *m_specialWorkspace->m_alpha        = m_workspaceAlphaTo;
+        *m_monitor->m_specialFade = m_monitorFadeTo;
+        *m_monitor->m_specialDim  = m_monitorDimTo;
+        *m_monitor->m_specialBlur = m_monitorBlurTo;
+        *TRANSITION.offset        = m_workspaceOffsetTo;
+        *TRANSITION.alpha         = m_workspaceAlphaTo;
     }
+
+    releaseForceRendering();
 }

--- a/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.hpp
+++ b/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.hpp
@@ -7,13 +7,15 @@
 class CSpecialWorkspaceGesture : public ITrackpadGesture {
   public:
     CSpecialWorkspaceGesture(const std::string& workspaceName);
-    virtual ~CSpecialWorkspaceGesture() = default;
+    virtual ~CSpecialWorkspaceGesture();
 
     virtual void begin(const ITrackpadGesture::STrackpadGestureBegin& e);
     virtual void update(const ITrackpadGesture::STrackpadGestureUpdate& e);
     virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
 
   private:
+    void          releaseForceRendering();
+
     std::string   m_specialWorkspaceName;
     PHLWORKSPACE  m_specialWorkspace;
     PHLMONITORREF m_monitor;

--- a/src/managers/input/trackpad/gestures/WorkspaceSwipeGesture.cpp
+++ b/src/managers/input/trackpad/gestures/WorkspaceSwipeGesture.cpp
@@ -1,14 +1,35 @@
 #include "WorkspaceSwipeGesture.hpp"
 
 #include "../../../../Compositor.hpp"
+#include "../../../../config/ConfigManager.hpp"
 #include "../../../../state/WorkspaceState.hpp"
 #include "../../../../desktop/state/FocusState.hpp"
+#include "../../../../overview/Overview.hpp"
 #include "../../../../render/Renderer.hpp"
 
 #include "../../UnifiedWorkspaceSwipeGesture.hpp"
 
+static float overviewMoveDelta(float delta) {
+    if (!Config::mgr())
+        return delta;
+
+    static auto PSWIPEINVR = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_invert");
+    return *PSWIPEINVR ? delta : -delta;
+}
+
 void CWorkspaceSwipeGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
     ITrackpadGesture::begin(e);
+
+    m_overview           = nullptr;
+    m_overviewMoveActive = false;
+
+    const auto OVERVIEW = Overview::overview().get();
+    if (OVERVIEW && OVERVIEW->isOpen()) {
+        m_overview = OVERVIEW;
+        if (const auto MOVABLE = dynamic_cast<Overview::IOverviewGestureMovable*>(OVERVIEW))
+            m_overviewMoveActive = MOVABLE->beginMoveGesture();
+        return;
+    }
 
     static auto PSWIPENEW = CConfigValue<Config::INTEGER>("gestures:workspace_swipe_create_new");
 
@@ -28,6 +49,14 @@ void CWorkspaceSwipeGesture::begin(const ITrackpadGesture::STrackpadGestureBegin
 }
 
 void CWorkspaceSwipeGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
+    if (m_overview) {
+        if (Overview::overview().get() == m_overview && m_overviewMoveActive) {
+            if (const auto MOVABLE = dynamic_cast<Overview::IOverviewGestureMovable*>(m_overview))
+                MOVABLE->updateMoveGesture(overviewMoveDelta(distance(e)));
+        }
+        return;
+    }
+
     if (!g_pUnifiedWorkspaceSwipe->isGestureInProgress())
         return;
 
@@ -40,6 +69,17 @@ void CWorkspaceSwipeGesture::update(const ITrackpadGesture::STrackpadGestureUpda
 }
 
 void CWorkspaceSwipeGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {
+    if (m_overview) {
+        if (Overview::overview().get() == m_overview && m_overviewMoveActive) {
+            if (const auto MOVABLE = dynamic_cast<Overview::IOverviewGestureMovable*>(m_overview))
+                MOVABLE->endMoveGesture();
+        }
+
+        m_overview           = nullptr;
+        m_overviewMoveActive = false;
+        return;
+    }
+
     if (!g_pUnifiedWorkspaceSwipe->isGestureInProgress())
         return;
 

--- a/src/managers/input/trackpad/gestures/WorkspaceSwipeGesture.hpp
+++ b/src/managers/input/trackpad/gestures/WorkspaceSwipeGesture.hpp
@@ -3,6 +3,10 @@
 #include "ITrackpadGesture.hpp"
 #include "../../../../desktop/DesktopTypes.hpp"
 
+namespace Overview {
+    class IOverview;
+}
+
 class CWorkspaceSwipeGesture : public ITrackpadGesture {
   public:
     CWorkspaceSwipeGesture()          = default;
@@ -13,4 +17,8 @@ class CWorkspaceSwipeGesture : public ITrackpadGesture {
     virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
 
     virtual bool isDirectionSensitive();
+
+  private:
+    Overview::IOverview* m_overview           = nullptr;
+    bool                 m_overviewMoveActive = false;
 };

--- a/src/managers/screenshare/CursorshareSession.cpp
+++ b/src/managers/screenshare/CursorshareSession.cpp
@@ -5,6 +5,7 @@
 #include "../../render/Renderer.hpp"
 #include "../../render/pass/ClearPassElement.hpp"
 #include "../../render/pass/TexPassElement.hpp"
+#include "../../render/pass/Pass.hpp"
 #include <hyprgraphics/egl/Egl.hpp>
 
 using namespace Hyprgraphics::Egl;
@@ -112,32 +113,33 @@ eScreenshareError CCursorshareSession::share(PHLMONITOR monitor, SP<IHLBuffer> b
     return ERROR_NONE;
 }
 
-void CCursorshareSession::render() {
+void CCursorshareSession::render(Render::CRenderingContext& context) {
     const auto  PERM = g_pDynamicPermissionManager->clientPermissionMode(m_client, PERMISSION_TYPE_CURSOR_POS);
 
     const auto& cursorImage = Pointer::mgr()->currentCursorImage();
 
     // TODO: implement a monitor independent render mode to buffer that does this in CHyprRenderer::begin() or something like that
-    g_pHyprRenderer->m_renderData.transformDamage = false;
+    context.transformDamage = false;
     g_pHyprRenderer->setViewport(0, 0, m_bufferSize.x, m_bufferSize.y);
 
     bool overlaps = Pointer::mgr()->getCursorBoxGlobal().overlaps(m_pendingFrame.sourceBoxCallback());
-    g_pHyprRenderer->startRenderPass();
+    g_pHyprRenderer->startRenderPass(context);
     if (PERM != PERMISSION_RULE_ALLOW_MODE_ALLOW || !overlaps) {
         // render black when not allowed
-        g_pHyprRenderer->draw(CClearPassElement::SClearData{Colors::BLACK});
+        g_pHyprRenderer->draw(context, CClearPassElement::SClearData{Colors::BLACK});
     } else if (!cursorImage.pBuffer || !cursorImage.surface || !cursorImage.bufferTex) {
         // render clear when cursor is probably hidden
-        g_pHyprRenderer->draw(CClearPassElement::SClearData{{0, 0, 0, 0}});
+        g_pHyprRenderer->draw(context, CClearPassElement::SClearData{{0, 0, 0, 0}});
     } else {
         // render cursor
-        g_pHyprRenderer->draw(CTexPassElement::SRenderData{
-            .tex = cursorImage.bufferTex,
-            .box = {{}, cursorImage.bufferTex->m_size},
-        });
+        g_pHyprRenderer->draw(context,
+                              CTexPassElement::SRenderData{
+                                  .tex = cursorImage.bufferTex,
+                                  .box = {{}, cursorImage.bufferTex->m_size},
+                              });
     }
 
-    g_pHyprRenderer->m_renderData.blockScreenShader = true;
+    context.blockScreenShader = true;
 }
 
 bool CCursorshareSession::copy() {
@@ -147,21 +149,24 @@ bool CCursorshareSession::copy() {
     // FIXME: this doesn't really make sense but just to be safe
     m_pendingFrame.callback(RESULT_TIMESTAMP);
 
-    CRegion fakeDamage = {0, 0, INT16_MAX, INT16_MAX};
+    CRegion                   fakeDamage = {0, 0, INT16_MAX, INT16_MAX};
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{m_pendingFrame.monitor, pass};
+
     if (auto attrs = m_pendingFrame.buffer->dmabuf(); attrs.success) {
         if (attrs.format != m_format) {
             LOGM(Log::ERR, "Can't copy: invalid format");
             return false;
         }
 
-        if (!g_pHyprRenderer->beginRenderToBuffer(m_pendingFrame.monitor, fakeDamage, m_pendingFrame.buffer, true)) {
+        if (!g_pHyprRenderer->beginRenderToBuffer(context, fakeDamage, m_pendingFrame.buffer, true)) {
             LOGM(Log::ERR, "Can't copy: failed to begin rendering to dmabuf");
             return false;
         }
 
-        render();
+        render(context);
 
-        g_pHyprRenderer->endRender([callback = m_pendingFrame.callback]() {
+        g_pHyprRenderer->endRender(context, [callback = m_pendingFrame.callback]() {
             if (callback)
                 callback(RESULT_COPIED);
         });
@@ -176,14 +181,14 @@ bool CCursorshareSession::copy() {
         auto outFB = g_pHyprRenderer->createFB();
         outFB->alloc(m_bufferSize.x, m_bufferSize.y, m_format);
 
-        if (!g_pHyprRenderer->beginFullFakeRender(m_pendingFrame.monitor, fakeDamage, outFB)) {
+        if (!g_pHyprRenderer->beginFullFakeRender(context, fakeDamage, outFB)) {
             LOGM(Log::ERR, "Can't copy: failed to begin rendering to shm");
             return false;
         }
 
-        render();
+        render(context);
 
-        g_pHyprRenderer->endRender();
+        g_pHyprRenderer->endRender(context);
 
         int glFormat = PFORMAT->glFormat;
 
@@ -204,12 +209,9 @@ bool CCursorshareSession::copy() {
         }
 
         if (!outFB->readPixels(m_pendingFrame.buffer, 0, 0, m_bufferSize.x, m_bufferSize.y)) {
-            g_pHyprRenderer->m_renderData.pMonitor.reset();
             LOGM(Log::ERR, "Can't copy: failed to read cursor pixels to shm");
             return false;
         }
-
-        g_pHyprRenderer->m_renderData.pMonitor.reset();
 
         m_pendingFrame.callback(RESULT_COPIED);
     } else {

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -14,6 +14,7 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../render/pass/ClearPassElement.hpp"
 #include "../../render/pass/RectPassElement.hpp"
+#include "../../render/pass/Pass.hpp"
 #include "helpers/cm/ColorManagement.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
 #include <hyprutils/math/Region.hpp>
@@ -179,13 +180,13 @@ void CScreenshareFrame::copy() {
         m_callback(RESULT_NOT_COPIED);
 }
 
-void CScreenshareFrame::renderMonitor() {
+void CScreenshareFrame::renderMonitor(Render::CRenderingContext& context) {
     if ((m_session->m_type != SHARE_MONITOR && m_session->m_type != SHARE_REGION) || done())
         return;
 
     const auto PMONITOR = m_session->monitor();
 
-    auto       TEXTURE = g_pHyprRenderer->m_renderData.pMonitor->resources()->getMirrorTexture();
+    auto       TEXTURE = context.sceneMonitor->resources()->getMirrorTexture();
     if (!TEXTURE) {
         LOGM(Log::ERR, "Invalid source texture");
         return;
@@ -194,34 +195,33 @@ void CScreenshareFrame::renderMonitor() {
     if (!TEXTURE->m_imageDescription)
         Log::logger->log(Log::ERR, "CM: FIXME no source image description for screenshare");
 
-    if (!g_pHyprRenderer->m_renderData.currentFB->imageDescription())
+    if (!context.currentFB->imageDescription())
         Log::logger->log(Log::ERR, "CM: FIXME no target image description for screenshare");
 
-    if (TEXTURE->m_imageDescription && g_pHyprRenderer->m_renderData.currentFB->imageDescription())
-        Log::logger->log(Log::TRACE, "CM: screenshot renderMonitor {} -> {}", TEXTURE->m_imageDescription->value(),
-                         g_pHyprRenderer->m_renderData.currentFB->imageDescription()->value());
+    if (TEXTURE->m_imageDescription && context.currentFB->imageDescription())
+        Log::logger->log(Log::TRACE, "CM: screenshot renderMonitor {} -> {}", TEXTURE->m_imageDescription->value(), context.currentFB->imageDescription()->value());
 
-    const bool IS_CM_AWARE               = PROTO::colorManagement && PROTO::colorManagement->isClientCMAware(m_session->m_client);
-    g_pHyprRenderer->m_renderData.fbSize = m_bufferSize;
-    g_pHyprRenderer->setProjectionType(Render::RPT_EXPORT);
-    g_pHyprRenderer->m_renderData.transformDamage = false;
-    g_pHyprRenderer->m_renderData.noSimplify      = true;
+    const bool IS_CM_AWARE = PROTO::colorManagement && PROTO::colorManagement->isClientCMAware(m_session->m_client);
+    context.fbSize         = m_bufferSize;
+    g_pHyprRenderer->setProjectionType(context, Render::RPT_EXPORT);
+    context.transformDamage = false;
+    context.noSimplify      = true;
     g_pHyprRenderer->setViewport(0, 0, m_bufferSize.x, m_bufferSize.y);
 
     // render monitor texture
     CBox       monbox = CBox{{}, PMONITOR->m_transformedSize}.translate(-m_session->m_captureBox.pos());
 
-    const auto OLD                                    = g_pHyprRenderer->m_renderData.renderModif.enabled;
-    g_pHyprRenderer->m_renderData.renderModif.enabled = false;
-    g_pHyprRenderer->startRenderPass();
-    g_pHyprRenderer->draw(
-        CTexPassElement::SRenderData{
-            .tex          = TEXTURE,
-            .box          = monbox,
-            .cmBackToSRGB = !IS_CM_AWARE,
-        },
-        {0, 0, m_bufferSize.x, m_bufferSize.y});
-    g_pHyprRenderer->m_renderData.renderModif.enabled = OLD;
+    const auto OLD              = context.renderModif.enabled;
+    context.renderModif.enabled = false;
+    g_pHyprRenderer->startRenderPass(context);
+    g_pHyprRenderer->draw(context,
+                          CTexPassElement::SRenderData{
+                              .tex          = TEXTURE,
+                              .box          = monbox,
+                              .cmBackToSRGB = !IS_CM_AWARE,
+                          },
+                          {0, 0, m_bufferSize.x, m_bufferSize.y});
+    context.renderModif.enabled = OLD;
 
     // render black boxes for noscreenshare
     auto hidePopups = [&](Vector2D popupBaseOffset) {
@@ -237,7 +237,7 @@ void CScreenshareFrame::renderMonitor() {
                         CBox{popupBaseOffset + popRel + localOff, size}.translate(PMONITOR->m_position).scale(PMONITOR->m_scale).translate(-m_session->m_captureBox.pos());
 
                     if LIKELY (surfBox.w > 0 && surfBox.h > 0)
-                        g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = surfBox, .color = Colors::BLACK}, surfBox);
+                        g_pHyprRenderer->draw(context, CRectPassElement::SRectData{.box = surfBox, .color = Colors::BLACK}, surfBox);
                 },
                 nullptr);
         };
@@ -258,7 +258,7 @@ void CScreenshareFrame::renderMonitor() {
                                           .scale(PMONITOR->m_scale)
                                           .translate(-m_session->m_captureBox.pos());
 
-        g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = noScreenShareBox, .color = Colors::BLACK}, noScreenShareBox);
+        g_pHyprRenderer->draw(context, CRectPassElement::SRectData{.box = noScreenShareBox, .color = Colors::BLACK}, noScreenShareBox);
 
         const auto     geom            = l->m_geometry;
         const Vector2D popupBaseOffset = REALPOS - Vector2D{geom.pos().x, geom.pos().y};
@@ -270,7 +270,7 @@ void CScreenshareFrame::renderMonitor() {
         if (!w->m_ruleApplicator->noScreenShare().valueOrDefault())
             continue;
 
-        if (!g_pHyprRenderer->shouldRenderWindow(w, PMONITOR))
+        if (!g_pHyprRenderer->shouldRenderWindow(context, w, PMONITOR))
             continue;
 
         if (w->isHidden())
@@ -295,14 +295,14 @@ void CScreenshareFrame::renderMonitor() {
         const auto rounding      = dontRound ? 0 : w->presentation().rounding() * PMONITOR->m_scale;
         const auto roundingPower = dontRound ? 2.0f : w->presentation().roundingPower();
 
-        g_pHyprRenderer->draw(
-            CRectPassElement::SRectData{
-                .box           = noScreenShareBox,
-                .color         = Colors::BLACK,
-                .round         = rounding,
-                .roundingPower = roundingPower,
-            },
-            noScreenShareBox);
+        g_pHyprRenderer->draw(context,
+                              CRectPassElement::SRectData{
+                                  .box           = noScreenShareBox,
+                                  .color         = Colors::BLACK,
+                                  .round         = rounding,
+                                  .roundingPower = roundingPower,
+                              },
+                              noScreenShareBox);
 
         if (w->backend().isX11() || !w->popupHead())
             continue;
@@ -316,11 +316,11 @@ void CScreenshareFrame::renderMonitor() {
     if (m_overlayCursor) {
         CRegion  fakeDamage = {0, 0, m_bufferSize.x, m_bufferSize.y};
         Vector2D cursorPos  = g_pInputManager->getMouseCoordsInternal() - PMONITOR->m_position - m_session->m_captureBox.pos() / PMONITOR->m_scale;
-        Pointer::mgr()->renderSoftwareCursorsFor(PMONITOR, Time::steadyNow(), fakeDamage, cursorPos, true);
+        Pointer::mgr()->renderSoftwareCursorsFor(context, PMONITOR, Time::steadyNow(), fakeDamage, cursorPos, true);
     }
 }
 
-void CScreenshareFrame::renderWindow() {
+void CScreenshareFrame::renderWindow(Render::CRenderingContext& context) {
     if (m_session->m_type != SHARE_WINDOW || done())
         return;
 
@@ -330,14 +330,13 @@ void CScreenshareFrame::renderWindow() {
     const auto NOW = Time::steadyNow();
 
     // TODO: implement a monitor independent render mode to buffer that does this in CHyprRenderer::begin() or something like that
-    g_pHyprRenderer->m_renderData.fbSize = m_bufferSize;
-    g_pHyprRenderer->setProjectionType(Render::RPT_EXPORT);
-    g_pHyprRenderer->m_renderData.transformDamage = false;
+    context.fbSize = m_bufferSize;
+    g_pHyprRenderer->setProjectionType(context, Render::RPT_EXPORT);
+    context.transformDamage = false;
     g_pHyprRenderer->setViewport(0, 0, m_bufferSize.x, m_bufferSize.y);
 
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(PWINDOW); // block the feedback to avoid spamming the surface if it's visible
-    g_pHyprRenderer->renderWindow(PWINDOW, PMONITOR, NOW, false, Render::RENDER_PASS_ALL, true, true);
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
+    context.blockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(PWINDOW); // block the feedback to avoid spamming the surface if it's visible
+    g_pHyprRenderer->renderWindow(context, PWINDOW, PMONITOR, NOW, false, Render::RENDER_PASS_ALL, true, true);
 
     if (!m_overlayCursor)
         return;
@@ -359,39 +358,39 @@ void CScreenshareFrame::renderWindow() {
         return;
 
     CRegion fakeDamage = {0, 0, INT16_MAX, INT16_MAX};
-    Pointer::mgr()->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), NOW, fakeDamage,
+    Pointer::mgr()->renderSoftwareCursorsFor(context, PMONITOR->m_self.lock(), NOW, fakeDamage,
                                              g_pInputManager->getMouseCoordsInternal() - PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT), true, true);
 }
 
-void CScreenshareFrame::render() {
+void CScreenshareFrame::render(Render::CRenderingContext& context) {
     const auto PERM = g_pDynamicPermissionManager->clientPermissionMode(m_session->m_client, PERMISSION_TYPE_SCREENCOPY);
 
     CRegion    frameRegion = {0, 0, m_bufferSize.x, m_bufferSize.y};
 
-    g_pHyprRenderer->draw(CClearPassElement::SClearData{{0, 0, 0, 0}}, frameRegion);
+    g_pHyprRenderer->draw(context, CClearPassElement::SClearData{{0, 0, 0, 0}}, frameRegion);
 
     if (PERM == PERMISSION_RULE_ALLOW_MODE_PENDING)
         return;
 
     bool windowShareDenied = m_session->m_type == SHARE_WINDOW && m_session->m_window->m_ruleApplicator && m_session->m_window->m_ruleApplicator->noScreenShare().valueOrDefault();
-    g_pHyprRenderer->startRenderPass();
+    g_pHyprRenderer->startRenderPass(context);
     if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY || windowShareDenied) {
         CBox texbox = CBox{m_bufferSize / 2.F, g_pHyprRenderer->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprRenderer->m_screencopyDeniedTexture->m_size / 2.F);
-        g_pHyprRenderer->draw(CTexPassElement::SRenderData{.tex = g_pHyprRenderer->m_screencopyDeniedTexture, .box = texbox}, texbox);
+        g_pHyprRenderer->draw(context, CTexPassElement::SRenderData{.tex = g_pHyprRenderer->m_screencopyDeniedTexture, .box = texbox}, texbox);
         return;
     }
 
     if (m_session->m_tempFB && m_session->m_tempFB->isAllocated()) {
         CBox texbox = {{}, m_bufferSize};
-        g_pHyprRenderer->draw(CTexPassElement::SRenderData{.tex = m_session->m_tempFB->getTexture(), .box = texbox}, texbox);
+        g_pHyprRenderer->draw(context, CTexPassElement::SRenderData{.tex = m_session->m_tempFB->getTexture(), .box = texbox}, texbox);
         m_session->m_tempFB->release();
         return;
     }
 
     switch (m_session->m_type) {
         case SHARE_REGION: // TODO: could this be better? this is how screencopy works
-        case SHARE_MONITOR: renderMonitor(); break;
-        case SHARE_WINDOW: renderWindow(); break;
+        case SHARE_MONITOR: renderMonitor(context); break;
+        case SHARE_WINDOW: renderWindow(context); break;
         case SHARE_NONE:
         default: return;
     }
@@ -401,19 +400,22 @@ bool CScreenshareFrame::copyDmabuf() {
     if (done())
         return false;
 
-    if (!g_pHyprRenderer->beginRender(m_session->monitor(), m_damage, Render::RENDER_MODE_TO_BUFFER, m_buffer, nullptr, true)) {
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{m_session->monitor(), pass};
+
+    if (!g_pHyprRenderer->beginRender(context, m_damage, Render::RENDER_MODE_TO_BUFFER, m_buffer, nullptr, true)) {
         LOGM(Log::ERR, "Can't copy: failed to begin rendering to dma frame");
         return false;
     }
-    g_pHyprRenderer->m_renderData.currentFB->setImageDescription(NColorManagement::DEFAULT_SRGB_IMAGE_DESCRIPTION);
+    context.currentFB->setImageDescription(NColorManagement::DEFAULT_SRGB_IMAGE_DESCRIPTION);
 
-    render();
+    render(context);
 
-    g_pHyprRenderer->m_renderData.blockScreenShader = true;
+    context.blockScreenShader = true;
 
     m_copyInFlight = true;
 
-    g_pHyprRenderer->endRender([self = m_self]() {
+    g_pHyprRenderer->endRender(context, [self = m_self]() {
         if (!self || self.expired())
             return;
 
@@ -442,22 +444,24 @@ bool CScreenshareFrame::copyShm() {
         return false;
     }
 
-    const auto PMONITOR = m_session->monitor();
+    const auto                PMONITOR = m_session->monitor();
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{PMONITOR, pass};
 
-    auto       outFB = g_pHyprRenderer->createFB();
+    auto                      outFB = g_pHyprRenderer->createFB();
     outFB->alloc(m_bufferSize.x, m_bufferSize.y, shm.format);
     outFB->setImageDescription(NColorManagement::DEFAULT_SRGB_IMAGE_DESCRIPTION);
 
-    if (!g_pHyprRenderer->beginFullFakeRender(PMONITOR, m_damage, outFB)) {
+    if (!g_pHyprRenderer->beginFullFakeRender(context, m_damage, outFB)) {
         LOGM(Log::ERR, "Can't copy: failed to begin rendering");
         return false;
     }
 
-    render();
+    render(context);
 
-    g_pHyprRenderer->m_renderData.blockScreenShader = true;
+    context.blockScreenShader = true;
 
-    g_pHyprRenderer->endRender();
+    g_pHyprRenderer->endRender(context);
 
     bool readSucceeded = true;
     m_damage.forEachRect([&](const auto& rect) {
@@ -469,8 +473,6 @@ bool CScreenshareFrame::copyShm() {
         if (!outFB->readPixels(m_buffer, rect.x1, rect.y1, width, height))
             readSucceeded = false;
     });
-
-    g_pHyprRenderer->m_renderData.pMonitor.reset();
 
     if (!readSucceeded) {
         LOGM(Log::ERR, "Can't copy: failed to read pixels to shm");
@@ -492,22 +494,24 @@ void CScreenshareFrame::storeTempFB() {
     m_session->m_tempFB->alloc(m_bufferSize.x, m_bufferSize.y);
     m_session->m_tempFB->setImageDescription(NColorManagement::DEFAULT_SRGB_IMAGE_DESCRIPTION);
 
-    CRegion fakeDamage = {0, 0, m_bufferSize.x, m_bufferSize.y};
+    CRegion                   fakeDamage = {0, 0, m_bufferSize.x, m_bufferSize.y};
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{m_session->monitor(), pass};
 
-    if (!g_pHyprRenderer->beginFullFakeRender(m_session->monitor(), fakeDamage, m_session->m_tempFB)) {
+    if (!g_pHyprRenderer->beginFullFakeRender(context, fakeDamage, m_session->m_tempFB)) {
         LOGM(Log::ERR, "Can't copy: failed to begin rendering to temp fb");
         return;
     }
 
     switch (m_session->m_type) {
         case SHARE_REGION: // TODO: could this be better? this is how screencopy works
-        case SHARE_MONITOR: renderMonitor(); break;
-        case SHARE_WINDOW: renderWindow(); break;
+        case SHARE_MONITOR: renderMonitor(context); break;
+        case SHARE_WINDOW: renderWindow(context); break;
         case SHARE_NONE:
         default: return;
     }
 
-    g_pHyprRenderer->endRender();
+    g_pHyprRenderer->endRender(context);
 }
 
 Vector2D CScreenshareFrame::bufferSize() const {

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -315,7 +315,7 @@ void CScreenshareFrame::renderMonitor(Render::CRenderingContext& context) {
 
     if (m_overlayCursor) {
         CRegion  fakeDamage = {0, 0, m_bufferSize.x, m_bufferSize.y};
-        Vector2D cursorPos  = g_pInputManager->getMouseCoordsInternal() - PMONITOR->m_position - m_session->m_captureBox.pos() / PMONITOR->m_scale;
+        Vector2D cursorPos  = Pointer::mgr()->untransformedPosition() - PMONITOR->m_position - m_session->m_captureBox.pos() / PMONITOR->m_scale;
         Pointer::mgr()->renderSoftwareCursorsFor(context, PMONITOR, Time::steadyNow(), fakeDamage, cursorPos, true);
     }
 }
@@ -359,7 +359,7 @@ void CScreenshareFrame::renderWindow(Render::CRenderingContext& context) {
 
     CRegion fakeDamage = {0, 0, INT16_MAX, INT16_MAX};
     Pointer::mgr()->renderSoftwareCursorsFor(context, PMONITOR->m_self.lock(), NOW, fakeDamage,
-                                             g_pInputManager->getMouseCoordsInternal() - PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT), true, true);
+                                             Pointer::mgr()->untransformedPosition() - PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT), true, true);
 }
 
 void CScreenshareFrame::render(Render::CRenderingContext& context) {

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -7,6 +7,7 @@
 #include "../../render/Renderer.hpp"
 #include "../../render/OpenGL.hpp"
 #include "../../output/Monitor.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include "../../state/MonitorState.hpp"
 #include "../../desktop/view/window/Window.hpp"
 #include "../../desktop/view/window/WindowPresentation.hpp"
@@ -280,13 +281,14 @@ void CScreenshareFrame::renderMonitor() {
         if UNLIKELY (!PWORKSPACE && w->presentation().alphaValue(WINDOW_ALPHA_FADE) * w->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) != 0.f)
             continue;
 
-        const auto renderOffset     = PWORKSPACE && !(w->m_state & WINDOW_STATE_PINNED) ? PWORKSPACE->m_renderOffset->value() : Vector2D{};
-        const auto REALSIZE         = w->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
-        const auto REALPOS          = w->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + renderOffset;
-        const auto noScreenShareBox = CBox{REALPOS.x, REALPOS.y, std::max(REALSIZE.x, 5.0), std::max(REALSIZE.y, 5.0)}
-                                          .translate(-PMONITOR->m_position)
-                                          .scale(PMONITOR->m_scale)
-                                          .translate(-m_session->m_captureBox.pos());
+        const auto PWORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+        const auto renderOffset      = PWORKSPACEMONITOR && !(w->m_state & WINDOW_STATE_PINNED) ? PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWORKSPACE) : Vector2D{};
+        const auto REALSIZE          = w->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
+        const auto REALPOS           = w->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + renderOffset;
+        const auto noScreenShareBox  = CBox{REALPOS.x, REALPOS.y, std::max(REALSIZE.x, 5.0), std::max(REALSIZE.y, 5.0)}
+                                           .translate(-PMONITOR->m_position)
+                                           .scale(PMONITOR->m_scale)
+                                           .translate(-m_session->m_captureBox.pos());
 
         // seems like rounding doesn't play well with how we manipulate the box position to render regions causing the window to leak through
         const auto dontRound     = m_session->m_captureBox.pos() != Vector2D() || Fullscreen::controller()->isFullscreen(w, Fullscreen::FSMODE_FULLSCREEN);

--- a/src/managers/screenshare/ScreenshareManager.hpp
+++ b/src/managers/screenshare/ScreenshareManager.hpp
@@ -145,7 +145,7 @@ namespace Screenshare {
         } m_listeners;
 
         bool copy();
-        void render();
+        void render(Render::CRenderingContext&);
         void calculateConstraints();
 
         friend class CScreenshareFrame;
@@ -183,10 +183,10 @@ namespace Screenshare {
         bool copyDmabuf();
         bool copyShm();
 
-        void render();
-        void renderMonitor();
-        void renderMonitorRegion();
-        void renderWindow();
+        void render(Render::CRenderingContext&);
+        void renderMonitor(Render::CRenderingContext&);
+        void renderMonitorRegion(Render::CRenderingContext&);
+        void renderWindow(Render::CRenderingContext&);
 
         void storeTempFB();
 

--- a/src/notification/NotificationOverlay.cpp
+++ b/src/notification/NotificationOverlay.cpp
@@ -198,7 +198,7 @@ std::vector<SP<CNotification>> CNotificationOverlay::getNotifications() const {
     return m_notifications;
 }
 
-CBox CNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
+CBox CNotificationOverlay::drawNotifications(Render::CRenderingContext& context, PHLMONITOR pMonitor) {
     const float reservedTopPx   = pMonitor->m_reservedArea.top() * pMonitor->m_scale;
     const float reservedRightPx = pMonitor->m_reservedArea.right() * pMonitor->m_scale;
 
@@ -252,24 +252,24 @@ CBox CNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
         CRectPassElement::SRectData bgData;
         bgData.box   = {firstRectX, offsetY, firstRectW, NOTIFSIZE.y};
         bgData.color = notif->color();
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(bgData));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(bgData));
 
         CRectPassElement::SRectData fgData;
         fgData.box   = {secondRectX, offsetY, secondRectW, NOTIFSIZE.y};
         fgData.color = CHyprColor{0.F, 0.F, 0.F, 1.F};
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(fgData));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(fgData));
 
         CRectPassElement::SRectData progressData;
         progressData.box   = {secondRectX + 3, offsetY + NOTIFSIZE.y - 4, THIRDRECTPERC * std::max(0.0, NOTIFSIZE.x - 6.0), 2};
         progressData.color = notif->color();
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(progressData));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(progressData));
 
         if (notif->icon() != ICON_NONE && notif->m_cache.iconTex) {
             CTexPassElement::SRenderData iconData;
             iconData.tex = notif->m_cache.iconTex;
             iconData.box = {secondRectX + NOTIF_LEFTBAR_SIZE + ICONPADFORNOTIF - 1, offsetY - 2 + std::round((NOTIFSIZE.y - ICONH) / 2.0), ICONW, ICONH};
             iconData.a   = 1.F;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(iconData)));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(iconData)));
         }
 
         if (notif->m_cache.textTex) {
@@ -277,7 +277,7 @@ CBox CNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
             textData.tex = notif->m_cache.textTex;
             textData.box = {secondRectX + NOTIF_LEFTBAR_SIZE + ICONW + 2 * ICONPADFORNOTIF, offsetY - 2 + std::round((NOTIFSIZE.y - TEXTH) / 2.0), TEXTW, TEXTH};
             textData.a   = 1.F;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(textData)));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(textData)));
         }
 
         // adjust offset and move on
@@ -294,7 +294,7 @@ CBox CNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
                 sc<int>(offsetY + NOTIF_OFFSET_Y)};
 }
 
-void CNotificationOverlay::draw(PHLMONITOR pMonitor) {
+void CNotificationOverlay::draw(Render::CRenderingContext& context, PHLMONITOR pMonitor) {
     // Draw the notifications
     if (m_notifications.empty()) {
         if (m_lastDamage.width > 0 && m_lastDamage.height > 0)
@@ -303,7 +303,7 @@ void CNotificationOverlay::draw(PHLMONITOR pMonitor) {
         return;
     }
 
-    CBox damage = drawNotifications(pMonitor);
+    CBox damage = drawNotifications(context, pMonitor);
 
     g_pHyprRenderer->damageBox(damage);
     g_pHyprRenderer->damageBox(m_lastDamage);

--- a/src/notification/NotificationOverlay.hpp
+++ b/src/notification/NotificationOverlay.hpp
@@ -5,6 +5,10 @@
 
 #include "../desktop/DesktopTypes.hpp"
 
+namespace Render {
+    class CRenderingContext;
+}
+
 namespace Notification {
 
     class CNotificationOverlay {
@@ -12,7 +16,7 @@ namespace Notification {
         CNotificationOverlay();
         ~CNotificationOverlay();
 
-        void              draw(PHLMONITOR pMonitor);
+        void              draw(Render::CRenderingContext&, PHLMONITOR pMonitor);
         SP<CNotification> addNotification(const std::string& text, const CHyprColor& color, const float timeMs, const eIcons icon = ICON_NONE, const float fontSize = 13.f);
         void              dismissNotifications(const int amount);
         void              dismissNotification(const SP<CNotification>& notification);
@@ -25,7 +29,7 @@ namespace Notification {
         void                           ensureNotificationCache(CNotification& notif, PHLMONITOR pMonitor, const std::string& fontFamily);
         eIconBackend                   iconBackendForFont(const std::string& fontFamily);
         CBox                           notificationDamageForMonitor(PHLMONITOR pMonitor);
-        CBox                           drawNotifications(PHLMONITOR pMonitor);
+        CBox                           drawNotifications(Render::CRenderingContext&, PHLMONITOR pMonitor);
         void                           scheduleFrames() const;
         CBox                           m_lastDamage;
 

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1835,7 +1835,7 @@ void CMonitor::setCTM(const Mat3x3& ctm_) {
 }
 
 uint32_t CMonitor::isSolitaryBlocked(bool full) {
-    uint32_t   reasons = 0;
+    uint32_t reasons = 0;
 
     const auto PWORKSPACE = m_activeWorkspace;
     if (!PWORKSPACE) {
@@ -1876,6 +1876,12 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
 
     if (PROTO::data->dndActive()) {
         reasons |= SC_DND;
+        if (!full)
+            return reasons;
+    }
+
+    if (m_resources && resources()->m_sceneStack.hasOverride()) {
+        reasons |= SC_TRANSFORM;
         if (!full)
             return reasons;
     }
@@ -2060,6 +2066,12 @@ uint16_t CMonitor::isDSBlocked(bool full) {
     static auto PDIRECTSCANOUT = CConfigValue<Config::INTEGER>("render:direct_scanout");
     static auto PNONSHADER     = CConfigValue<Config::INTEGER>("render:non_shader_cm");
     const auto  PWORKSPACE     = m_activeWorkspace;
+
+    if (resources()->m_sceneStack.hasOverride()) {
+        reasons |= DS_BLOCK_TRANSFORM;
+        if (!full)
+            return reasons;
+    }
 
     // Fast reject for the hot render path; full=true callers still collect
     // the remaining blockers for hyprctl/debug output below.

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -52,6 +52,7 @@
 #include "../helpers/Drm.hpp"
 #include "MonitorFrameScheduler.hpp"
 #include "OutputCommitCoordinator.hpp"
+#include "WorkspaceTransition.hpp"
 #include <aquamarine/output/Output.hpp>
 #include "debug/log/Logger.hpp"
 #include "notification/NotificationOverlay.hpp"
@@ -85,7 +86,8 @@ constexpr const char* drmFormatToString(uint32_t drmFormat) {
     }
 }
 
-CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_name(output_->name), m_state(this), m_output(output_), m_imageDescription(getDefaultImageDescription()) {
+CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) :
+    m_name(output_->name), m_state(this), m_output(output_), m_workspaceTransition(makeUnique<CWorkspaceTransition>(*this)), m_imageDescription(getDefaultImageDescription()) {
     Animation::mgr()->createAnimation(0.f, m_specialFade, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
     m_specialFade->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
     Animation::mgr()->createAnimation(0.f, m_specialDim, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
@@ -106,6 +108,7 @@ CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_name(output_->name), m_s
 }
 
 CMonitor::~CMonitor() {
+    m_workspaceTransition->clear();
     m_events.destroy.emit();
     if (g_pHyprRenderer && g_pHyprRenderer->glBackend())
         g_pHyprRenderer->glBackend()->destroyMonitorResources(m_self);
@@ -1666,6 +1669,15 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace, bool noFocus)
     }
 
     // open special
+    const bool TRANSFERREDTRANSITION = PMONITOR && PMONITOR != m_self && PMONITOR->m_workspaceTransition->get(pWorkspace);
+    if (PMONITOR && PMONITOR != m_self) {
+        PMONITOR->m_workspaceTransition->transferTo(*m_workspaceTransition, pWorkspace);
+        if (TRANSFERREDTRANSITION) {
+            g_pHyprRenderer->damageMonitor(PMONITOR);
+            g_pHyprRenderer->damageMonitor(m_self.lock());
+        }
+    }
+
     pWorkspace->m_monitor               = m_self;
     m_activeSpecialWorkspace            = pWorkspace;
     m_activeSpecialWorkspace->m_visible = true;
@@ -1881,14 +1893,21 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
             return reasons;
     }
 
-    if (PWORKSPACE->m_alpha->value() != 1.f) {
+    if (m_workspaceTransition->alphaValue(PWORKSPACE) != 1.F) {
         reasons |= SC_ALPHA;
         if (!full)
             return reasons;
     }
 
-    if (PWORKSPACE->m_renderOffset->value() != Vector2D{}) {
+    if (m_workspaceTransition->offsetValue(PWORKSPACE) != Vector2D{}) {
         reasons |= SC_OFFSET;
+        if (!full)
+            return reasons;
+    }
+
+    const auto TRANSITIONPARTICIPANTS = m_workspaceTransition->participants();
+    if (!TRANSITIONPARTICIPANTS.empty()) {
+        reasons |= SC_WORKSPACES;
         if (!full)
             return reasons;
     }
@@ -1947,8 +1966,12 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
         }
     }
 
-    for (auto const& ws : State::workspaceState()->workspaces()) {
-        if (ws->m_alpha->value() <= 0.F || !ws->m_isSpecialWorkspace || ws->m_monitor != m_self)
+    auto specialWorkspaces = m_workspaceTransition->participants(true);
+    if (m_activeSpecialWorkspace && !std::ranges::contains(specialWorkspaces, m_activeSpecialWorkspace))
+        specialWorkspaces.emplace_back(m_activeSpecialWorkspace);
+
+    for (auto const& ws : specialWorkspaces) {
+        if (m_workspaceTransition->alphaValue(ws) <= 0.F)
             continue;
 
         reasons |= SC_WORKSPACES;
@@ -2093,6 +2116,12 @@ uint16_t CMonitor::isDSBlocked(bool full) {
 
     if (Pointer::mgr()->softwareLockedFor(m_self.lock())) {
         reasons |= DS_BLOCK_SW;
+        if (!full)
+            return reasons;
+    }
+
+    if (!m_workspaceTransition->participants().empty()) {
+        reasons |= DS_BLOCK_TRANSFORM;
         if (!full)
             return reasons;
     }

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1162,7 +1162,7 @@ void CMonitor::scheduleFrame(Aquamarine::IOutput::scheduleFrameReason reason) {
 }
 
 void CMonitor::addDamage(const pixman_region32_t* rg) {
-    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->position()).run() == m_self) {
+    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run() == m_self) {
         m_damage.damageEntire();
         scheduleFrame(Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
     } else if (m_damage.damage(rg))
@@ -1174,7 +1174,7 @@ void CMonitor::addDamage(const CRegion& rg) {
 }
 
 void CMonitor::addDamage(const CBox& box) {
-    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->position()).run() == m_self) {
+    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run() == m_self) {
         m_damage.damageEntire();
         scheduleFrame(Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
         return;
@@ -2024,7 +2024,7 @@ uint8_t CMonitor::isTearingBlocked(bool full) {
         }
     }
 
-    const bool CURSOR_ZOOMED = m_cursorZoom->value() != 1.0 && m_self == State::monitorState()->query().vec(Pointer::mgr()->position()).run();
+    const bool CURSOR_ZOOMED = m_cursorZoom->value() != 1.0 && m_self == State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run();
     if (CURSOR_ZOOMED || m_zoomAnimProgress->value() != 1.0) {
         reasons |= TC_ZOOM;
         if (!full) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1149,7 +1149,7 @@ void CMonitor::scheduleFrame(Aquamarine::IOutput::scheduleFrameReason reason) {
 }
 
 void CMonitor::addDamage(const pixman_region32_t* rg) {
-    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->position()).run() == m_self) {
+    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run() == m_self) {
         m_damage.damageEntire();
         scheduleFrame(Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
     } else if (m_damage.damage(rg))
@@ -1161,7 +1161,7 @@ void CMonitor::addDamage(const CRegion& rg) {
 }
 
 void CMonitor::addDamage(const CBox& box) {
-    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->position()).run() == m_self) {
+    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run() == m_self) {
         m_damage.damageEntire();
         scheduleFrame(Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
         return;
@@ -2011,7 +2011,7 @@ uint8_t CMonitor::isTearingBlocked(bool full) {
         }
     }
 
-    const bool CURSOR_ZOOMED = m_cursorZoom->value() != 1.0 && m_self == State::monitorState()->query().vec(Pointer::mgr()->position()).run();
+    const bool CURSOR_ZOOMED = m_cursorZoom->value() != 1.0 && m_self == State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run();
     if (CURSOR_ZOOMED || m_zoomAnimProgress->value() != 1.0) {
         reasons |= TC_ZOOM;
         if (!full) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1835,7 +1835,7 @@ void CMonitor::setCTM(const Mat3x3& ctm_) {
 }
 
 uint32_t CMonitor::isSolitaryBlocked(bool full) {
-    uint32_t reasons = 0;
+    uint32_t   reasons = 0;
 
     const auto PWORKSPACE = m_activeWorkspace;
     if (!PWORKSPACE) {
@@ -2011,7 +2011,8 @@ uint8_t CMonitor::isTearingBlocked(bool full) {
         }
     }
 
-    if (g_pHyprRenderer->m_renderData.mouseZoomFactor != 1.0) {
+    const bool CURSOR_ZOOMED = m_cursorZoom->value() != 1.0 && m_self == State::monitorState()->query().vec(Pointer::mgr()->position()).run();
+    if (CURSOR_ZOOMED || m_zoomAnimProgress->value() != 1.0) {
         reasons |= TC_ZOOM;
         if (!full) {
             Log::logger->log(Log::WARN, "Tearing commit requested but scale factor is not 1, ignoring");

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1848,7 +1848,7 @@ void CMonitor::setCTM(const Mat3x3& ctm_) {
 }
 
 uint32_t CMonitor::isSolitaryBlocked(bool full) {
-    uint32_t   reasons = 0;
+    uint32_t reasons = 0;
 
     const auto PWORKSPACE = m_activeWorkspace;
     if (!PWORKSPACE) {
@@ -1889,6 +1889,12 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
 
     if (PROTO::data->dndActive()) {
         reasons |= SC_DND;
+        if (!full)
+            return reasons;
+    }
+
+    if (m_resources && resources()->m_sceneStack.hasOverride()) {
+        reasons |= SC_TRANSFORM;
         if (!full)
             return reasons;
     }
@@ -2073,6 +2079,12 @@ uint16_t CMonitor::isDSBlocked(bool full) {
     static auto PDIRECTSCANOUT = CConfigValue<Config::INTEGER>("render:direct_scanout");
     static auto PNONSHADER     = CConfigValue<Config::INTEGER>("render:non_shader_cm");
     const auto  PWORKSPACE     = m_activeWorkspace;
+
+    if (resources()->m_sceneStack.hasOverride()) {
+        reasons |= DS_BLOCK_TRANSFORM;
+        if (!full)
+            return reasons;
+    }
 
     // Fast reject for the hot render path; full=true callers still collect
     // the remaining blockers for hyprctl/debug output below.

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1848,7 +1848,7 @@ void CMonitor::setCTM(const Mat3x3& ctm_) {
 }
 
 uint32_t CMonitor::isSolitaryBlocked(bool full) {
-    uint32_t reasons = 0;
+    uint32_t   reasons = 0;
 
     const auto PWORKSPACE = m_activeWorkspace;
     if (!PWORKSPACE) {
@@ -2024,7 +2024,8 @@ uint8_t CMonitor::isTearingBlocked(bool full) {
         }
     }
 
-    if (g_pHyprRenderer->m_renderData.mouseZoomFactor != 1.0) {
+    const bool CURSOR_ZOOMED = m_cursorZoom->value() != 1.0 && m_self == State::monitorState()->query().vec(Pointer::mgr()->position()).run();
+    if (CURSOR_ZOOMED || m_zoomAnimProgress->value() != 1.0) {
         reasons |= TC_ZOOM;
         if (!full) {
             Log::logger->log(Log::WARN, "Tearing commit requested but scale factor is not 1, ignoring");

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -51,6 +51,7 @@
 #include "../event/EventBus.hpp"
 #include "../helpers/Drm.hpp"
 #include "MonitorFrameScheduler.hpp"
+#include "WorkspaceTransition.hpp"
 #include <aquamarine/output/Output.hpp>
 #include "debug/log/Logger.hpp"
 #include "notification/NotificationOverlay.hpp"
@@ -84,7 +85,8 @@ constexpr const char* drmFormatToString(uint32_t drmFormat) {
     }
 }
 
-CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_name(output_->name), m_state(this), m_output(output_), m_imageDescription(getDefaultImageDescription()) {
+CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) :
+    m_name(output_->name), m_state(this), m_output(output_), m_workspaceTransition(makeUnique<CWorkspaceTransition>(*this)), m_imageDescription(getDefaultImageDescription()) {
     Animation::mgr()->createAnimation(0.f, m_specialFade, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
     m_specialFade->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
     Animation::mgr()->createAnimation(0.f, m_specialDim, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
@@ -103,6 +105,7 @@ CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_name(output_->name), m_s
 }
 
 CMonitor::~CMonitor() {
+    m_workspaceTransition->clear();
     m_events.destroy.emit();
     if (g_pHyprRenderer && g_pHyprRenderer->glBackend())
         g_pHyprRenderer->glBackend()->destroyMonitorResources(m_self);
@@ -1653,6 +1656,15 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace, bool noFocus)
     }
 
     // open special
+    const bool TRANSFERREDTRANSITION = PMONITOR && PMONITOR != m_self && PMONITOR->m_workspaceTransition->get(pWorkspace);
+    if (PMONITOR && PMONITOR != m_self) {
+        PMONITOR->m_workspaceTransition->transferTo(*m_workspaceTransition, pWorkspace);
+        if (TRANSFERREDTRANSITION) {
+            g_pHyprRenderer->damageMonitor(PMONITOR);
+            g_pHyprRenderer->damageMonitor(m_self.lock());
+        }
+    }
+
     pWorkspace->m_monitor               = m_self;
     m_activeSpecialWorkspace            = pWorkspace;
     m_activeSpecialWorkspace->m_visible = true;
@@ -1868,14 +1880,21 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
             return reasons;
     }
 
-    if (PWORKSPACE->m_alpha->value() != 1.f) {
+    if (m_workspaceTransition->alphaValue(PWORKSPACE) != 1.F) {
         reasons |= SC_ALPHA;
         if (!full)
             return reasons;
     }
 
-    if (PWORKSPACE->m_renderOffset->value() != Vector2D{}) {
+    if (m_workspaceTransition->offsetValue(PWORKSPACE) != Vector2D{}) {
         reasons |= SC_OFFSET;
+        if (!full)
+            return reasons;
+    }
+
+    const auto TRANSITIONPARTICIPANTS = m_workspaceTransition->participants();
+    if (!TRANSITIONPARTICIPANTS.empty()) {
+        reasons |= SC_WORKSPACES;
         if (!full)
             return reasons;
     }
@@ -1934,8 +1953,12 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
         }
     }
 
-    for (auto const& ws : State::workspaceState()->workspaces()) {
-        if (ws->m_alpha->value() <= 0.F || !ws->m_isSpecialWorkspace || ws->m_monitor != m_self)
+    auto specialWorkspaces = m_workspaceTransition->participants(true);
+    if (m_activeSpecialWorkspace && !std::ranges::contains(specialWorkspaces, m_activeSpecialWorkspace))
+        specialWorkspaces.emplace_back(m_activeSpecialWorkspace);
+
+    for (auto const& ws : specialWorkspaces) {
+        if (m_workspaceTransition->alphaValue(ws) <= 0.F)
             continue;
 
         reasons |= SC_WORKSPACES;
@@ -2080,6 +2103,12 @@ uint16_t CMonitor::isDSBlocked(bool full) {
 
     if (Pointer::mgr()->softwareLockedFor(m_self.lock())) {
         reasons |= DS_BLOCK_SW;
+        if (!full)
+            return reasons;
+    }
+
+    if (!m_workspaceTransition->participants().empty()) {
+        reasons |= DS_BLOCK_TRANSFORM;
         if (!full)
             return reasons;
     }

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -41,6 +41,7 @@ namespace Monitor {
     class CMonitorResources;
     class CMonitorFrameScheduler;
     class COutputCommitCoordinator;
+    class CWorkspaceTransition;
     class CMonitor;
 
     class CMonitorState {
@@ -138,6 +139,7 @@ namespace Monitor {
 
         UP<CMonitorFrameScheduler>     m_frameScheduler;
         UP<COutputCommitCoordinator>   m_commitCoordinator;
+        UP<CWorkspaceTransition>       m_workspaceTransition;
 
         // mirroring
         PHLMONITORREF              m_mirrorOf;

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -40,6 +40,7 @@ class CEventLoopTimer;
 namespace Monitor {
     class CMonitorResources;
     class CMonitorFrameScheduler;
+    class CWorkspaceTransition;
     class CMonitor;
 
     class CMonitorState {
@@ -136,6 +137,7 @@ namespace Monitor {
         PHLMONITORREF                  m_self;
 
         UP<CMonitorFrameScheduler>     m_frameScheduler;
+        UP<CWorkspaceTransition>       m_workspaceTransition;
 
         // mirroring
         PHLMONITORREF              m_mirrorOf;

--- a/src/output/MonitorResources.cpp
+++ b/src/output/MonitorResources.cpp
@@ -62,6 +62,11 @@ SP<Render::IFramebuffer> CMonitorResources::getUnusedWorkBuffer() {
     return res.buffer;
 }
 
+size_t CMonitorResources::availableWorkBufferCount() const {
+    const auto AVAILABLE = std::ranges::count_if(m_workBuffers, [](const auto& resource) { return resource.buffer.strongRef() < 2; });
+    return AVAILABLE + MAX_WORK_BUFFERS - m_workBuffers.size();
+}
+
 SP<Render::IFramebuffer> CMonitorResources::getUnusedWorkBuffer(const Vector2D& size) {
     RASSERT((size.x > 0 && size.y > 0), "cannot get a workbuffer with negative / zero size! (attempted {}x{})", size.x, size.y);
 

--- a/src/output/MonitorResources.cpp
+++ b/src/output/MonitorResources.cpp
@@ -3,9 +3,11 @@
 #include "../helpers/cm/ColorManagement.hpp"
 #include "../render/Renderer.hpp"
 #include "../config/ConfigValue.hpp"
+#include "../render/scene/MonitorScene.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <format>
+#include <hyprutils/memory/SharedPtr.hpp>
 
 using namespace Monitor;
 using namespace NColorManagement;
@@ -19,6 +21,7 @@ CMonitorResources::CMonitorResources(WP<CMonitor> monitor, DRMFormat format, Vec
     m_monitor(monitor), m_drmFormat(format), m_size(size), m_imageDescription(imageDescription) {
     initFB(m_blurFB);
     monitor->m_blurFBDirty = true;
+    m_sceneStack.push(makeShared<Render::CMonitorScene>(monitor.lock()));
 }
 
 void CMonitorResources::initFB(SP<Render::IFramebuffer> fb) {

--- a/src/output/MonitorResources.cpp
+++ b/src/output/MonitorResources.cpp
@@ -63,6 +63,11 @@ SP<Render::IFramebuffer> CMonitorResources::getUnusedWorkBuffer() {
     return res.buffer;
 }
 
+size_t CMonitorResources::availableWorkBufferCount() const {
+    const auto AVAILABLE = std::ranges::count_if(m_workBuffers, [](const auto& resource) { return resource.buffer.strongRef() < 2; });
+    return AVAILABLE + MAX_WORK_BUFFERS - m_workBuffers.size();
+}
+
 SP<Render::IFramebuffer> CMonitorResources::getUnusedWorkBuffer(const Vector2D& size) {
     RASSERT((size.x > 0 && size.y > 0), "cannot get a workbuffer with negative / zero size! (attempted {}x{})", size.x, size.y);
 

--- a/src/output/MonitorResources.cpp
+++ b/src/output/MonitorResources.cpp
@@ -2,9 +2,11 @@
 #include "../managers/screenshare/ScreenshareManager.hpp"
 #include "../helpers/cm/ColorManagement.hpp"
 #include "../render/Renderer.hpp"
+#include "../render/scene/MonitorScene.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <format>
+#include <hyprutils/memory/SharedPtr.hpp>
 
 using namespace Monitor;
 using namespace NColorManagement;
@@ -18,6 +20,7 @@ CMonitorResources::CMonitorResources(WP<CMonitor> monitor, DRMFormat format, Vec
     m_monitor(monitor), m_drmFormat(format), m_size(size), m_imageDescription(imageDescription) {
     initFB(m_blurFB);
     monitor->m_blurFBDirty = true;
+    m_sceneStack.push(makeShared<Render::CMonitorScene>(monitor.lock()));
 }
 
 void CMonitorResources::initFB(SP<Render::IFramebuffer> fb) {

--- a/src/output/MonitorResources.hpp
+++ b/src/output/MonitorResources.hpp
@@ -15,6 +15,7 @@ namespace Monitor {
 
         SP<Render::IFramebuffer> getUnusedWorkBuffer();
         SP<Render::IFramebuffer> getUnusedWorkBuffer(const Vector2D& size);
+        size_t                   availableWorkBufferCount() const;
         void                     forEachUnusedFB(std::function<void(SP<Render::IFramebuffer>)> callback, bool includeNamed = false);
         bool                     hasMirrorFB() const;
         bool                     shouldKeepMirrorFB() const;

--- a/src/output/MonitorResources.hpp
+++ b/src/output/MonitorResources.hpp
@@ -4,6 +4,7 @@
 #include "../helpers/Format.hpp"
 #include "../helpers/time/Timer.hpp"
 #include "../render/Framebuffer.hpp"
+#include "../render/scene/SceneStack.hpp"
 #include <hyprutils/math/Vector2D.hpp>
 #include <vector>
 
@@ -32,6 +33,8 @@ namespace Monitor {
 
         SP<Render::ITexture>     m_stencilTex; // TODO fix blur ignore alpha and remove
         SP<Render::IFramebuffer> m_blurFB;
+
+        Render::CSceneStack      m_sceneStack;
 
       private:
         void                                initFB(SP<Render::IFramebuffer> fb);

--- a/src/output/MonitorResources.hpp
+++ b/src/output/MonitorResources.hpp
@@ -4,6 +4,7 @@
 #include "../helpers/Format.hpp"
 #include "../helpers/time/Timer.hpp"
 #include "../render/Framebuffer.hpp"
+#include "../render/scene/SceneStack.hpp"
 #include <hyprutils/math/Vector2D.hpp>
 #include <vector>
 
@@ -31,6 +32,8 @@ namespace Monitor {
 
         SP<Render::ITexture>     m_stencilTex; // TODO fix blur ignore alpha and remove
         SP<Render::IFramebuffer> m_blurFB;
+
+        Render::CSceneStack      m_sceneStack;
 
       private:
         void                                initFB(SP<Render::IFramebuffer> fb);

--- a/src/output/MonitorZoomController.cpp
+++ b/src/output/MonitorZoomController.cpp
@@ -2,7 +2,7 @@
 
 #include <hyprlang.hpp>
 #include "../config/ConfigValue.hpp"
-#include "../managers/input/InputManager.hpp"
+#include "../pointer/PointerManager.hpp"
 #include "../render/OpenGL.hpp"
 #include "desktop/DesktopTypes.hpp"
 #include "render/Renderer.hpp"
@@ -28,7 +28,7 @@ Vector2D CMonitorZoomController::getAnchor(const PHLMONITORREF& monitor) {
     if (m_anchorPinned)
         return m_pinnedAnchor;
 
-    return g_pInputManager->getMouseCoordsInternal() - monitor->m_position;
+    return Pointer::mgr()->untransformedPosition() - monitor->m_position;
 }
 
 void CMonitorZoomController::zoomWithDetachedCamera(CBox& result, const Render::CRenderingContext& context) {

--- a/src/output/MonitorZoomController.cpp
+++ b/src/output/MonitorZoomController.cpp
@@ -31,12 +31,12 @@ Vector2D CMonitorZoomController::getAnchor(const PHLMONITORREF& monitor) {
     return g_pInputManager->getMouseCoordsInternal() - monitor->m_position;
 }
 
-void CMonitorZoomController::zoomWithDetachedCamera(CBox& result, const Render::SRenderData& m_renderData) {
+void CMonitorZoomController::zoomWithDetachedCamera(CBox& result, const Render::CRenderingContext& context) {
     static auto PZOOMRIGID = CConfigValue<Config::INTEGER>("cursor:zoom_rigid");
 
-    const auto  m      = m_renderData.pMonitor;
+    const auto  m      = context.sceneMonitor;
     auto        monbox = CBox(0, 0, m->m_size.x, m->m_size.y);
-    const auto  ZOOM   = g_pHyprRenderer->m_renderData.mouseZoomFactor;
+    const auto  ZOOM   = context.mouseZoomFactor;
     const auto  MOUSE  = getAnchor(m);
 
     if (m_lastZoomLevel != ZOOM) {
@@ -95,22 +95,22 @@ void CMonitorZoomController::zoomWithDetachedCamera(CBox& result, const Render::
     result = monbox;
 }
 
-void CMonitorZoomController::applyZoomTransform(CBox& monbox, const Render::SRenderData& m_renderData) {
+void CMonitorZoomController::applyZoomTransform(CBox& monbox, const Render::CRenderingContext& context) {
     static auto PZOOMRIGID          = CConfigValue<Config::INTEGER>("cursor:zoom_rigid");
     static auto PZOOMDETACHEDCAMERA = CConfigValue<Config::INTEGER>("cursor:zoom_detached_camera");
-    const auto  ZOOM                = g_pHyprRenderer->m_renderData.mouseZoomFactor;
+    const auto  ZOOM                = context.mouseZoomFactor;
 
     if (ZOOM == 1.F)
         return;
 
-    const auto m        = m_renderData.pMonitor;
+    const auto m        = context.sceneMonitor;
     const auto ORIGINAL = monbox;
     const auto INITANIM = m->m_zoomAnimProgress->value() != 1.0;
 
     if (*PZOOMDETACHEDCAMERA && !INITANIM)
-        zoomWithDetachedCamera(monbox, m_renderData);
+        zoomWithDetachedCamera(monbox, context);
     else {
-        const auto ZOOMCENTER = g_pHyprRenderer->m_renderData.mouseZoomUseMouse ? getAnchor(m) * m->m_scale : m->m_transformedSize / 2.f;
+        const auto ZOOMCENTER = context.mouseZoomUseMouse ? getAnchor(m) * m->m_scale : m->m_transformedSize / 2.f;
 
         monbox.translate(-ZOOMCENTER).scale(ZOOM).translate(*PZOOMRIGID ? m->m_transformedSize / 2.0 : ZOOMCENTER);
     }

--- a/src/output/MonitorZoomController.hpp
+++ b/src/output/MonitorZoomController.hpp
@@ -4,7 +4,7 @@
 #include "../desktop/DesktopTypes.hpp"
 
 namespace Render {
-    struct SRenderData;
+    class CRenderingContext;
 }
 
 namespace Monitor {
@@ -15,11 +15,11 @@ namespace Monitor {
         void pinAnchor(const Vector2D& anchor);
         void clearAnchor();
 
-        void applyZoomTransform(CBox& monbox, const Render::SRenderData& m_renderData);
+        void applyZoomTransform(CBox& monbox, const Render::CRenderingContext& context);
         bool shouldDamageEntire(float zoomLevel);
 
       private:
-        void     zoomWithDetachedCamera(CBox& result, const Render::SRenderData& m_renderData);
+        void     zoomWithDetachedCamera(CBox& result, const Render::CRenderingContext& context);
         Vector2D getAnchor(const PHLMONITORREF& monitor);
 
         CBox     m_camera;

--- a/src/output/WorkspaceTransition.cpp
+++ b/src/output/WorkspaceTransition.cpp
@@ -5,7 +5,8 @@
 #include "../config/shared/animation/AnimationTree.hpp"
 #include "../desktop/Workspace.hpp"
 #include "../desktop/state/WindowState.hpp"
-#include "../desktop/view/Window.hpp"
+#include "../desktop/view/window/Window.hpp"
+#include "../desktop/view/window/WindowPresentation.hpp"
 #include "../managers/eventLoop/EventLoopManager.hpp"
 
 #include <algorithm>
@@ -178,7 +179,7 @@ void CWorkspaceTransition::installCallbacks(SWorkspaceTransitionState& state) {
             if (!validMapped(window) || window->m_workspace != WORKSPACE)
                 continue;
 
-            window->onWorkspaceAnimUpdate();
+            window->presentation().onWorkspaceAnimUpdate();
         }
     });
 

--- a/src/output/WorkspaceTransition.cpp
+++ b/src/output/WorkspaceTransition.cpp
@@ -1,0 +1,199 @@
+#include "WorkspaceTransition.hpp"
+
+#include "Monitor.hpp"
+#include "../animation/AnimationManager.hpp"
+#include "../config/shared/animation/AnimationTree.hpp"
+#include "../desktop/Workspace.hpp"
+#include "../desktop/state/WindowState.hpp"
+#include "../desktop/view/Window.hpp"
+#include "../managers/eventLoop/EventLoopManager.hpp"
+
+#include <algorithm>
+#include <ranges>
+
+using namespace Monitor;
+
+CWorkspaceTransition::CWorkspaceTransition(CMonitor& owner) : m_owner(owner) {
+    ;
+}
+
+SWorkspaceTransitionState& CWorkspaceTransition::ensure(PHLWORKSPACE workspace) {
+    RASSERT(workspace, "Cannot create transition state for a null workspace");
+
+    if (const auto OWNER = workspace->m_monitor.lock(); OWNER && OWNER.get() != &m_owner)
+        return OWNER->m_workspaceTransition->ensure(workspace);
+
+    if (const auto STATE = get(workspace); STATE)
+        return *STATE;
+
+    auto state       = makeUnique<SWorkspaceTransitionState>();
+    state->workspace = workspace;
+
+    const auto CONFIG = Config::animationTree()->getAnimationPropertyConfig(workspace->m_isSpecialWorkspace ? "specialWorkspaceIn" : "workspacesIn");
+    Animation::mgr()->createAnimation(Vector2D{}, state->offset, CONFIG, workspace, AVARDAMAGE_ENTIRE);
+    Animation::mgr()->createAnimation(1.F, state->alpha, CONFIG, workspace, AVARDAMAGE_ENTIRE);
+    installCallbacks(*state);
+
+    m_states.emplace_back(std::move(state));
+    return *m_states.back();
+}
+
+SWorkspaceTransitionState* CWorkspaceTransition::get(PHLWORKSPACE workspace) {
+    const auto IT = std::ranges::find_if(m_states, [&workspace](const auto& state) { return state->workspace == workspace; });
+    return IT == m_states.end() ? nullptr : IT->get();
+}
+
+const SWorkspaceTransitionState* CWorkspaceTransition::get(PHLWORKSPACE workspace) const {
+    const auto IT = std::ranges::find_if(m_states, [&workspace](const auto& state) { return state->workspace == workspace; });
+    return IT == m_states.end() ? nullptr : IT->get();
+}
+
+bool CWorkspaceTransition::participates(PHLWORKSPACE workspace) const {
+    const auto STATE = get(workspace);
+    return STATE && (STATE->offset->isBeingAnimated() || STATE->alpha->isBeingAnimated() || STATE->forceRendering);
+}
+
+bool CWorkspaceTransition::isAnimating(PHLWORKSPACE workspace) const {
+    const auto STATE = get(workspace);
+    return STATE && (STATE->offset->isBeingAnimated() || STATE->alpha->isBeingAnimated());
+}
+
+bool CWorkspaceTransition::forceRendering(PHLWORKSPACE workspace) const {
+    const auto STATE = get(workspace);
+    return STATE && STATE->forceRendering;
+}
+
+float CWorkspaceTransition::alphaValue(PHLWORKSPACE workspace) const {
+    const auto STATE = get(workspace);
+    return STATE ? STATE->alpha->value() : 1.F;
+}
+
+Vector2D CWorkspaceTransition::offsetValue(PHLWORKSPACE workspace) const {
+    const auto STATE = get(workspace);
+    return STATE ? STATE->offset->value() : Vector2D{};
+}
+
+std::string CWorkspaceTransition::style(PHLWORKSPACE workspace) const {
+    if (const auto STATE = get(workspace); STATE)
+        return STATE->alpha->getStyle();
+
+    if (!workspace)
+        return {};
+
+    const auto CONFIG = Config::animationTree()->getAnimationPropertyConfig(workspace->m_isSpecialWorkspace ? "specialWorkspaceIn" : "workspacesIn");
+    return CONFIG && CONFIG->pValues ? CONFIG->pValues->internalStyle : std::string{};
+}
+
+std::vector<PHLWORKSPACE> CWorkspaceTransition::participants(std::optional<bool> special) const {
+    std::vector<PHLWORKSPACE> result;
+    result.reserve(m_states.size());
+
+    for (const auto& state : m_states) {
+        const auto WORKSPACE = state->workspace.lock();
+        if (!WORKSPACE || (!state->offset->isBeingAnimated() && !state->alpha->isBeingAnimated() && !state->forceRendering) ||
+            (special.has_value() && WORKSPACE->m_isSpecialWorkspace != *special))
+            continue;
+
+        result.emplace_back(WORKSPACE);
+    }
+
+    return result;
+}
+
+void CWorkspaceTransition::setForceRendering(PHLWORKSPACE workspace, bool forceRendering) {
+    if (!workspace)
+        return;
+
+    if (const auto OWNER = workspace->m_monitor.lock(); OWNER && OWNER.get() != &m_owner) {
+        OWNER->m_workspaceTransition->setForceRendering(workspace, forceRendering);
+        return;
+    }
+
+    if (forceRendering) {
+        ensure(workspace).forceRendering = true;
+        return;
+    }
+
+    const auto STATE = get(workspace);
+    if (!STATE)
+        return;
+
+    STATE->forceRendering = false;
+    prune(workspace);
+}
+
+void CWorkspaceTransition::transferTo(CWorkspaceTransition& destination, PHLWORKSPACE workspace) {
+    if (&destination == this || !workspace)
+        return;
+
+    const auto IT = std::ranges::find_if(m_states, [&workspace](const auto& state) { return state->workspace == workspace; });
+    if (IT == m_states.end())
+        return;
+
+    destination.remove(workspace);
+    auto state = std::move(*IT);
+    m_states.erase(IT);
+
+    destination.installCallbacks(*state);
+    destination.m_states.emplace_back(std::move(state));
+}
+
+void CWorkspaceTransition::remove(PHLWORKSPACE workspace) {
+    std::erase_if(m_states, [&workspace](const auto& state) { return state->workspace == workspace; });
+}
+
+void CWorkspaceTransition::clear() {
+    for (const auto& state : m_states) {
+        state->offset->resetAllCallbacks();
+        state->alpha->resetAllCallbacks();
+    }
+
+    m_states.clear();
+}
+
+void CWorkspaceTransition::prune(PHLWORKSPACE workspace) {
+    std::erase_if(m_states, [this, &workspace](const auto& state) {
+        const auto WORKSPACE = state->workspace.lock();
+        if (!WORKSPACE)
+            return true;
+        if (workspace && WORKSPACE != workspace)
+            return false;
+        if (m_owner.m_activeSpecialWorkspace == WORKSPACE)
+            return false;
+
+        return !state->offset->isBeingAnimated() && !state->alpha->isBeingAnimated() && !state->forceRendering;
+    });
+}
+
+void CWorkspaceTransition::installCallbacks(SWorkspaceTransitionState& state) {
+    state.offset->resetAllCallbacks();
+    state.alpha->resetAllCallbacks();
+
+    state.offset->setUpdateCallback([workspace = state.workspace](auto) {
+        const auto WORKSPACE = workspace.lock();
+        if (!WORKSPACE)
+            return;
+
+        for (const auto& window : Desktop::windowState()->windows()) {
+            if (!validMapped(window) || window->m_workspace != WORKSPACE)
+                continue;
+
+            window->onWorkspaceAnimUpdate();
+        }
+    });
+
+    const auto DEFER_PRUNE = [monitor = PHLMONITORREF{m_owner.m_self}, workspace = state.workspace](auto) {
+        if (!g_pEventLoopManager)
+            return;
+
+        g_pEventLoopManager->doLater([monitor, workspace] {
+            if (!monitor || !monitor->m_workspaceTransition)
+                return;
+
+            monitor->m_workspaceTransition->prune(workspace.lock());
+        });
+    };
+
+    state.offset->setCallbackOnEnd(DEFER_PRUNE, false);
+    state.alpha->setCallbackOnEnd(DEFER_PRUNE, false);
+}

--- a/src/output/WorkspaceTransition.hpp
+++ b/src/output/WorkspaceTransition.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "../helpers/AnimatedVariable.hpp"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Monitor {
+    class CMonitor;
+
+    struct SWorkspaceTransitionState {
+        PHLWORKSPACEREF      workspace;
+        PHLANIMVAR<Vector2D> offset;
+        PHLANIMVAR<float>    alpha;
+        bool                 forceRendering = false;
+    };
+
+    class CWorkspaceTransition {
+      public:
+        explicit CWorkspaceTransition(CMonitor& owner);
+
+        SWorkspaceTransitionState&       ensure(PHLWORKSPACE workspace);
+        SWorkspaceTransitionState*       get(PHLWORKSPACE workspace);
+        const SWorkspaceTransitionState* get(PHLWORKSPACE workspace) const;
+
+        bool                             participates(PHLWORKSPACE workspace) const;
+        bool                             isAnimating(PHLWORKSPACE workspace) const;
+        bool                             forceRendering(PHLWORKSPACE workspace) const;
+        float                            alphaValue(PHLWORKSPACE workspace) const;
+        Vector2D                         offsetValue(PHLWORKSPACE workspace) const;
+        std::string                      style(PHLWORKSPACE workspace) const;
+        std::vector<PHLWORKSPACE>        participants(std::optional<bool> special = std::nullopt) const;
+
+        void                             setForceRendering(PHLWORKSPACE workspace, bool forceRendering);
+        void                             transferTo(CWorkspaceTransition& destination, PHLWORKSPACE workspace);
+        void                             remove(PHLWORKSPACE workspace);
+        void                             clear();
+        void                             prune(PHLWORKSPACE workspace = nullptr);
+
+      private:
+        void                                       installCallbacks(SWorkspaceTransitionState& state);
+
+        CMonitor&                                  m_owner;
+        std::vector<UP<SWorkspaceTransitionState>> m_states;
+    };
+}

--- a/src/overview/Overview.cpp
+++ b/src/overview/Overview.cpp
@@ -1,6 +1,10 @@
 #include "overview/Overview.hpp"
 #include "hyprland/Overview.hpp"
 
+bool Overview::IOverview::shouldRenderWorkspace(PHLWORKSPACE) const {
+    return false;
+}
+
 UP<Overview::IOverview>& Overview::overview() {
     static UP<Overview::IOverview> p = makeUnique<Overview::Hyprland::COverview>();
     return p;

--- a/src/overview/Overview.cpp
+++ b/src/overview/Overview.cpp
@@ -1,6 +1,59 @@
 #include "overview/Overview.hpp"
 #include "hyprland/Overview.hpp"
 
+void Overview::openWithQuery(IOverview* overview, PHLMONITOR monitor, const std::string& query) {
+    if (!overview)
+        return;
+
+    if (const auto QUERY_OPENABLE = dynamic_cast<IOverviewQueryOpenable*>(overview)) {
+        QUERY_OPENABLE->open(monitor, query);
+        return;
+    }
+
+    if (typeid(*overview) == typeid(Hyprland::COverview)) {
+        sc<Hyprland::COverview*>(overview)->open(monitor, query);
+        return;
+    }
+
+    overview->open(monitor);
+}
+
+Overview::SOverviewState Overview::state(const IOverview* overview) {
+    if (!overview)
+        return {};
+
+    if (const auto STATE_PROVIDER = dynamic_cast<const IOverviewStateProvider*>(overview))
+        return STATE_PROVIDER->state();
+
+    if (typeid(*overview) == typeid(Hyprland::COverview))
+        return sc<const Hyprland::COverview*>(overview)->state();
+
+    return {.open = overview->isOpen()};
+}
+
+static std::optional<bool> moveOverview(Overview::IOverview* overview, bool left) {
+    if (!overview)
+        return std::nullopt;
+
+    if (const auto NAVIGABLE = dynamic_cast<Overview::IOverviewNavigable*>(overview))
+        return left ? NAVIGABLE->moveLeft() : NAVIGABLE->moveRight();
+
+    if (typeid(*overview) == typeid(Overview::Hyprland::COverview)) {
+        const auto BUILTIN = sc<Overview::Hyprland::COverview*>(overview);
+        return left ? BUILTIN->moveLeft() : BUILTIN->moveRight();
+    }
+
+    return std::nullopt;
+}
+
+std::optional<bool> Overview::moveLeft(IOverview* overview) {
+    return moveOverview(overview, true);
+}
+
+std::optional<bool> Overview::moveRight(IOverview* overview) {
+    return moveOverview(overview, false);
+}
+
 bool Overview::IOverview::shouldRenderWorkspace(PHLWORKSPACE) const {
     return false;
 }

--- a/src/overview/Overview.cpp
+++ b/src/overview/Overview.cpp
@@ -5,6 +5,10 @@ bool Overview::IOverview::shouldRenderWorkspace(PHLWORKSPACE) const {
     return false;
 }
 
+PHLWORKSPACE Overview::IOverview::inputWorkspace() const {
+    return nullptr;
+}
+
 UP<Overview::IOverview>& Overview::overview() {
     static UP<Overview::IOverview> p = makeUnique<Overview::Hyprland::COverview>();
     return p;

--- a/src/overview/Overview.cpp
+++ b/src/overview/Overview.cpp
@@ -1,0 +1,7 @@
+#include "overview/Overview.hpp"
+#include "hyprland/Overview.hpp"
+
+UP<Overview::IOverview>& Overview::overview() {
+    static UP<Overview::IOverview> p = makeUnique<Overview::Hyprland::COverview>();
+    return p;
+}

--- a/src/overview/Overview.hpp
+++ b/src/overview/Overview.hpp
@@ -39,6 +39,15 @@ namespace Overview {
         IOverview() = default;
     };
 
+    class IOverviewGesture {
+      public:
+        virtual ~IOverviewGesture() = default;
+
+        virtual bool beginGesture(PHLMONITOR monitor) = 0;
+        virtual void updateGesture(float completion)  = 0;
+        virtual void endGesture(bool commit)          = 0;
+    };
+
     /*
      * If you are a plugin and want to override this, remember to reset this ptr on unload and
      * populate with Overview::Hyprland::COverview

--- a/src/overview/Overview.hpp
+++ b/src/overview/Overview.hpp
@@ -24,10 +24,11 @@ namespace Overview {
          * Request to close the overview prematurely. This is not closed if the overview
          * decides to close itself.
          */
-        virtual void close() = 0;
+        virtual void         close() = 0;
 
-        virtual bool isOpen() const = 0;
-        virtual bool shouldRenderWorkspace(PHLWORKSPACE workspace) const;
+        virtual bool         isOpen() const = 0;
+        virtual bool         shouldRenderWorkspace(PHLWORKSPACE workspace) const;
+        virtual PHLWORKSPACE inputWorkspace() const;
 
         struct {
             CSignalT<> opened;

--- a/src/overview/Overview.hpp
+++ b/src/overview/Overview.hpp
@@ -39,13 +39,22 @@ namespace Overview {
         IOverview() = default;
     };
 
-    class IOverviewGesture {
+    class IOverviewGestureOpenable {
       public:
-        virtual ~IOverviewGesture() = default;
+        virtual ~IOverviewGestureOpenable() = default;
 
-        virtual bool beginGesture(PHLMONITOR monitor) = 0;
-        virtual void updateGesture(float completion)  = 0;
-        virtual void endGesture(bool commit)          = 0;
+        virtual bool beginOpenGesture(PHLMONITOR monitor) = 0;
+        virtual void updateOpenGesture(float completion)  = 0;
+        virtual void endOpenGesture(bool commit)          = 0;
+    };
+
+    class IOverviewGestureMovable {
+      public:
+        virtual ~IOverviewGestureMovable() = default;
+
+        virtual bool beginMoveGesture()         = 0;
+        virtual void updateMoveGesture(float Δ) = 0;
+        virtual void endMoveGesture()           = 0;
     };
 
     /*

--- a/src/overview/Overview.hpp
+++ b/src/overview/Overview.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "../helpers/memory/Memory.hpp"
+#include "../desktop/DesktopTypes.hpp"
+#include "../helpers/signal/Signal.hpp"
+
+namespace Overview {
+
+    /*
+     * An interface for an overview. Normally, Hyprland only implements one,
+     * but this is an easy to override point of entry for plugins.
+     */
+    class IOverview {
+      public:
+        virtual ~IOverview() = default;
+
+        /*
+         * Request to open the overview on a given monitor. The overview doesn't
+         * have to be confined to it, it's merely a hint.
+         */
+        virtual void open(PHLMONITOR monitor) = 0;
+
+        /*
+         * Request to close the overview prematurely. This is not closed if the overview
+         * decides to close itself.
+         */
+        virtual void close() = 0;
+
+        virtual bool isOpen() const = 0;
+
+        struct {
+            CSignalT<> opened;
+            CSignalT<> closed;
+        } m_events;
+
+      protected:
+        IOverview() = default;
+    };
+
+    /*
+     * If you are a plugin and want to override this, remember to reset this ptr on unload and
+     * populate with Overview::Hyprland::COverview
+     */
+    UP<IOverview>& overview();
+};

--- a/src/overview/Overview.hpp
+++ b/src/overview/Overview.hpp
@@ -4,7 +4,17 @@
 #include "../desktop/DesktopTypes.hpp"
 #include "../helpers/signal/Signal.hpp"
 
+#include <string>
+#include <optional>
+
 namespace Overview {
+
+    struct SOverviewState {
+        bool         open = false;
+        PHLMONITOR   monitor;
+        PHLWORKSPACE workspace;
+        std::string  query;
+    };
 
     /*
      * An interface for an overview. Normally, Hyprland only implements one,
@@ -56,6 +66,33 @@ namespace Overview {
         virtual void updateMoveGesture(float Δ) = 0;
         virtual void endMoveGesture()           = 0;
     };
+
+    class IOverviewNavigable {
+      public:
+        virtual ~IOverviewNavigable() = default;
+
+        virtual bool moveLeft()  = 0;
+        virtual bool moveRight() = 0;
+    };
+
+    class IOverviewQueryOpenable {
+      public:
+        virtual ~IOverviewQueryOpenable() = default;
+
+        virtual void open(PHLMONITOR monitor, const std::string& query) = 0;
+    };
+
+    class IOverviewStateProvider {
+      public:
+        virtual ~IOverviewStateProvider() = default;
+
+        virtual SOverviewState state() const = 0;
+    };
+
+    void                openWithQuery(IOverview* overview, PHLMONITOR monitor, const std::string& query);
+    SOverviewState      state(const IOverview* overview);
+    std::optional<bool> moveLeft(IOverview* overview);
+    std::optional<bool> moveRight(IOverview* overview);
 
     /*
      * If you are a plugin and want to override this, remember to reset this ptr on unload and

--- a/src/overview/Overview.hpp
+++ b/src/overview/Overview.hpp
@@ -27,6 +27,7 @@ namespace Overview {
         virtual void close() = 0;
 
         virtual bool isOpen() const = 0;
+        virtual bool shouldRenderWorkspace(PHLWORKSPACE workspace) const;
 
         struct {
             CSignalT<> opened;

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -26,7 +26,9 @@
 #include "../../layout/LayoutManager.hpp"
 #include "../../layout/supplementary/DragController.hpp"
 
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <hyprutils/math/Vector2D.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <ranges>
@@ -43,7 +45,9 @@ COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)) {
 }
 
 COverview::~COverview() {
-    m_isOpen = false;
+    m_finishCloseLock.reset();
+    m_isOpen        = false;
+    m_gestureActive = false;
     if (m_progress)
         m_progress->resetAllCallbacks();
     finishClose(false);
@@ -391,21 +395,23 @@ void COverview::releaseDragFromOverview() {
     resetDragHover();
 }
 
-void COverview::open(PHLMONITOR monitor) {
+bool COverview::prepareOpen(PHLMONITOR monitor, bool& newScene) {
+    newScene = false;
     if (!monitor || !monitor->m_enabled || monitor->isMirror() || !g_pHyprRenderer || (g_pSessionLockManager && g_pSessionLockManager->isSessionLocked()))
-        return;
+        return false;
 
     if (!monitor->m_lastScanout.expired() || monitor->m_directScanoutIsActive)
         monitor->handleDSleave();
 
     const auto CURRENT_MONITOR = m_monitor.lock();
     if (m_sceneInstalled && CURRENT_MONITOR != monitor) {
-        m_isOpen = false;
+        m_isOpen        = false;
+        m_gestureActive = false;
         finishClose();
     }
 
     if (m_isOpen)
-        return;
+        return true;
 
     m_inputMode = eInputMode::NAVIGATION;
     m_scene->setTextboxFocus(false);
@@ -421,21 +427,19 @@ void COverview::open(PHLMONITOR monitor) {
                 if (m_isOpen)
                     return;
 
-                if (g_pEventLoopManager)
-                    g_pEventLoopManager->doLater([this] { finishClose(); });
-                else
-                    finishClose();
+                scheduleFinishClose();
             },
             false);
     }
 
-    const bool NEW_SCENE = !m_sceneInstalled;
-    const auto RESOURCES = NEW_SCENE ? monitor->resources() : m_resources;
+    newScene             = !m_sceneInstalled;
+    const auto RESOURCES = newScene ? monitor->resources() : m_resources;
     if (!RESOURCES)
-        return;
+        return false;
 
     m_isOpen = true;
-    if (NEW_SCENE) {
+    m_finishCloseLock.reset();
+    if (newScene) {
         m_monitor   = monitor;
         m_resources = RESOURCES;
         m_scene->start(monitor, RESOURCES);
@@ -449,12 +453,53 @@ void COverview::open(PHLMONITOR monitor) {
         installListeners();
     }
 
-    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewIn"));
-    *m_progress = 1.F;
-
     monitor->recheckSolitary();
     if (g_pHyprRenderer)
         g_pHyprRenderer->damageMonitor(monitor);
+
+    return true;
+}
+
+void COverview::settleProgress(float goal, bool opening) {
+    if (!m_progress)
+        return;
+
+    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig(opening ? "overviewIn" : "overviewOut"));
+    *m_progress = goal;
+
+    if (goal != 0.F || m_progress->value() > 0.F || !m_sceneInstalled || m_isOpen)
+        return;
+
+    scheduleFinishClose();
+}
+
+void COverview::scheduleFinishClose() {
+    if (m_finishCloseLock)
+        return;
+
+    if (!g_pEventLoopManager) {
+        finishClose();
+        return;
+    }
+
+    m_finishCloseLock = g_pEventLoopManager->doLaterLock([this] {
+        m_finishCloseLock.reset();
+        finishClose();
+    });
+}
+
+void COverview::open(PHLMONITOR monitor) {
+    const bool KEEP_SELECTED_FULLSCREEN = m_gestureActive && !m_gestureOpening;
+    if (m_gestureActive)
+        endGesture(m_gestureOpening);
+
+    bool NEW_SCENE = false;
+    if (!prepareOpen(monitor, NEW_SCENE))
+        return;
+
+    if (!KEEP_SELECTED_FULLSCREEN)
+        m_scene->useSelectedWorkspaceForFullscreen(false);
+    settleProgress(1.F, true);
 
     if (NEW_SCENE)
         m_events.opened.emit();
@@ -464,11 +509,17 @@ void COverview::close() {
     if (!m_isOpen || !m_sceneInstalled)
         return;
 
-    m_isOpen = false;
+    m_gestureActive = false;
+    m_isOpen        = false;
     resetDragHover();
-    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewOut"));
-    *m_progress = 0.F;
+    commitClose();
+    settleProgress(0.F, false);
 
+    if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+void COverview::commitClose() {
     const auto MONITOR  = m_monitor.lock();
     const auto SELECTED = m_scene->selectedWorkspace();
     if (MONITOR && SELECTED && SELECTED != MONITOR->m_activeWorkspace)
@@ -476,7 +527,7 @@ void COverview::close() {
 
     const auto QUERY = m_scene->currentQuery();
 
-    if (!QUERY.empty()) {
+    if (MONITOR && MONITOR->m_activeWorkspace && !QUERY.empty()) {
         // select the window, if applicable
         // if we match the workspace name our search is exclusive for the workspace, don't focus shit
         if (!StringUtils::fullMatchCaseIns(MONITOR->m_activeWorkspace->m_name, QUERY)) {
@@ -492,9 +543,65 @@ void COverview::close() {
             }
         }
     }
+}
 
-    if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
-        g_pHyprRenderer->damageMonitor(MONITOR);
+bool COverview::beginGesture(PHLMONITOR monitor) {
+    if (m_gestureActive)
+        return false;
+
+    const bool OPENING   = !m_isOpen;
+    bool       NEW_SCENE = false;
+    if (OPENING && !prepareOpen(monitor, NEW_SCENE))
+        return false;
+    if (!OPENING && !m_sceneInstalled)
+        return false;
+
+    m_gestureActive  = true;
+    m_gestureOpening = OPENING;
+    m_gestureStart   = std::clamp(m_progress->value(), 0.F, 1.F);
+    m_scene->useSelectedWorkspaceForFullscreen(!OPENING);
+    m_progress->setValueAndWarp(m_gestureStart);
+
+    if (NEW_SCENE)
+        m_events.opened.emit();
+
+    return true;
+}
+
+void COverview::updateGesture(float completion) {
+    if (!m_gestureActive || !m_progress)
+        return;
+
+    const float TARGET = m_gestureOpening ? 1.F : 0.F;
+    m_progress->setValueAndWarp(std::lerp(m_gestureStart, TARGET, std::clamp(completion, 0.F, 1.F)));
+}
+
+void COverview::endGesture(bool commit) {
+    if (!m_gestureActive)
+        return;
+
+    m_gestureActive = false;
+    if (m_gestureOpening) {
+        if (commit) {
+            settleProgress(1.F, true);
+            return;
+        }
+
+        m_isOpen = false;
+        resetDragHover();
+        settleProgress(0.F, false);
+        return;
+    }
+
+    if (!commit) {
+        settleProgress(1.F, true);
+        return;
+    }
+
+    m_isOpen = false;
+    resetDragHover();
+    commitClose();
+    settleProgress(0.F, false);
 }
 
 bool COverview::isOpen() const {
@@ -517,7 +624,9 @@ void COverview::finishClose(bool emitEvent) {
     if (m_isOpen || !m_sceneInstalled)
         return;
 
+    m_finishCloseLock.reset();
     m_sceneInstalled = false;
+    m_gestureActive  = false;
     resetDragHover();
     stopKeyRepeat(m_keyRepeat.keycode);
     m_listeners = {};
@@ -555,7 +664,9 @@ void COverview::closeImmediately() {
     if (!m_sceneInstalled)
         return;
 
-    m_isOpen = false;
+    m_finishCloseLock.reset();
+    m_isOpen        = false;
+    m_gestureActive = false;
     resetDragHover();
     if (m_progress)
         m_progress->setValueAndWarp(0.F);

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -20,6 +20,7 @@
 #include "../../output/MonitorResources.hpp"
 #include "../../pointer/PointerManager.hpp"
 #include "../../pointer/PointerTransformer.hpp"
+#include "../../pointer/cursor/CursorShapeOverrideController.hpp"
 #include "../../protocols/core/DataDevice.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../state/MonitorState.hpp"
@@ -116,6 +117,11 @@ void COverview::installListeners() {
         if (!MONITOR->logicalBox().containsPoint(MOUSE))
             return;
 
+        if (!m_isOpen) {
+            i.cancelled = true;
+            return;
+        }
+
         if (m_scene->pointerButton(e.button, true, MOUSE - MONITOR->logicalBox().pos())) {
             m_interceptedButtons.emplace_back(e.button);
             i.cancelled = true;
@@ -138,19 +144,51 @@ void COverview::installListeners() {
 
         const auto RAW = Pointer::mgr()->untransformedPosition();
         if (!MONITOR->logicalBox().containsPoint(RAW)) {
+            updatePointerState();
             releaseDragFromOverview();
             return;
         }
 
-        if (!g_layoutManager->dragController()->target())
-            m_scene->pointerMove(RAW - MONITOR->logicalBox().pos());
-        else
+        updatePointerState();
+        if (g_layoutManager->dragController()->target())
             g_layoutManager->moveMouse(g_pInputManager->getMouseCoordsInternal());
 
         i.cancelled = !PROTO::data || !PROTO::data->dndActive();
     });
-    m_listeners.dragMotion = g_layoutManager->dragController()->m_events.motion.listen([this] { recheckDrag(); });
-    m_listeners.dragEnded  = g_layoutManager->dragController()->m_events.ended.listen([this] { resetDragHover(); });
+    m_listeners.dragMotion = g_layoutManager->dragController()->m_events.motion.listen([this] {
+        updatePointerState();
+        recheckDrag();
+    });
+    m_listeners.dragEnded  = g_layoutManager->dragController()->m_events.ended.listen([this] {
+        resetDragHover();
+        updatePointerState();
+    });
+}
+
+void COverview::updatePointerState() {
+    const auto MONITOR = m_monitor.lock();
+    if (!m_isOpen || !MONITOR || !Pointer::mgr()) {
+        m_scene->pointerLeave();
+        Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI);
+        return;
+    }
+
+    const auto RAW = Pointer::mgr()->untransformedPosition();
+    if (!MONITOR->logicalBox().containsPoint(RAW)) {
+        if (m_scene->pointerMove(RAW - MONITOR->logicalBox().pos()))
+            return;
+
+        m_scene->pointerLeave();
+        Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI);
+        return;
+    }
+
+    if (g_layoutManager && g_layoutManager->dragController()->target())
+        m_scene->pointerLeave();
+    else if (m_scene->pointerMove(RAW - MONITOR->logicalBox().pos()))
+        return;
+
+    Pointer::Cursor::overrideController->setOverride("default", Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI);
 }
 
 bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat) {
@@ -183,6 +221,7 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
             m_inputMode = eInputMode::NAVIGATION;
             m_scene->resetQuery();
             m_scene->setTextboxFocus(false);
+            updatePointerState();
             return true;
         }
     }
@@ -210,6 +249,7 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
         return false;
 
     m_scene->setTextboxFocus(true);
+    updatePointerState();
     m_scene->keyboardKey(KEYSYM, true, repeat, std::move(utf8), sc<uint32_t>(MODIFIERS));
     m_inputMode = eInputMode::TEXT;
 
@@ -217,6 +257,7 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
         m_inputMode = eInputMode::NAVIGATION;
         m_scene->resetQuery();
         m_scene->setTextboxFocus(false);
+        updatePointerState();
         return true;
     }
 
@@ -453,6 +494,8 @@ bool COverview::prepareOpen(PHLMONITOR monitor, bool& newScene) {
         installListeners();
     }
 
+    updatePointerState();
+
     monitor->recheckSolitary();
     if (g_pHyprRenderer)
         g_pHyprRenderer->damageMonitor(monitor);
@@ -511,6 +554,7 @@ void COverview::close() {
 
     m_gestureActive = false;
     m_isOpen        = false;
+    updatePointerState();
     resetDragHover();
     commitClose();
     settleProgress(0.F, false);
@@ -588,6 +632,7 @@ void COverview::endGesture(bool commit) {
         }
 
         m_isOpen = false;
+        updatePointerState();
         resetDragHover();
         settleProgress(0.F, false);
         return;
@@ -599,6 +644,7 @@ void COverview::endGesture(bool commit) {
     }
 
     m_isOpen = false;
+    updatePointerState();
     resetDragHover();
     commitClose();
     settleProgress(0.F, false);
@@ -627,6 +673,7 @@ void COverview::finishClose(bool emitEvent) {
     m_finishCloseLock.reset();
     m_sceneInstalled = false;
     m_gestureActive  = false;
+    updatePointerState();
     resetDragHover();
     stopKeyRepeat(m_keyRepeat.keycode);
     m_listeners = {};
@@ -667,6 +714,7 @@ void COverview::closeImmediately() {
     m_finishCloseLock.reset();
     m_isOpen        = false;
     m_gestureActive = false;
+    updatePointerState();
     resetDragHover();
     if (m_progress)
         m_progress->setValueAndWarp(0.F);

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -55,35 +55,6 @@ COverview::~COverview() {
 }
 
 void COverview::installListeners() {
-    m_listeners.keyboardKey = Event::bus()->m_events.input.keyboard.key.listen([this](const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard, Event::SCallbackInfo& info) {
-        const auto INTERCEPTED = [&] {
-            return std::ranges::find_if(m_interceptedKeys, [&event, &keyboard](const auto& key) { return key.first == keyboard && key.second == event.keycode; });
-        };
-
-        if (event.state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-            const auto IT = INTERCEPTED();
-            if (IT == m_interceptedKeys.end())
-                return;
-
-            m_interceptedKeys.erase(IT);
-            stopKeyRepeat(event.keycode);
-            info.cancelled = true;
-            return;
-        }
-
-        if (!m_isOpen || !keyboard || !keyboard->m_xkbState)
-            return;
-
-        if (!handleSearchKey(event.keycode, keyboard))
-            return;
-
-        info.cancelled = true;
-        if (INTERCEPTED() == m_interceptedKeys.end())
-            m_interceptedKeys.emplace_back(keyboard, event.keycode);
-        if (m_isOpen)
-            startKeyRepeat(event.keycode, keyboard);
-    });
-
     m_listeners.monitorDisconnect  = m_monitor->m_events.disconnect.listen([this] { closeImmediately(); });
     m_listeners.monitorModeChanged = m_monitor->m_events.modeChanged.listen([this] { closeImmediately(); });
     m_listeners.monitorPreRender   = Event::bus()->m_events.render.preChecks.listen([this](PHLMONITOR monitor) {
@@ -163,6 +134,19 @@ void COverview::installListeners() {
         resetDragHover();
         updatePointerState();
     });
+}
+
+void COverview::onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard) {
+    if (event.state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+        stopKeyRepeat(event.keycode, keyboard);
+        return;
+    }
+
+    if (!m_isOpen || !keyboard || !keyboard->m_xkbState || !handleSearchKey(event.keycode, keyboard))
+        return;
+
+    if (m_isOpen)
+        startKeyRepeat(event.keycode, keyboard);
 }
 
 void COverview::updatePointerState() {
@@ -295,8 +279,8 @@ void COverview::startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard) {
     m_keyRepeat.timer->updateTimeout(std::chrono::milliseconds(std::max(0, keyboard->m_repeatDelay)));
 }
 
-void COverview::stopKeyRepeat(uint32_t keycode) {
-    if (!m_keyRepeat.timer || m_keyRepeat.keycode != keycode)
+void COverview::stopKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard) {
+    if (!m_keyRepeat.timer || m_keyRepeat.keycode != keycode || (keyboard && m_keyRepeat.keyboard != keyboard))
         return;
 
     m_keyRepeat.timer->updateTimeout(std::nullopt);
@@ -492,6 +476,8 @@ bool COverview::prepareOpen(PHLMONITOR monitor, bool& newScene) {
         m_progress->setValueAndWarp(0.F);
 
         installListeners();
+        m_keyboardEventHandler = dynamicPointerCast<IKeyboardEventHandler>(WP<IOverview>(Overview::overview()));
+        g_pSeatManager->m_keyboardEventHandlers.push(m_keyboardEventHandler);
     }
 
     updatePointerState();
@@ -705,8 +691,10 @@ void COverview::finishClose(bool emitEvent) {
     updatePointerState();
     resetDragHover();
     stopKeyRepeat(m_keyRepeat.keycode);
+    if (g_pSeatManager)
+        g_pSeatManager->m_keyboardEventHandlers.remove(m_keyboardEventHandler);
+    m_keyboardEventHandler.reset();
     m_listeners = {};
-    m_interceptedKeys.clear();
     m_interceptedButtons.clear();
 
     if (g_layoutManager)

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -1,16 +1,38 @@
 #include "Overview.hpp"
 
+#include "config/shared/actions/ConfigActions.hpp"
+#include "desktop/state/FocusState.hpp"
+#include "desktop/view/window/Window.hpp"
+#include "devices/IPointer.hpp"
+#include "input/Keys.hpp"
+#include "managers/eventLoop/EventLoopTimer.hpp"
+#include "managers/input/InputManager.hpp"
+#include "overview/hyprland/scene/WorkspaceTapeController.hpp"
 #include "scene/OverviewScene.hpp"
+#include "scene/WorkspaceTapeController.hpp"
 #include "../../animation/AnimationManager.hpp"
 #include "../../config/shared/animation/AnimationTree.hpp"
 #include "../../event/EventBus.hpp"
+#include "../../managers/eventLoop/EventLoopManager.hpp"
+#include "../../devices/IKeyboard.hpp"
 #include "../../managers/SessionLockManager.hpp"
 #include "../../output/Monitor.hpp"
 #include "../../output/MonitorResources.hpp"
 #include "../../render/Renderer.hpp"
+#include "../../layout/LayoutManager.hpp"
+#include "../../layout/supplementary/DragController.hpp"
+
+#include <chrono>
+#include <hyprutils/math/Vector2D.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <ranges>
+#include <wayland-server-protocol.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
 
 using namespace Overview;
 using namespace Overview::Hyprland;
+
+constexpr const float DRAG_MOVE_MS = 500.F;
 
 COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)) {
     ;
@@ -21,6 +43,138 @@ COverview::~COverview() {
     if (m_progress)
         m_progress->resetAllCallbacks();
     finishClose(false);
+}
+
+void COverview::installListeners() {
+    m_listeners.keyboardKey = Event::bus()->m_events.input.keyboard.key.listen([this](const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard, Event::SCallbackInfo& info) {
+        const auto INTERCEPTED = [&] {
+            return std::ranges::find_if(m_interceptedKeys, [&event, &keyboard](const auto& key) { return key.first == keyboard && key.second == event.keycode; });
+        };
+
+        if (event.state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+            const auto IT = INTERCEPTED();
+            if (IT == m_interceptedKeys.end())
+                return;
+
+            m_interceptedKeys.erase(IT);
+            info.cancelled = true;
+            return;
+        }
+
+        if (!m_isOpen || !keyboard || !keyboard->m_xkbSymState)
+            return;
+
+        const auto KEYSYM = xkb_state_key_get_one_sym(keyboard->m_xkbSymState, event.keycode + 8);
+        if (KEYSYM != XKB_KEY_Left && KEYSYM != XKB_KEY_Right && KEYSYM != XKB_KEY_h && KEYSYM != XKB_KEY_l)
+            return;
+
+        info.cancelled = true;
+        if (INTERCEPTED() == m_interceptedKeys.end())
+            m_interceptedKeys.emplace_back(keyboard, event.keycode);
+        if (KEYSYM == XKB_KEY_Left || KEYSYM == XKB_KEY_h)
+            m_scene->navigateLeft();
+        else
+            m_scene->navigateRight();
+    });
+
+    m_listeners.monitorDisconnect  = m_monitor->m_events.disconnect.listen([this] { closeImmediately(); });
+    m_listeners.monitorModeChanged = m_monitor->m_events.modeChanged.listen([this] { closeImmediately(); });
+    m_listeners.monitorPreRender   = Event::bus()->m_events.render.preChecks.listen([this](PHLMONITOR monitor) {
+        if (monitor != m_monitor.lock() || monitor->resources() == m_resources)
+            return;
+
+        closeImmediately();
+    });
+
+    if (g_pSessionLockManager)
+        m_listeners.sessionLock = g_pSessionLockManager->m_events.lock.listen([this] { closeImmediately(); });
+
+    m_listeners.mouseButton = Event::bus()->m_events.input.mouse.button.listen([this](IPointer::SButtonEvent e, Event::SCallbackInfo& i) {
+        if (e.state != WL_POINTER_BUTTON_STATE_PRESSED)
+            return;
+
+        if (!m_monitor)
+            return;
+
+        if (!m_monitor->logicalBox().containsPoint(g_pInputManager->getMouseCoordsInternal()))
+            return;
+
+        // TODO: make this better. This is to support drags, and is obviously kinda wrong.
+        if (g_pInputManager->getModsFromAllKBs() != Input::eKeyboardModifiers::HL_MODIFIER_NONE)
+            return;
+
+        close();
+
+        i.cancelled = true;
+    });
+
+    m_listeners.mouseMove = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D p, Event::SCallbackInfo& i) { recheckDrag(); });
+}
+
+void COverview::recheckDrag() {
+    auto resetDrag = [this] {
+        m_drag.isWithin = false;
+        if (m_drag.eventLoopTimer)
+            m_drag.eventLoopTimer->cancel();
+    };
+
+    if (!m_monitor) {
+        resetDrag();
+        return;
+    }
+
+    if (!m_monitor->logicalBox().containsPoint(g_pInputManager->getMouseCoordsInternal())) {
+        resetDrag();
+        return;
+    }
+
+    const auto TARGET = g_layoutManager->dragController()->target();
+
+    if (!TARGET) {
+        resetDrag();
+        return;
+    }
+
+    const auto MONBOX                   = m_monitor->logicalBox();
+    const auto MOUSE_LOCAL              = g_pInputManager->getMouseCoordsInternal() - MONBOX.pos();
+    const auto SIDE_WIDTH               = (MONBOX.size().x - (MONBOX.size() * CWorkspaceTapeController::TILE_SCALE).x) / 2.F;
+    const bool MOUSE_IS_LEFT_DIST       = MOUSE_LOCAL.x < SIDE_WIDTH;
+    const auto IS_MOUSE_WITHIN_DISTANCE = MOUSE_IS_LEFT_DIST || MOUSE_LOCAL.x > MONBOX.size().x - SIDE_WIDTH;
+
+    if (!IS_MOUSE_WITHIN_DISTANCE) {
+        resetDrag();
+        return;
+    }
+
+    if (IS_MOUSE_WITHIN_DISTANCE && m_drag.isWithin) {
+        // check if timer passed, if so, move
+        if (m_drag.debouncer.getMillis() < DRAG_MOVE_MS)
+            return;
+
+        if (MOUSE_IS_LEFT_DIST)
+            m_scene->navigateLeft();
+        else
+            m_scene->navigateRight();
+
+        // set the current dragger's workspace MOTHERFUCKER
+        if (TARGET->window()) {
+            TARGET->window()->moveToWorkspace(m_scene->selectedWorkspace());
+            g_layoutManager->dragController()->overrideDragWindowTargetWS(m_scene->selectedWorkspace());
+        }
+
+        m_drag.debouncer.reset();
+        return;
+    }
+
+    m_drag.isWithin = true;
+    m_drag.debouncer.reset();
+
+    if (!m_drag.eventLoopTimer) {
+        m_drag.eventLoopTimer =
+            makeShared<CEventLoopTimer>(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS) + 10), [this](SP<CEventLoopTimer> self, void* data) { recheckDrag(); }, nullptr);
+        g_pEventLoopManager->addTimer(m_drag.eventLoopTimer);
+    } else
+        m_drag.eventLoopTimer->updateTimeout(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS) + 10));
 }
 
 void COverview::open(PHLMONITOR monitor) {
@@ -40,14 +194,19 @@ void COverview::open(PHLMONITOR monitor) {
         return;
 
     if (!m_progress) {
-        Animation::mgr()->createAnimation(0.F, m_progress, Config::animationTree()->getAnimationPropertyConfig("workspacesIn"), AVARDAMAGE_NONE);
+        Animation::mgr()->createAnimation(0.F, m_progress, Config::animationTree()->getAnimationPropertyConfig("overviewIn"), AVARDAMAGE_NONE);
         m_progress->setUpdateCallback([this](auto) {
             if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
                 g_pHyprRenderer->damageMonitor(MONITOR);
         });
         m_progress->setCallbackOnEnd(
             [this](auto) {
-                if (!m_isOpen)
+                if (m_isOpen)
+                    return;
+
+                if (g_pEventLoopManager)
+                    g_pEventLoopManager->doLater([this] { finishClose(); });
+                else
                     finishClose();
             },
             false);
@@ -62,23 +221,15 @@ void COverview::open(PHLMONITOR monitor) {
     if (NEW_SCENE) {
         m_monitor   = monitor;
         m_resources = RESOURCES;
+        m_scene->start(monitor, RESOURCES);
         RESOURCES->m_sceneStack.push(m_scene);
         m_sceneInstalled = true;
         m_progress->setValueAndWarp(0.F);
 
-        m_listeners.monitorDisconnect  = monitor->m_events.disconnect.listen([this] { closeImmediately(); });
-        m_listeners.monitorModeChanged = monitor->m_events.modeChanged.listen([this] { closeImmediately(); });
-        m_listeners.monitorPreRender   = Event::bus()->m_events.render.preChecks.listen([this](PHLMONITOR monitor) {
-            if (monitor != m_monitor.lock() || monitor->resources() == m_resources)
-                return;
-
-            closeImmediately();
-        });
-        if (g_pSessionLockManager)
-            m_listeners.sessionLock = g_pSessionLockManager->m_events.lock.listen([this] { closeImmediately(); });
+        installListeners();
     }
 
-    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("workspacesIn"));
+    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewIn"));
     *m_progress = 1.F;
 
     monitor->recheckSolitary();
@@ -94,8 +245,12 @@ void COverview::close() {
         return;
 
     m_isOpen = false;
-    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("workspacesOut"));
+    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewOut"));
     *m_progress = 0.F;
+
+    const auto MONITOR = m_monitor.lock();
+    if (MONITOR && m_scene->selectedWorkspace() != MONITOR->m_activeWorkspace)
+        Config::Actions::changeWorkspace(m_scene->selectedWorkspace());
 
     if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
         g_pHyprRenderer->damageMonitor(MONITOR);
@@ -103,6 +258,10 @@ void COverview::close() {
 
 bool COverview::isOpen() const {
     return m_isOpen;
+}
+
+bool COverview::shouldRenderWorkspace(PHLWORKSPACE workspace) const {
+    return m_sceneInstalled && workspace && m_scene->selectedWorkspace() == workspace;
 }
 
 void COverview::finishClose(bool emitEvent) {

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -1,5 +1,5 @@
 #include "Overview.hpp"
-#include "StringUtils.hpp"
+#include "Query.hpp"
 
 #include "config/shared/actions/ConfigActions.hpp"
 #include "desktop/state/FocusState.hpp"
@@ -560,17 +560,15 @@ void COverview::commitClose() {
     if (MONITOR && SELECTED && SELECTED != MONITOR->m_activeWorkspace)
         Config::Actions::changeWorkspace(SELECTED);
 
-    const auto QUERY = m_scene->currentQuery();
+    const auto QUERY = m_scene->query();
 
-    if (MONITOR && MONITOR->m_activeWorkspace && !QUERY.empty()) {
-        // select the window, if applicable
-        // if we match the workspace name our search is exclusive for the workspace, don't focus shit
-        if (!StringUtils::fullMatchCaseIns(MONITOR->m_activeWorkspace->m_name, QUERY)) {
+    if (MONITOR && MONITOR->m_activeWorkspace && QUERY && !QUERY->empty()) {
+        if (QUERY->matchWorkspace(MONITOR->m_activeWorkspace->m_name) != Mode::eWorkspaceMatch::EXACT) {
             for (const auto& w : Desktop::windowState()->windows()) {
                 if (w->m_workspace != MONITOR->m_activeWorkspace || !w->focusAvailable())
                     continue;
 
-                if (!StringUtils::matchesName(w->metadata().appID(), QUERY) && !StringUtils::matchesName(w->metadata().title(), QUERY))
+                if (!QUERY->matchesWindow(w->metadata().appID(), w->metadata().title()))
                     continue;
 
                 Desktop::focusState()->fullWindowFocus(w, Desktop::eFocusReason::FOCUS_REASON_SWITCH_TO_WINDOW_HARD);

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -131,6 +131,7 @@ void COverview::installListeners() {
         recheckDrag();
     });
     m_listeners.dragEnded  = g_layoutManager->dragController()->m_events.ended.listen([this] {
+        m_drag.createdWorkspace = false;
         resetDragHover();
         updatePointerState();
     });
@@ -370,9 +371,11 @@ void COverview::applyDragHoverTarget() {
             }
             break;
         case eDragHoverTarget::RIGHT_EDGE:
-            if (m_scene->navigateRight()) {
+            if (const auto RESULT = m_scene->navigateRight(!m_drag.createdWorkspace, true); RESULT != eWorkspaceNavigationResult::NONE) {
                 workspace = m_scene->selectedWorkspace();
-                repeat    = true;
+                repeat    = RESULT == eWorkspaceNavigationResult::EXISTING;
+                if (RESULT == eWorkspaceNavigationResult::CREATED)
+                    m_drag.createdWorkspace = true;
             }
             break;
         case eDragHoverTarget::MINI_TILE:
@@ -683,9 +686,10 @@ void COverview::finishClose(bool emitEvent) {
         return;
 
     m_finishCloseLock.reset();
-    m_sceneInstalled    = false;
-    m_gestureActive     = false;
-    m_moveGestureActive = false;
+    m_sceneInstalled        = false;
+    m_gestureActive         = false;
+    m_moveGestureActive     = false;
+    m_drag.createdWorkspace = false;
     updatePointerState();
     resetDragHover();
     stopKeyRepeat(m_keyRepeat.keycode);

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -261,7 +261,7 @@ bool COverview::isOpen() const {
 }
 
 bool COverview::shouldRenderWorkspace(PHLWORKSPACE workspace) const {
-    return m_sceneInstalled && workspace && m_scene->selectedWorkspace() == workspace;
+    return m_sceneInstalled && workspace && workspace->m_visible && m_scene->selectedWorkspace() == workspace;
 }
 
 void COverview::finishClose(bool emitEvent) {

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -1,0 +1,141 @@
+#include "Overview.hpp"
+
+#include "scene/OverviewScene.hpp"
+#include "../../animation/AnimationManager.hpp"
+#include "../../config/shared/animation/AnimationTree.hpp"
+#include "../../event/EventBus.hpp"
+#include "../../managers/SessionLockManager.hpp"
+#include "../../output/Monitor.hpp"
+#include "../../output/MonitorResources.hpp"
+#include "../../render/Renderer.hpp"
+
+using namespace Overview;
+using namespace Overview::Hyprland;
+
+COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)) {
+    ;
+}
+
+COverview::~COverview() {
+    m_isOpen = false;
+    if (m_progress)
+        m_progress->resetAllCallbacks();
+    finishClose(false);
+}
+
+void COverview::open(PHLMONITOR monitor) {
+    if (!monitor || !monitor->m_enabled || monitor->isMirror() || !g_pHyprRenderer || (g_pSessionLockManager && g_pSessionLockManager->isSessionLocked()))
+        return;
+
+    if (!monitor->m_lastScanout.expired() || monitor->m_directScanoutIsActive)
+        monitor->handleDSleave();
+
+    const auto CURRENT_MONITOR = m_monitor.lock();
+    if (m_sceneInstalled && CURRENT_MONITOR != monitor) {
+        m_isOpen = false;
+        finishClose();
+    }
+
+    if (m_isOpen)
+        return;
+
+    if (!m_progress) {
+        Animation::mgr()->createAnimation(0.F, m_progress, Config::animationTree()->getAnimationPropertyConfig("workspacesIn"), AVARDAMAGE_NONE);
+        m_progress->setUpdateCallback([this](auto) {
+            if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
+                g_pHyprRenderer->damageMonitor(MONITOR);
+        });
+        m_progress->setCallbackOnEnd(
+            [this](auto) {
+                if (!m_isOpen)
+                    finishClose();
+            },
+            false);
+    }
+
+    const bool NEW_SCENE = !m_sceneInstalled;
+    const auto RESOURCES = NEW_SCENE ? monitor->resources() : m_resources;
+    if (!RESOURCES)
+        return;
+
+    m_isOpen = true;
+    if (NEW_SCENE) {
+        m_monitor   = monitor;
+        m_resources = RESOURCES;
+        RESOURCES->m_sceneStack.push(m_scene);
+        m_sceneInstalled = true;
+        m_progress->setValueAndWarp(0.F);
+
+        m_listeners.monitorDisconnect  = monitor->m_events.disconnect.listen([this] { closeImmediately(); });
+        m_listeners.monitorModeChanged = monitor->m_events.modeChanged.listen([this] { closeImmediately(); });
+        m_listeners.monitorPreRender   = Event::bus()->m_events.render.preChecks.listen([this](PHLMONITOR monitor) {
+            if (monitor != m_monitor.lock() || monitor->resources() == m_resources)
+                return;
+
+            closeImmediately();
+        });
+        if (g_pSessionLockManager)
+            m_listeners.sessionLock = g_pSessionLockManager->m_events.lock.listen([this] { closeImmediately(); });
+    }
+
+    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("workspacesIn"));
+    *m_progress = 1.F;
+
+    monitor->recheckSolitary();
+    if (g_pHyprRenderer)
+        g_pHyprRenderer->damageMonitor(monitor);
+
+    if (NEW_SCENE)
+        m_events.opened.emit();
+}
+
+void COverview::close() {
+    if (!m_isOpen || !m_sceneInstalled)
+        return;
+
+    m_isOpen = false;
+    m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("workspacesOut"));
+    *m_progress = 0.F;
+
+    if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+bool COverview::isOpen() const {
+    return m_isOpen;
+}
+
+void COverview::finishClose(bool emitEvent) {
+    if (m_isOpen || !m_sceneInstalled)
+        return;
+
+    m_sceneInstalled = false;
+    m_listeners      = {};
+
+    const auto MONITOR   = m_monitor.lock();
+    const auto RESOURCES = m_resources;
+    if (RESOURCES)
+        RESOURCES->m_sceneStack.remove(m_scene);
+
+    m_scene->reset();
+    m_resources.reset();
+    m_monitor.reset();
+
+    if (MONITOR && g_pHyprRenderer) {
+        MONITOR->recheckSolitary();
+        g_pHyprRenderer->damageMonitor(MONITOR);
+    }
+
+    if (emitEvent)
+        m_events.closed.emit();
+}
+
+void COverview::closeImmediately() {
+    if (!m_sceneInstalled)
+        return;
+
+    m_isOpen = false;
+    if (m_progress)
+        m_progress->setValueAndWarp(0.F);
+    finishClose();
+}

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -22,14 +22,11 @@
 #include "../../layout/LayoutManager.hpp"
 #include "../../layout/supplementary/DragController.hpp"
 
-#include <array>
 #include <chrono>
-#include <cstdlib>
 #include <hyprutils/math/Vector2D.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <ranges>
 #include <wayland-server-protocol.h>
-#include <xkbcommon/xkbcommon-compose.h>
 #include <xkbcommon/xkbcommon-keysyms.h>
 
 using namespace Overview;
@@ -37,40 +34,7 @@ using namespace Overview::Hyprland;
 
 constexpr const float DRAG_MOVE_MS = 500.F;
 
-struct COverview::SXKBComposeState {
-    SXKBComposeState() {
-        context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-        if (!context)
-            return;
-
-        const char* locale = std::getenv("LC_ALL");
-        if (!locale || !*locale)
-            locale = std::getenv("LC_CTYPE");
-        if (!locale || !*locale)
-            locale = std::getenv("LANG");
-        if (!locale || !*locale)
-            locale = "C";
-
-        table = xkb_compose_table_new_from_locale(context, locale, XKB_COMPOSE_COMPILE_NO_FLAGS);
-        if (table)
-            state = xkb_compose_state_new(table, XKB_COMPOSE_STATE_NO_FLAGS);
-    }
-
-    ~SXKBComposeState() {
-        if (state)
-            xkb_compose_state_unref(state);
-        if (table)
-            xkb_compose_table_unref(table);
-        if (context)
-            xkb_context_unref(context);
-    }
-
-    xkb_context*       context = nullptr;
-    xkb_compose_table* table   = nullptr;
-    xkb_compose_state* state   = nullptr;
-};
-
-COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)), m_composeState(makeUnique<SXKBComposeState>()) {
+COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)) {
     ;
 }
 
@@ -204,33 +168,19 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
         return true;
     }
 
-    std::array<char, 64> utf8Buffer = {};
-    const int            utf8Size   = xkb_state_key_get_utf8(keyboard->m_xkbState, keycode + 8, utf8Buffer.data(), utf8Buffer.size());
-    auto                 utf8       = utf8Size > 0 ? std::string{utf8Buffer.data(), sc<size_t>(utf8Size)} : std::string{};
-    const auto           MODIFIERS  = g_pInputManager->getModsFromAllKBs();
-    const bool           EDIT_KEY   = KEYSYM == XKB_KEY_BackSpace || KEYSYM == XKB_KEY_Delete || KEYSYM == XKB_KEY_Left || KEYSYM == XKB_KEY_Right || KEYSYM == XKB_KEY_Home ||
+    const int   UTF8_SIZE = xkb_state_key_get_utf8(keyboard->m_xkbState, keycode + 8, nullptr, 0);
+    std::string utf8;
+    if (UTF8_SIZE > 0) {
+        utf8.resize(sc<size_t>(UTF8_SIZE) + 1);
+        const int WRITTEN = xkb_state_key_get_utf8(keyboard->m_xkbState, keycode + 8, utf8.data(), utf8.size());
+        utf8.resize(WRITTEN > 0 ? sc<size_t>(WRITTEN) : 0);
+    }
+
+    const auto MODIFIERS = keyboard->getModifiers();
+    const bool EDIT_KEY  = KEYSYM == XKB_KEY_BackSpace || KEYSYM == XKB_KEY_Delete || KEYSYM == XKB_KEY_Left || KEYSYM == XKB_KEY_Right || KEYSYM == XKB_KEY_Home ||
         KEYSYM == XKB_KEY_End || KEYSYM == XKB_KEY_KP_Home || KEYSYM == XKB_KEY_KP_End;
     const bool TEXT_SHORTCUT         = (MODIFIERS & Input::HL_MODIFIER_CTRL) && (KEYSYM == XKB_KEY_a || KEYSYM == XKB_KEY_A);
     const bool BLOCKED_TEXT_MODIFIER = !!(MODIFIERS & (Input::HL_MODIFIER_CTRL | Input::HL_MODIFIER_ALT | Input::HL_MODIFIER_META));
-    if (!repeat && !EDIT_KEY && !TEXT_SHORTCUT && !BLOCKED_TEXT_MODIFIER && m_composeState && m_composeState->state) {
-        xkb_compose_state_feed(m_composeState->state, KEYSYM);
-        const auto STATUS = xkb_compose_state_get_status(m_composeState->state);
-        if (STATUS == XKB_COMPOSE_COMPOSING)
-            return true;
-
-        if (STATUS == XKB_COMPOSE_COMPOSED) {
-            const int composeSize = xkb_compose_state_get_utf8(m_composeState->state, nullptr, 0);
-            if (composeSize > 0) {
-                std::vector<char> composeBuffer(sc<size_t>(composeSize) + 1, '\0');
-                const int         written = xkb_compose_state_get_utf8(m_composeState->state, composeBuffer.data(), composeBuffer.size());
-                if (written > 0)
-                    utf8.assign(composeBuffer.data(), std::min(sc<size_t>(written), composeBuffer.size() - 1));
-            } else
-                utf8.clear();
-            xkb_compose_state_reset(m_composeState->state);
-        } else if (STATUS == XKB_COMPOSE_CANCELLED)
-            xkb_compose_state_reset(m_composeState->state);
-    }
 
     if (!EDIT_KEY && !TEXT_SHORTCUT && (utf8.empty() || BLOCKED_TEXT_MODIFIER))
         return false;
@@ -392,8 +342,6 @@ void COverview::open(PHLMONITOR monitor) {
         return;
 
     m_isOpen = true;
-    if (m_composeState && m_composeState->state)
-        xkb_compose_state_reset(m_composeState->state);
     if (NEW_SCENE) {
         m_monitor   = monitor;
         m_resources = RESOURCES;

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -22,11 +22,14 @@
 #include "../../layout/LayoutManager.hpp"
 #include "../../layout/supplementary/DragController.hpp"
 
+#include <array>
 #include <chrono>
+#include <cstdlib>
 #include <hyprutils/math/Vector2D.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <ranges>
 #include <wayland-server-protocol.h>
+#include <xkbcommon/xkbcommon-compose.h>
 #include <xkbcommon/xkbcommon-keysyms.h>
 
 using namespace Overview;
@@ -34,7 +37,40 @@ using namespace Overview::Hyprland;
 
 constexpr const float DRAG_MOVE_MS = 500.F;
 
-COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)) {
+struct COverview::SXKBComposeState {
+    SXKBComposeState() {
+        context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+        if (!context)
+            return;
+
+        const char* locale = std::getenv("LC_ALL");
+        if (!locale || !*locale)
+            locale = std::getenv("LC_CTYPE");
+        if (!locale || !*locale)
+            locale = std::getenv("LANG");
+        if (!locale || !*locale)
+            locale = "C";
+
+        table = xkb_compose_table_new_from_locale(context, locale, XKB_COMPOSE_COMPILE_NO_FLAGS);
+        if (table)
+            state = xkb_compose_state_new(table, XKB_COMPOSE_STATE_NO_FLAGS);
+    }
+
+    ~SXKBComposeState() {
+        if (state)
+            xkb_compose_state_unref(state);
+        if (table)
+            xkb_compose_table_unref(table);
+        if (context)
+            xkb_context_unref(context);
+    }
+
+    xkb_context*       context = nullptr;
+    xkb_compose_table* table   = nullptr;
+    xkb_compose_state* state   = nullptr;
+};
+
+COverview::COverview() : m_scene(makeShared<COverviewScene>(*this)), m_composeState(makeUnique<SXKBComposeState>()) {
     ;
 }
 
@@ -57,24 +93,22 @@ void COverview::installListeners() {
                 return;
 
             m_interceptedKeys.erase(IT);
+            stopKeyRepeat(event.keycode);
             info.cancelled = true;
             return;
         }
 
-        if (!m_isOpen || !keyboard || !keyboard->m_xkbSymState)
+        if (!m_isOpen || !keyboard || !keyboard->m_xkbState)
             return;
 
-        const auto KEYSYM = xkb_state_key_get_one_sym(keyboard->m_xkbSymState, event.keycode + 8);
-        if (KEYSYM != XKB_KEY_Left && KEYSYM != XKB_KEY_Right && KEYSYM != XKB_KEY_h && KEYSYM != XKB_KEY_l)
+        if (!handleSearchKey(event.keycode, keyboard))
             return;
 
         info.cancelled = true;
         if (INTERCEPTED() == m_interceptedKeys.end())
             m_interceptedKeys.emplace_back(keyboard, event.keycode);
-        if (KEYSYM == XKB_KEY_Left || KEYSYM == XKB_KEY_h)
-            m_scene->navigateLeft();
-        else
-            m_scene->navigateRight();
+        if (m_isOpen)
+            startKeyRepeat(event.keycode, keyboard);
     });
 
     m_listeners.monitorDisconnect  = m_monitor->m_events.disconnect.listen([this] { closeImmediately(); });
@@ -90,14 +124,31 @@ void COverview::installListeners() {
         m_listeners.sessionLock = g_pSessionLockManager->m_events.lock.listen([this] { closeImmediately(); });
 
     m_listeners.mouseButton = Event::bus()->m_events.input.mouse.button.listen([this](IPointer::SButtonEvent e, Event::SCallbackInfo& i) {
+        const auto INTERCEPTED = std::ranges::find(m_interceptedButtons, e.button);
+        if (e.state == WL_POINTER_BUTTON_STATE_RELEASED && INTERCEPTED != m_interceptedButtons.end()) {
+            if (const auto MONITOR = m_monitor.lock())
+                m_scene->pointerButton(e.button, false, g_pInputManager->getMouseCoordsInternal() - MONITOR->logicalBox().pos());
+            m_interceptedButtons.erase(INTERCEPTED);
+            i.cancelled = true;
+            return;
+        }
+
         if (e.state != WL_POINTER_BUTTON_STATE_PRESSED)
             return;
 
-        if (!m_monitor)
+        const auto MONITOR = m_monitor.lock();
+        if (!MONITOR)
             return;
 
-        if (!m_monitor->logicalBox().containsPoint(g_pInputManager->getMouseCoordsInternal()))
+        const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+        if (!MONITOR->logicalBox().containsPoint(MOUSE))
             return;
+
+        if (m_scene->pointerButton(e.button, true, MOUSE - MONITOR->logicalBox().pos())) {
+            m_interceptedButtons.emplace_back(e.button);
+            i.cancelled = true;
+            return;
+        }
 
         // TODO: make this better. This is to support drags, and is obviously kinda wrong.
         if (g_pInputManager->getModsFromAllKBs() != Input::eKeyboardModifiers::HL_MODIFIER_NONE)
@@ -108,7 +159,127 @@ void COverview::installListeners() {
         i.cancelled = true;
     });
 
-    m_listeners.mouseMove = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D p, Event::SCallbackInfo& i) { recheckDrag(); });
+    m_listeners.mouseMove = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D p, Event::SCallbackInfo& i) {
+        const auto MONITOR = m_monitor.lock();
+        if (MONITOR && m_scene->pointerMove(p - MONITOR->logicalBox().pos()))
+            i.cancelled = true;
+        recheckDrag();
+    });
+}
+
+bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat) {
+    if (!m_isOpen || !keyboard || !keyboard->m_xkbState)
+        return false;
+
+    const auto KEYSYM = xkb_state_key_get_one_sym(keyboard->m_xkbState, keycode + 8);
+
+    // Text mode follows a small "vim"-like mode behavior:
+    // By default, we're in NAVIGATE: escape closes, left/right navigates
+    // if we start typing, we enter TEXT mode, and escape goes out of it, enter closes.
+    if (m_inputMode == eInputMode::NAVIGATION) {
+        if (KEYSYM == XKB_KEY_Left) {
+            m_scene->navigateLeft();
+            return true;
+        }
+
+        if (KEYSYM == XKB_KEY_Right) {
+            m_scene->navigateRight();
+            return true;
+        }
+
+        if (KEYSYM == XKB_KEY_Escape) {
+            close();
+            return true;
+        }
+    } else if (m_inputMode == eInputMode::TEXT) {
+        if (KEYSYM == XKB_KEY_Escape) {
+            m_inputMode = eInputMode::NAVIGATION;
+            m_scene->setTextboxFocus(false);
+            return true;
+        }
+    }
+
+    if (KEYSYM == XKB_KEY_Return || KEYSYM == XKB_KEY_KP_Enter) {
+        close();
+        return true;
+    }
+
+    std::array<char, 64> utf8Buffer = {};
+    const int            utf8Size   = xkb_state_key_get_utf8(keyboard->m_xkbState, keycode + 8, utf8Buffer.data(), utf8Buffer.size());
+    auto                 utf8       = utf8Size > 0 ? std::string{utf8Buffer.data(), sc<size_t>(utf8Size)} : std::string{};
+    const auto           MODIFIERS  = g_pInputManager->getModsFromAllKBs();
+    const bool           EDIT_KEY   = KEYSYM == XKB_KEY_BackSpace || KEYSYM == XKB_KEY_Delete || KEYSYM == XKB_KEY_Left || KEYSYM == XKB_KEY_Right || KEYSYM == XKB_KEY_Home ||
+        KEYSYM == XKB_KEY_End || KEYSYM == XKB_KEY_KP_Home || KEYSYM == XKB_KEY_KP_End;
+    const bool TEXT_SHORTCUT         = (MODIFIERS & Input::HL_MODIFIER_CTRL) && (KEYSYM == XKB_KEY_a || KEYSYM == XKB_KEY_A);
+    const bool BLOCKED_TEXT_MODIFIER = !!(MODIFIERS & (Input::HL_MODIFIER_CTRL | Input::HL_MODIFIER_ALT | Input::HL_MODIFIER_META));
+    if (!repeat && !EDIT_KEY && !TEXT_SHORTCUT && !BLOCKED_TEXT_MODIFIER && m_composeState && m_composeState->state) {
+        xkb_compose_state_feed(m_composeState->state, KEYSYM);
+        const auto STATUS = xkb_compose_state_get_status(m_composeState->state);
+        if (STATUS == XKB_COMPOSE_COMPOSING)
+            return true;
+
+        if (STATUS == XKB_COMPOSE_COMPOSED) {
+            const int composeSize = xkb_compose_state_get_utf8(m_composeState->state, nullptr, 0);
+            if (composeSize > 0) {
+                std::vector<char> composeBuffer(sc<size_t>(composeSize) + 1, '\0');
+                const int         written = xkb_compose_state_get_utf8(m_composeState->state, composeBuffer.data(), composeBuffer.size());
+                if (written > 0)
+                    utf8.assign(composeBuffer.data(), std::min(sc<size_t>(written), composeBuffer.size() - 1));
+            } else
+                utf8.clear();
+            xkb_compose_state_reset(m_composeState->state);
+        } else if (STATUS == XKB_COMPOSE_CANCELLED)
+            xkb_compose_state_reset(m_composeState->state);
+    }
+
+    if (!EDIT_KEY && !TEXT_SHORTCUT && (utf8.empty() || BLOCKED_TEXT_MODIFIER))
+        return false;
+
+    m_scene->setTextboxFocus(true);
+    m_scene->keyboardKey(KEYSYM, true, repeat, std::move(utf8), sc<uint32_t>(MODIFIERS));
+    m_inputMode = eInputMode::TEXT;
+
+    return true;
+}
+
+void COverview::startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard) {
+    if (!keyboard || !keyboard->m_xkbKeymap || keyboard->m_repeatRate <= 0 || !xkb_keymap_key_repeats(keyboard->m_xkbKeymap, keycode + 8)) {
+        stopKeyRepeat(m_keyRepeat.keycode);
+        return;
+    }
+
+    m_keyRepeat.keyboard = keyboard;
+    m_keyRepeat.keycode  = keycode;
+    if (!m_keyRepeat.timer) {
+        m_keyRepeat.timer = makeShared<CEventLoopTimer>(
+            std::nullopt,
+            [this](SP<CEventLoopTimer> self, void*) {
+                const auto KEYBOARD = m_keyRepeat.keyboard.lock();
+                if (!m_isOpen || !KEYBOARD || KEYBOARD->m_repeatRate <= 0) {
+                    self->updateTimeout(std::nullopt);
+                    return;
+                }
+
+                if (!handleSearchKey(m_keyRepeat.keycode, KEYBOARD, true)) {
+                    self->updateTimeout(std::nullopt);
+                    return;
+                }
+                self->updateTimeout(std::chrono::milliseconds(std::max(1, 1000 / KEYBOARD->m_repeatRate)));
+            },
+            nullptr);
+        g_pEventLoopManager->addTimer(m_keyRepeat.timer);
+    }
+
+    m_keyRepeat.timer->updateTimeout(std::chrono::milliseconds(std::max(0, keyboard->m_repeatDelay)));
+}
+
+void COverview::stopKeyRepeat(uint32_t keycode) {
+    if (!m_keyRepeat.timer || m_keyRepeat.keycode != keycode)
+        return;
+
+    m_keyRepeat.timer->updateTimeout(std::nullopt);
+    m_keyRepeat.keyboard.reset();
+    m_keyRepeat.keycode = 0;
 }
 
 void COverview::recheckDrag() {
@@ -193,6 +364,9 @@ void COverview::open(PHLMONITOR monitor) {
     if (m_isOpen)
         return;
 
+    m_inputMode = eInputMode::NAVIGATION;
+    m_scene->setTextboxFocus(false);
+
     if (!m_progress) {
         Animation::mgr()->createAnimation(0.F, m_progress, Config::animationTree()->getAnimationPropertyConfig("overviewIn"), AVARDAMAGE_NONE);
         m_progress->setUpdateCallback([this](auto) {
@@ -218,6 +392,8 @@ void COverview::open(PHLMONITOR monitor) {
         return;
 
     m_isOpen = true;
+    if (m_composeState && m_composeState->state)
+        xkb_compose_state_reset(m_composeState->state);
     if (NEW_SCENE) {
         m_monitor   = monitor;
         m_resources = RESOURCES;
@@ -248,9 +424,10 @@ void COverview::close() {
     m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewOut"));
     *m_progress = 0.F;
 
-    const auto MONITOR = m_monitor.lock();
-    if (MONITOR && m_scene->selectedWorkspace() != MONITOR->m_activeWorkspace)
-        Config::Actions::changeWorkspace(m_scene->selectedWorkspace());
+    const auto MONITOR  = m_monitor.lock();
+    const auto SELECTED = m_scene->selectedWorkspace();
+    if (MONITOR && SELECTED && SELECTED != MONITOR->m_activeWorkspace)
+        Config::Actions::changeWorkspace(SELECTED);
 
     if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
         g_pHyprRenderer->damageMonitor(MONITOR);
@@ -269,7 +446,10 @@ void COverview::finishClose(bool emitEvent) {
         return;
 
     m_sceneInstalled = false;
-    m_listeners      = {};
+    stopKeyRepeat(m_keyRepeat.keycode);
+    m_listeners = {};
+    m_interceptedKeys.clear();
+    m_interceptedButtons.clear();
 
     const auto MONITOR   = m_monitor.lock();
     const auto RESOURCES = m_resources;

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -188,12 +188,12 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
     // if we delete all the text with backspace, automatically goes back to navi.
     if (m_inputMode == eInputMode::NAVIGATION) {
         if (KEYSYM == XKB_KEY_Left) {
-            m_scene->navigateLeft();
+            moveLeft();
             return true;
         }
 
         if (KEYSYM == XKB_KEY_Right) {
-            m_scene->navigateRight();
+            moveRight();
             return true;
         }
 
@@ -521,6 +521,11 @@ void COverview::scheduleFinishClose() {
 }
 
 void COverview::open(PHLMONITOR monitor) {
+    open(monitor, "");
+}
+
+void COverview::open(PHLMONITOR monitor, const std::string& query) {
+    const bool WAS_OPEN                 = m_isOpen;
     const bool KEEP_SELECTED_FULLSCREEN = m_gestureActive && !m_gestureOpening;
     if (m_gestureActive)
         endOpenGesture(m_gestureOpening);
@@ -530,6 +535,9 @@ void COverview::open(PHLMONITOR monitor) {
     bool NEW_SCENE = false;
     if (!prepareOpen(monitor, NEW_SCENE))
         return;
+
+    if (!WAS_OPEN)
+        m_scene->setQuery(query);
 
     if (!KEEP_SELECTED_FULLSCREEN)
         m_scene->useSelectedWorkspaceForFullscreen(false);
@@ -667,6 +675,26 @@ void COverview::endMoveGesture() {
 
 bool COverview::isOpen() const {
     return m_isOpen;
+}
+
+SOverviewState COverview::state() const {
+    SOverviewState result{.open = m_isOpen};
+    if (!m_isOpen || !m_sceneInstalled)
+        return result;
+
+    result.monitor   = m_monitor.lock();
+    result.workspace = m_scene->selectedWorkspace();
+    if (const auto QUERY = m_scene->query())
+        result.query = QUERY->raw();
+    return result;
+}
+
+bool COverview::moveLeft() {
+    return m_isOpen && m_sceneInstalled && m_scene->navigateLeft();
+}
+
+bool COverview::moveRight() {
+    return m_isOpen && m_sceneInstalled && m_scene->navigateRight() != eWorkspaceNavigationResult::NONE;
 }
 
 bool COverview::shouldRenderWorkspace(PHLWORKSPACE workspace) const {

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -16,7 +16,11 @@
 #include "../../managers/SessionLockManager.hpp"
 #include "../../output/Monitor.hpp"
 #include "../../output/MonitorResources.hpp"
+#include "../../pointer/PointerManager.hpp"
+#include "../../pointer/PointerTransformer.hpp"
+#include "../../protocols/core/DataDevice.hpp"
 #include "../../render/Renderer.hpp"
+#include "../../state/MonitorState.hpp"
 #include "../../layout/LayoutManager.hpp"
 #include "../../layout/supplementary/DragController.hpp"
 
@@ -89,7 +93,7 @@ void COverview::installListeners() {
         const auto INTERCEPTED = std::ranges::find(m_interceptedButtons, e.button);
         if (e.state == WL_POINTER_BUTTON_STATE_RELEASED && INTERCEPTED != m_interceptedButtons.end()) {
             if (const auto MONITOR = m_monitor.lock())
-                m_scene->pointerButton(e.button, false, g_pInputManager->getMouseCoordsInternal() - MONITOR->logicalBox().pos());
+                m_scene->pointerButton(e.button, false, Pointer::mgr()->untransformedPosition() - MONITOR->logicalBox().pos());
             m_interceptedButtons.erase(INTERCEPTED);
             i.cancelled = true;
             return;
@@ -102,7 +106,7 @@ void COverview::installListeners() {
         if (!MONITOR)
             return;
 
-        const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+        const auto MOUSE = Pointer::mgr()->untransformedPosition();
         if (!MONITOR->logicalBox().containsPoint(MOUSE))
             return;
 
@@ -121,10 +125,23 @@ void COverview::installListeners() {
         i.cancelled = true;
     });
 
-    m_listeners.mouseMove  = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D p, Event::SCallbackInfo& i) {
+    m_listeners.mouseMove  = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D, Event::SCallbackInfo& i) {
         const auto MONITOR = m_monitor.lock();
-        if (MONITOR && !g_layoutManager->dragController()->target() && m_scene->pointerMove(p - MONITOR->logicalBox().pos()))
-            i.cancelled = true;
+        if (!MONITOR)
+            return;
+
+        const auto RAW = Pointer::mgr()->untransformedPosition();
+        if (!MONITOR->logicalBox().containsPoint(RAW)) {
+            releaseDragFromOverview();
+            return;
+        }
+
+        if (!g_layoutManager->dragController()->target())
+            m_scene->pointerMove(RAW - MONITOR->logicalBox().pos());
+        else
+            g_layoutManager->moveMouse(g_pInputManager->getMouseCoordsInternal());
+
+        i.cancelled = !PROTO::data || !PROTO::data->dndActive();
     });
     m_listeners.dragMotion = g_layoutManager->dragController()->m_events.motion.listen([this] { recheckDrag(); });
     m_listeners.dragEnded  = g_layoutManager->dragController()->m_events.ended.listen([this] { resetDragHover(); });
@@ -239,9 +256,9 @@ void COverview::recheckDrag() {
         return;
     }
 
-    const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+    const auto MOUSE = Pointer::mgr()->untransformedPosition();
     if (!MONITOR->logicalBox().containsPoint(MOUSE)) {
-        resetDragHover();
+        releaseDragFromOverview();
         return;
     }
 
@@ -285,9 +302,9 @@ void COverview::applyDragHoverTarget() {
         return;
     }
 
-    const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+    const auto MOUSE = Pointer::mgr()->untransformedPosition();
     if (!MONITOR->logicalBox().containsPoint(MOUSE)) {
-        resetDragHover();
+        releaseDragFromOverview();
         return;
     }
 
@@ -330,8 +347,9 @@ void COverview::applyDragHoverTarget() {
     if (!workspace || workspace != m_scene->selectedWorkspace() || !TARGET || !TARGET->window())
         return;
 
-    TARGET->window()->moveToWorkspace(workspace);
+    TARGET->assignToSpace(workspace->m_space);
     DRAG->overrideDragWindowTargetWS(workspace);
+    g_layoutManager->moveMouse(m_scene->transformPointer(Pointer::mgr()->untransformedPosition()));
     if (repeat && m_drag.eventLoopTimer)
         m_drag.eventLoopTimer->updateTimeout(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS)));
 }
@@ -342,6 +360,24 @@ void COverview::resetDragHover() {
     m_drag.dragTarget.reset();
     if (m_drag.eventLoopTimer)
         m_drag.eventLoopTimer->updateTimeout(std::nullopt);
+}
+
+void COverview::releaseDragFromOverview() {
+    const auto& DRAG = g_layoutManager->dragController();
+    DRAG->clearDragWindowTargetWS();
+
+    const auto TARGET = DRAG->target();
+    if (!TARGET || DRAG->mode() != MBIND_MOVE || !DRAG->dragThresholdReached()) {
+        resetDragHover();
+        return;
+    }
+
+    const auto MONITOR   = State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run();
+    const auto WORKSPACE = MONITOR ? (MONITOR->m_activeSpecialWorkspace ? MONITOR->m_activeSpecialWorkspace : MONITOR->m_activeWorkspace) : nullptr;
+    if (TARGET->window() && WORKSPACE && TARGET->workspace() != WORKSPACE)
+        TARGET->assignToSpace(WORKSPACE->m_space);
+
+    resetDragHover();
 }
 
 void COverview::open(PHLMONITOR monitor) {
@@ -393,7 +429,10 @@ void COverview::open(PHLMONITOR monitor) {
         m_resources = RESOURCES;
         m_scene->start(monitor, RESOURCES);
         RESOURCES->m_sceneStack.push(m_scene);
-        m_sceneInstalled = true;
+        m_sceneInstalled     = true;
+        m_pointerTransformer = makeShared<Pointer::CPointerTransformer>(
+            [this](Vector2D pos) { return m_sceneInstalled && (!PROTO::data || !PROTO::data->dndActive()) ? m_scene->transformPointer(pos) : pos; });
+        Pointer::mgr()->addTransformer(m_pointerTransformer);
         m_progress->setValueAndWarp(0.F);
 
         installListeners();
@@ -436,6 +475,14 @@ bool COverview::shouldRenderWorkspace(PHLWORKSPACE workspace) const {
     return m_sceneInstalled && workspace && workspace->m_visible && m_scene->selectedWorkspace() == workspace;
 }
 
+PHLWORKSPACE COverview::inputWorkspace() const {
+    const auto MONITOR = m_monitor.lock();
+    if (!m_sceneInstalled || !MONITOR || !Pointer::mgr() || !MONITOR->logicalBox().containsPoint(Pointer::mgr()->untransformedPosition()))
+        return nullptr;
+
+    return m_scene->selectedWorkspace();
+}
+
 void COverview::finishClose(bool emitEvent) {
     if (m_isOpen || !m_sceneInstalled)
         return;
@@ -447,6 +494,12 @@ void COverview::finishClose(bool emitEvent) {
     m_interceptedKeys.clear();
     m_interceptedButtons.clear();
 
+    if (g_layoutManager)
+        g_layoutManager->dragController()->clearDragWindowTargetWS();
+    if (Pointer::mgr())
+        Pointer::mgr()->removeTransformer(m_pointerTransformer);
+    m_pointerTransformer.reset();
+
     const auto MONITOR   = m_monitor.lock();
     const auto RESOURCES = m_resources;
     if (RESOURCES)
@@ -455,6 +508,9 @@ void COverview::finishClose(bool emitEvent) {
     m_scene->reset();
     m_resources.reset();
     m_monitor.reset();
+
+    if (g_pInputManager)
+        g_pInputManager->simulateMouseMovement();
 
     if (MONITOR && g_pHyprRenderer) {
         MONITOR->recheckSolitary();

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -1,7 +1,9 @@
 #include "Overview.hpp"
+#include "StringUtils.hpp"
 
 #include "config/shared/actions/ConfigActions.hpp"
 #include "desktop/state/FocusState.hpp"
+#include "desktop/state/WindowState.hpp"
 #include "desktop/view/window/Window.hpp"
 #include "devices/IPointer.hpp"
 #include "input/Keys.hpp"
@@ -471,6 +473,25 @@ void COverview::close() {
     const auto SELECTED = m_scene->selectedWorkspace();
     if (MONITOR && SELECTED && SELECTED != MONITOR->m_activeWorkspace)
         Config::Actions::changeWorkspace(SELECTED);
+
+    const auto QUERY = m_scene->currentQuery();
+
+    if (!QUERY.empty()) {
+        // select the window, if applicable
+        // if we match the workspace name our search is exclusive for the workspace, don't focus shit
+        if (!StringUtils::fullMatchCaseIns(MONITOR->m_activeWorkspace->m_name, QUERY)) {
+            for (const auto& w : Desktop::windowState()->windows()) {
+                if (w->m_workspace != MONITOR->m_activeWorkspace || !w->focusAvailable())
+                    continue;
+
+                if (!StringUtils::matchesName(w->metadata().appID(), QUERY) && !StringUtils::matchesName(w->metadata().title(), QUERY))
+                    continue;
+
+                Desktop::focusState()->fullWindowFocus(w, Desktop::eFocusReason::FOCUS_REASON_SWITCH_TO_WINDOW_HARD);
+                break;
+            }
+        }
+    }
 
     if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
         g_pHyprRenderer->damageMonitor(MONITOR);

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -534,7 +534,9 @@ void COverview::scheduleFinishClose() {
 void COverview::open(PHLMONITOR monitor) {
     const bool KEEP_SELECTED_FULLSCREEN = m_gestureActive && !m_gestureOpening;
     if (m_gestureActive)
-        endGesture(m_gestureOpening);
+        endOpenGesture(m_gestureOpening);
+    if (m_moveGestureActive)
+        endMoveGesture();
 
     bool NEW_SCENE = false;
     if (!prepareOpen(monitor, NEW_SCENE))
@@ -551,6 +553,9 @@ void COverview::open(PHLMONITOR monitor) {
 void COverview::close() {
     if (!m_isOpen || !m_sceneInstalled)
         return;
+
+    if (m_moveGestureActive)
+        endMoveGesture();
 
     m_gestureActive = false;
     m_isOpen        = false;
@@ -589,7 +594,7 @@ void COverview::commitClose() {
     }
 }
 
-bool COverview::beginGesture(PHLMONITOR monitor) {
+bool COverview::beginOpenGesture(PHLMONITOR monitor) {
     if (m_gestureActive)
         return false;
 
@@ -612,7 +617,7 @@ bool COverview::beginGesture(PHLMONITOR monitor) {
     return true;
 }
 
-void COverview::updateGesture(float completion) {
+void COverview::updateOpenGesture(float completion) {
     if (!m_gestureActive || !m_progress)
         return;
 
@@ -620,7 +625,7 @@ void COverview::updateGesture(float completion) {
     m_progress->setValueAndWarp(std::lerp(m_gestureStart, TARGET, std::clamp(completion, 0.F, 1.F)));
 }
 
-void COverview::endGesture(bool commit) {
+void COverview::endOpenGesture(bool commit) {
     if (!m_gestureActive)
         return;
 
@@ -650,6 +655,29 @@ void COverview::endGesture(bool commit) {
     settleProgress(0.F, false);
 }
 
+bool COverview::beginMoveGesture() {
+    if (!m_isOpen || !m_sceneInstalled || m_gestureActive || m_moveGestureActive)
+        return false;
+
+    m_moveGestureActive = m_scene->beginMoveGesture();
+    return m_moveGestureActive;
+}
+
+void COverview::updateMoveGesture(float Δ) {
+    if (!m_moveGestureActive)
+        return;
+
+    m_scene->updateMoveGesture(Δ);
+}
+
+void COverview::endMoveGesture() {
+    if (!m_moveGestureActive)
+        return;
+
+    m_moveGestureActive = false;
+    m_scene->endMoveGesture();
+}
+
 bool COverview::isOpen() const {
     return m_isOpen;
 }
@@ -671,8 +699,9 @@ void COverview::finishClose(bool emitEvent) {
         return;
 
     m_finishCloseLock.reset();
-    m_sceneInstalled = false;
-    m_gestureActive  = false;
+    m_sceneInstalled    = false;
+    m_gestureActive     = false;
+    m_moveGestureActive = false;
     updatePointerState();
     resetDragHover();
     stopKeyRepeat(m_keyRepeat.keycode);
@@ -712,8 +741,9 @@ void COverview::closeImmediately() {
         return;
 
     m_finishCloseLock.reset();
-    m_isOpen        = false;
-    m_gestureActive = false;
+    m_isOpen            = false;
+    m_gestureActive     = false;
+    m_moveGestureActive = false;
     updatePointerState();
     resetDragHover();
     if (m_progress)

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -7,9 +7,7 @@
 #include "input/Keys.hpp"
 #include "managers/eventLoop/EventLoopTimer.hpp"
 #include "managers/input/InputManager.hpp"
-#include "overview/hyprland/scene/WorkspaceTapeController.hpp"
 #include "scene/OverviewScene.hpp"
-#include "scene/WorkspaceTapeController.hpp"
 #include "../../animation/AnimationManager.hpp"
 #include "../../config/shared/animation/AnimationTree.hpp"
 #include "../../event/EventBus.hpp"
@@ -123,12 +121,13 @@ void COverview::installListeners() {
         i.cancelled = true;
     });
 
-    m_listeners.mouseMove = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D p, Event::SCallbackInfo& i) {
+    m_listeners.mouseMove  = Event::bus()->m_events.input.mouse.move.listen([this](Vector2D p, Event::SCallbackInfo& i) {
         const auto MONITOR = m_monitor.lock();
-        if (MONITOR && m_scene->pointerMove(p - MONITOR->logicalBox().pos()))
+        if (MONITOR && !g_layoutManager->dragController()->target() && m_scene->pointerMove(p - MONITOR->logicalBox().pos()))
             i.cancelled = true;
-        recheckDrag();
     });
+    m_listeners.dragMotion = g_layoutManager->dragController()->m_events.motion.listen([this] { recheckDrag(); });
+    m_listeners.dragEnded  = g_layoutManager->dragController()->m_events.ended.listen([this] { resetDragHover(); });
 }
 
 bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat) {
@@ -233,69 +232,116 @@ void COverview::stopKeyRepeat(uint32_t keycode) {
 }
 
 void COverview::recheckDrag() {
-    auto resetDrag = [this] {
-        m_drag.isWithin = false;
-        if (m_drag.eventLoopTimer)
-            m_drag.eventLoopTimer->cancel();
-    };
-
-    if (!m_monitor) {
-        resetDrag();
+    const auto  MONITOR = m_monitor.lock();
+    const auto& DRAG    = g_layoutManager->dragController();
+    if (!m_isOpen || !MONITOR || !DRAG->target() || DRAG->mode() != MBIND_MOVE || !DRAG->dragThresholdReached()) {
+        resetDragHover();
         return;
     }
 
-    if (!m_monitor->logicalBox().containsPoint(g_pInputManager->getMouseCoordsInternal())) {
-        resetDrag();
+    const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+    if (!MONITOR->logicalBox().containsPoint(MOUSE)) {
+        resetDragHover();
         return;
     }
 
-    const auto TARGET = g_layoutManager->dragController()->target();
+    const auto MOUSE_LOCAL = MOUSE - MONITOR->logicalBox().pos();
+    const auto MINI_TILE   = m_scene->miniWorkspaceAt(MOUSE_LOCAL);
+    auto       target      = eDragHoverTarget::NONE;
+    if (MINI_TILE)
+        target = eDragHoverTarget::MINI_TILE;
+    else {
+        const auto MAIN_AREA = m_scene->mainArea();
+        if (MOUSE_LOCAL.x < MAIN_AREA.x)
+            target = eDragHoverTarget::LEFT_EDGE;
+        else if (MOUSE_LOCAL.x > MAIN_AREA.x + MAIN_AREA.w)
+            target = eDragHoverTarget::RIGHT_EDGE;
+    }
 
-    if (!TARGET) {
-        resetDrag();
+    if (target == eDragHoverTarget::NONE) {
+        resetDragHover();
         return;
     }
 
-    const auto MONBOX                   = m_monitor->logicalBox();
-    const auto MOUSE_LOCAL              = g_pInputManager->getMouseCoordsInternal() - MONBOX.pos();
-    const auto SIDE_WIDTH               = (MONBOX.size().x - (MONBOX.size() * CWorkspaceTapeController::TILE_SCALE).x) / 2.F;
-    const bool MOUSE_IS_LEFT_DIST       = MOUSE_LOCAL.x < SIDE_WIDTH;
-    const auto IS_MOUSE_WITHIN_DISTANCE = MOUSE_IS_LEFT_DIST || MOUSE_LOCAL.x > MONBOX.size().x - SIDE_WIDTH;
-
-    if (!IS_MOUSE_WITHIN_DISTANCE) {
-        resetDrag();
+    if (target == m_drag.target && m_drag.dragTarget == DRAG->target() && (target != eDragHoverTarget::MINI_TILE || m_drag.workspace == MINI_TILE))
         return;
-    }
 
-    if (IS_MOUSE_WITHIN_DISTANCE && m_drag.isWithin) {
-        // check if timer passed, if so, move
-        if (m_drag.debouncer.getMillis() < DRAG_MOVE_MS)
-            return;
-
-        if (MOUSE_IS_LEFT_DIST)
-            m_scene->navigateLeft();
-        else
-            m_scene->navigateRight();
-
-        // set the current dragger's workspace MOTHERFUCKER
-        if (TARGET->window()) {
-            TARGET->window()->moveToWorkspace(m_scene->selectedWorkspace());
-            g_layoutManager->dragController()->overrideDragWindowTargetWS(m_scene->selectedWorkspace());
-        }
-
-        m_drag.debouncer.reset();
-        return;
-    }
-
-    m_drag.isWithin = true;
-    m_drag.debouncer.reset();
-
+    m_drag.target     = target;
+    m_drag.workspace  = MINI_TILE;
+    m_drag.dragTarget = DRAG->target();
     if (!m_drag.eventLoopTimer) {
-        m_drag.eventLoopTimer =
-            makeShared<CEventLoopTimer>(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS) + 10), [this](SP<CEventLoopTimer> self, void* data) { recheckDrag(); }, nullptr);
+        m_drag.eventLoopTimer = makeShared<CEventLoopTimer>(std::nullopt, [this](SP<CEventLoopTimer>, void*) { applyDragHoverTarget(); }, nullptr);
         g_pEventLoopManager->addTimer(m_drag.eventLoopTimer);
-    } else
-        m_drag.eventLoopTimer->updateTimeout(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS) + 10));
+    }
+
+    m_drag.eventLoopTimer->updateTimeout(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS)));
+}
+
+void COverview::applyDragHoverTarget() {
+    const auto& DRAG    = g_layoutManager->dragController();
+    const auto  MONITOR = m_monitor.lock();
+    if (!m_isOpen || !MONITOR || !DRAG->target() || m_drag.dragTarget != DRAG->target() || DRAG->mode() != MBIND_MOVE || !DRAG->dragThresholdReached()) {
+        resetDragHover();
+        return;
+    }
+
+    const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+    if (!MONITOR->logicalBox().containsPoint(MOUSE)) {
+        resetDragHover();
+        return;
+    }
+
+    const auto MOUSE_LOCAL   = MOUSE - MONITOR->logicalBox().pos();
+    const auto MINI_TILE     = m_scene->miniWorkspaceAt(MOUSE_LOCAL);
+    const auto MAIN_AREA     = m_scene->mainArea();
+    const bool STILL_HOVERED = (m_drag.target == eDragHoverTarget::MINI_TILE && MINI_TILE && m_drag.workspace == MINI_TILE) ||
+        (m_drag.target == eDragHoverTarget::LEFT_EDGE && !MINI_TILE && MOUSE_LOCAL.x < MAIN_AREA.x) ||
+        (m_drag.target == eDragHoverTarget::RIGHT_EDGE && !MINI_TILE && MOUSE_LOCAL.x > MAIN_AREA.x + MAIN_AREA.w);
+    if (!STILL_HOVERED) {
+        resetDragHover();
+        recheckDrag();
+        return;
+    }
+
+    PHLWORKSPACE workspace;
+    bool         repeat = false;
+    switch (m_drag.target) {
+        case eDragHoverTarget::LEFT_EDGE:
+            if (m_scene->navigateLeft()) {
+                workspace = m_scene->selectedWorkspace();
+                repeat    = true;
+            }
+            break;
+        case eDragHoverTarget::RIGHT_EDGE:
+            if (m_scene->navigateRight()) {
+                workspace = m_scene->selectedWorkspace();
+                repeat    = true;
+            }
+            break;
+        case eDragHoverTarget::MINI_TILE:
+            workspace = m_drag.workspace.lock();
+            if (workspace)
+                m_scene->selectWorkspace(workspace);
+            break;
+        case eDragHoverTarget::NONE: return;
+    }
+
+    const auto TARGET = DRAG->target();
+    if (!workspace || workspace != m_scene->selectedWorkspace() || !TARGET || !TARGET->window())
+        return;
+
+    TARGET->window()->moveToWorkspace(workspace);
+    DRAG->overrideDragWindowTargetWS(workspace);
+    if (repeat && m_drag.eventLoopTimer)
+        m_drag.eventLoopTimer->updateTimeout(std::chrono::milliseconds(sc<int32_t>(DRAG_MOVE_MS)));
+}
+
+void COverview::resetDragHover() {
+    m_drag.target = eDragHoverTarget::NONE;
+    m_drag.workspace.reset();
+    m_drag.dragTarget.reset();
+    if (m_drag.eventLoopTimer)
+        m_drag.eventLoopTimer->updateTimeout(std::nullopt);
 }
 
 void COverview::open(PHLMONITOR monitor) {
@@ -369,6 +415,7 @@ void COverview::close() {
         return;
 
     m_isOpen = false;
+    resetDragHover();
     m_progress->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewOut"));
     *m_progress = 0.F;
 
@@ -394,6 +441,7 @@ void COverview::finishClose(bool emitEvent) {
         return;
 
     m_sceneInstalled = false;
+    resetDragHover();
     stopKeyRepeat(m_keyRepeat.keycode);
     m_listeners = {};
     m_interceptedKeys.clear();
@@ -422,6 +470,7 @@ void COverview::closeImmediately() {
         return;
 
     m_isOpen = false;
+    resetDragHover();
     if (m_progress)
         m_progress->setValueAndWarp(0.F);
     finishClose();

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -531,3 +531,7 @@ void COverview::closeImmediately() {
         m_progress->setValueAndWarp(0.F);
     finishClose();
 }
+
+SP<COverviewScene> COverview::scene() const {
+    return m_scene;
+}

--- a/src/overview/hyprland/Overview.cpp
+++ b/src/overview/hyprland/Overview.cpp
@@ -156,6 +156,7 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
     // Text mode follows a small "vim"-like mode behavior:
     // By default, we're in NAVIGATE: escape closes, left/right navigates
     // if we start typing, we enter TEXT mode, and escape goes out of it, enter closes.
+    // if we delete all the text with backspace, automatically goes back to navi.
     if (m_inputMode == eInputMode::NAVIGATION) {
         if (KEYSYM == XKB_KEY_Left) {
             m_scene->navigateLeft();
@@ -174,6 +175,7 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
     } else if (m_inputMode == eInputMode::TEXT) {
         if (KEYSYM == XKB_KEY_Escape) {
             m_inputMode = eInputMode::NAVIGATION;
+            m_scene->resetQuery();
             m_scene->setTextboxFocus(false);
             return true;
         }
@@ -204,6 +206,13 @@ bool COverview::handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool r
     m_scene->setTextboxFocus(true);
     m_scene->keyboardKey(KEYSYM, true, repeat, std::move(utf8), sc<uint32_t>(MODIFIERS));
     m_inputMode = eInputMode::TEXT;
+
+    if (m_scene->currentQuery().empty()) {
+        m_inputMode = eInputMode::NAVIGATION;
+        m_scene->resetQuery();
+        m_scene->setTextboxFocus(false);
+        return true;
+    }
 
     return true;
 }

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -2,7 +2,6 @@
 
 #include "../Overview.hpp"
 #include "../../helpers/AnimatedVariable.hpp"
-#include "../../helpers/time/Timer.hpp"
 #include "../../managers/eventLoop/EventLoopTimer.hpp"
 
 #include <utility>
@@ -10,6 +9,9 @@
 
 namespace Monitor {
     class CMonitorResources;
+}
+namespace Layout {
+    class ITarget;
 }
 class IKeyboard;
 
@@ -31,6 +33,8 @@ namespace Overview::Hyprland {
         void                           closeImmediately();
         void                           installListeners();
         void                           recheckDrag();
+        void                           applyDragHoverTarget();
+        void                           resetDragHover();
         bool                           handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat = false);
         void                           startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard);
         void                           stopKeyRepeat(uint32_t keycode);
@@ -50,12 +54,21 @@ namespace Overview::Hyprland {
             CHyprSignalListener mouseMove;
             CHyprSignalListener sessionLock;
             CHyprSignalListener keyboardKey;
+            CHyprSignalListener dragMotion;
+            CHyprSignalListener dragEnded;
         } m_listeners;
 
+        enum class eDragHoverTarget : uint8_t {
+            NONE,
+            LEFT_EDGE,
+            RIGHT_EDGE,
+            MINI_TILE,
+        };
+
         struct {
-            CTimer debouncer;
-            // met criteria
-            bool                isWithin = false;
+            eDragHoverTarget    target = eDragHoverTarget::NONE;
+            PHLWORKSPACEREF     workspace;
+            WP<Layout::ITarget> dragTarget;
             SP<CEventLoopTimer> eventLoopTimer;
         } m_drag;
 

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -95,6 +95,7 @@ namespace Overview::Hyprland {
             PHLWORKSPACEREF     workspace;
             WP<Layout::ITarget> dragTarget;
             SP<CEventLoopTimer> eventLoopTimer;
+            bool                createdWorkspace = false;
         } m_drag;
 
         struct {

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -31,6 +31,9 @@ namespace Overview::Hyprland {
         void                           closeImmediately();
         void                           installListeners();
         void                           recheckDrag();
+        bool                           handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat = false);
+        void                           startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard);
+        void                           stopKeyRepeat(uint32_t keycode);
 
         bool                           m_isOpen         = false;
         bool                           m_sceneInstalled = false;
@@ -38,6 +41,8 @@ namespace Overview::Hyprland {
         WP<Monitor::CMonitorResources> m_resources;
         PHLANIMVAR<float>              m_progress;
         SP<COverviewScene>             m_scene;
+        struct SXKBComposeState;
+        UP<SXKBComposeState> m_composeState;
 
         struct {
             CHyprSignalListener monitorDisconnect;
@@ -56,7 +61,19 @@ namespace Overview::Hyprland {
             SP<CEventLoopTimer> eventLoopTimer;
         } m_drag;
 
+        struct {
+            WP<IKeyboard>       keyboard;
+            uint32_t            keycode = 0;
+            SP<CEventLoopTimer> timer;
+        } m_keyRepeat;
+
+        enum class eInputMode : uint8_t {
+            NAVIGATION,
+            TEXT
+        } m_inputMode = COverview::eInputMode::NAVIGATION;
+
         std::vector<std::pair<WP<IKeyboard>, uint32_t>> m_interceptedKeys;
+        std::vector<uint32_t>                           m_interceptedButtons;
 
         friend class COverviewScene;
     };

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -41,8 +41,6 @@ namespace Overview::Hyprland {
         WP<Monitor::CMonitorResources> m_resources;
         PHLANIMVAR<float>              m_progress;
         SP<COverviewScene>             m_scene;
-        struct SXKBComposeState;
-        UP<SXKBComposeState> m_composeState;
 
         struct {
             CHyprSignalListener monitorDisconnect;

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../Overview.hpp"
+#include "../../helpers/AnimatedVariable.hpp"
+
+namespace Monitor {
+    class CMonitorResources;
+}
+
+namespace Overview::Hyprland {
+    class COverviewScene;
+
+    class COverview : public Overview::IOverview {
+      public:
+        COverview();
+        virtual ~COverview() override;
+
+        virtual void open(PHLMONITOR monitor) override;
+        virtual void close() override;
+        virtual bool isOpen() const override;
+
+      private:
+        void                           finishClose(bool emitEvent = true);
+        void                           closeImmediately();
+
+        bool                           m_isOpen         = false;
+        bool                           m_sceneInstalled = false;
+        PHLMONITORREF                  m_monitor;
+        WP<Monitor::CMonitorResources> m_resources;
+        PHLANIMVAR<float>              m_progress;
+        SP<COverviewScene>             m_scene;
+
+        struct {
+            CHyprSignalListener monitorDisconnect;
+            CHyprSignalListener monitorModeChanged;
+            CHyprSignalListener monitorPreRender;
+            CHyprSignalListener sessionLock;
+        } m_listeners;
+
+        friend class COverviewScene;
+    };
+};

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -28,8 +28,10 @@ namespace Overview::Hyprland {
         virtual ~COverview() override;
 
         virtual void         open(PHLMONITOR monitor) override;
+        void                 open(PHLMONITOR monitor, const std::string& query);
         virtual void         close() override;
         virtual bool         isOpen() const override;
+        SOverviewState       state() const;
         virtual bool         shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
         virtual PHLWORKSPACE inputWorkspace() const override;
         virtual bool         beginOpenGesture(PHLMONITOR monitor) override;
@@ -38,6 +40,8 @@ namespace Overview::Hyprland {
         virtual bool         beginMoveGesture() override;
         virtual void         updateMoveGesture(float Δ) override;
         virtual void         endMoveGesture() override;
+        bool                 moveLeft();
+        bool                 moveRight();
         virtual void         onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard) override;
 
         SP<COverviewScene>   scene() const;

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -2,6 +2,7 @@
 
 #include "../Overview.hpp"
 #include "../../helpers/AnimatedVariable.hpp"
+#include "../../managers/SeatManager.hpp"
 #include "../../managers/eventLoop/EventLoopTimer.hpp"
 
 #include <utility>
@@ -16,13 +17,12 @@ namespace Layout {
 namespace Pointer {
     class CPointerTransformer;
 }
-class IKeyboard;
 struct SEventLoopDoLaterLock;
 
 namespace Overview::Hyprland {
     class COverviewScene;
 
-    class COverview : public Overview::IOverview, public Overview::IOverviewGestureOpenable, public Overview::IOverviewGestureMovable {
+    class COverview : public Overview::IOverview, public Overview::IOverviewGestureOpenable, public Overview::IOverviewGestureMovable, public IKeyboardEventHandler {
       public:
         COverview();
         virtual ~COverview() override;
@@ -38,6 +38,7 @@ namespace Overview::Hyprland {
         virtual bool         beginMoveGesture() override;
         virtual void         updateMoveGesture(float Δ) override;
         virtual void         endMoveGesture() override;
+        virtual void         onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboard> keyboard) override;
 
         SP<COverviewScene>   scene() const;
 
@@ -56,7 +57,7 @@ namespace Overview::Hyprland {
         void                             resetDragHover();
         bool                             handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat = false);
         void                             startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard);
-        void                             stopKeyRepeat(uint32_t keycode);
+        void                             stopKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard = nullptr);
 
         bool                             m_isOpen            = false;
         bool                             m_sceneInstalled    = false;
@@ -78,7 +79,6 @@ namespace Overview::Hyprland {
             CHyprSignalListener mouseButton;
             CHyprSignalListener mouseMove;
             CHyprSignalListener sessionLock;
-            CHyprSignalListener keyboardKey;
             CHyprSignalListener dragMotion;
             CHyprSignalListener dragEnded;
         } m_listeners;
@@ -103,13 +103,14 @@ namespace Overview::Hyprland {
             SP<CEventLoopTimer> timer;
         } m_keyRepeat;
 
+        WP<IKeyboardEventHandler> m_keyboardEventHandler;
+
         enum class eInputMode : uint8_t {
             NAVIGATION,
             TEXT
         } m_inputMode = COverview::eInputMode::NAVIGATION;
 
-        std::vector<std::pair<WP<IKeyboard>, uint32_t>> m_interceptedKeys;
-        std::vector<uint32_t>                           m_interceptedButtons;
+        std::vector<uint32_t> m_interceptedButtons;
 
         friend class COverviewScene;
     };

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -13,6 +13,9 @@ namespace Monitor {
 namespace Layout {
     class ITarget;
 }
+namespace Pointer {
+    class CPointerTransformer;
+}
 class IKeyboard;
 
 namespace Overview::Hyprland {
@@ -23,28 +26,31 @@ namespace Overview::Hyprland {
         COverview();
         virtual ~COverview() override;
 
-        virtual void open(PHLMONITOR monitor) override;
-        virtual void close() override;
-        virtual bool isOpen() const override;
-        virtual bool shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
+        virtual void         open(PHLMONITOR monitor) override;
+        virtual void         close() override;
+        virtual bool         isOpen() const override;
+        virtual bool         shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
+        virtual PHLWORKSPACE inputWorkspace() const override;
 
       private:
-        void                           finishClose(bool emitEvent = true);
-        void                           closeImmediately();
-        void                           installListeners();
-        void                           recheckDrag();
-        void                           applyDragHoverTarget();
-        void                           resetDragHover();
-        bool                           handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat = false);
-        void                           startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard);
-        void                           stopKeyRepeat(uint32_t keycode);
+        void                             finishClose(bool emitEvent = true);
+        void                             closeImmediately();
+        void                             installListeners();
+        void                             recheckDrag();
+        void                             applyDragHoverTarget();
+        void                             releaseDragFromOverview();
+        void                             resetDragHover();
+        bool                             handleSearchKey(uint32_t keycode, SP<IKeyboard> keyboard, bool repeat = false);
+        void                             startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard);
+        void                             stopKeyRepeat(uint32_t keycode);
 
-        bool                           m_isOpen         = false;
-        bool                           m_sceneInstalled = false;
-        PHLMONITORREF                  m_monitor;
-        WP<Monitor::CMonitorResources> m_resources;
-        PHLANIMVAR<float>              m_progress;
-        SP<COverviewScene>             m_scene;
+        bool                             m_isOpen         = false;
+        bool                             m_sceneInstalled = false;
+        PHLMONITORREF                    m_monitor;
+        WP<Monitor::CMonitorResources>   m_resources;
+        PHLANIMVAR<float>                m_progress;
+        SP<COverviewScene>               m_scene;
+        SP<Pointer::CPointerTransformer> m_pointerTransformer;
 
         struct {
             CHyprSignalListener monitorDisconnect;

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -17,11 +17,12 @@ namespace Pointer {
     class CPointerTransformer;
 }
 class IKeyboard;
+struct SEventLoopDoLaterLock;
 
 namespace Overview::Hyprland {
     class COverviewScene;
 
-    class COverview : public Overview::IOverview {
+    class COverview : public Overview::IOverview, public Overview::IOverviewGesture {
       public:
         COverview();
         virtual ~COverview() override;
@@ -31,12 +32,19 @@ namespace Overview::Hyprland {
         virtual bool         isOpen() const override;
         virtual bool         shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
         virtual PHLWORKSPACE inputWorkspace() const override;
+        virtual bool         beginGesture(PHLMONITOR monitor) override;
+        virtual void         updateGesture(float completion) override;
+        virtual void         endGesture(bool commit) override;
 
         SP<COverviewScene>   scene() const;
 
       private:
         void                             finishClose(bool emitEvent = true);
         void                             closeImmediately();
+        bool                             prepareOpen(PHLMONITOR monitor, bool& newScene);
+        void                             commitClose();
+        void                             settleProgress(float goal, bool opening);
+        void                             scheduleFinishClose();
         void                             installListeners();
         void                             recheckDrag();
         void                             applyDragHoverTarget();
@@ -48,11 +56,15 @@ namespace Overview::Hyprland {
 
         bool                             m_isOpen         = false;
         bool                             m_sceneInstalled = false;
+        bool                             m_gestureActive  = false;
+        bool                             m_gestureOpening = false;
+        float                            m_gestureStart   = 0.F;
         PHLMONITORREF                    m_monitor;
         WP<Monitor::CMonitorResources>   m_resources;
         PHLANIMVAR<float>                m_progress;
         SP<COverviewScene>               m_scene;
         SP<Pointer::CPointerTransformer> m_pointerTransformer;
+        UP<SEventLoopDoLaterLock>        m_finishCloseLock;
 
         struct {
             CHyprSignalListener monitorDisconnect;

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -32,6 +32,8 @@ namespace Overview::Hyprland {
         virtual bool         shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
         virtual PHLWORKSPACE inputWorkspace() const override;
 
+        SP<COverviewScene>   scene() const;
+
       private:
         void                             finishClose(bool emitEvent = true);
         void                             closeImmediately();

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -46,6 +46,7 @@ namespace Overview::Hyprland {
         void                             settleProgress(float goal, bool opening);
         void                             scheduleFinishClose();
         void                             installListeners();
+        void                             updatePointerState();
         void                             recheckDrag();
         void                             applyDragHoverTarget();
         void                             releaseDragFromOverview();

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -22,7 +22,7 @@ struct SEventLoopDoLaterLock;
 namespace Overview::Hyprland {
     class COverviewScene;
 
-    class COverview : public Overview::IOverview, public Overview::IOverviewGesture {
+    class COverview : public Overview::IOverview, public Overview::IOverviewGestureOpenable, public Overview::IOverviewGestureMovable {
       public:
         COverview();
         virtual ~COverview() override;
@@ -32,9 +32,12 @@ namespace Overview::Hyprland {
         virtual bool         isOpen() const override;
         virtual bool         shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
         virtual PHLWORKSPACE inputWorkspace() const override;
-        virtual bool         beginGesture(PHLMONITOR monitor) override;
-        virtual void         updateGesture(float completion) override;
-        virtual void         endGesture(bool commit) override;
+        virtual bool         beginOpenGesture(PHLMONITOR monitor) override;
+        virtual void         updateOpenGesture(float completion) override;
+        virtual void         endOpenGesture(bool commit) override;
+        virtual bool         beginMoveGesture() override;
+        virtual void         updateMoveGesture(float Δ) override;
+        virtual void         endMoveGesture() override;
 
         SP<COverviewScene>   scene() const;
 
@@ -55,11 +58,12 @@ namespace Overview::Hyprland {
         void                             startKeyRepeat(uint32_t keycode, SP<IKeyboard> keyboard);
         void                             stopKeyRepeat(uint32_t keycode);
 
-        bool                             m_isOpen         = false;
-        bool                             m_sceneInstalled = false;
-        bool                             m_gestureActive  = false;
-        bool                             m_gestureOpening = false;
-        float                            m_gestureStart   = 0.F;
+        bool                             m_isOpen            = false;
+        bool                             m_sceneInstalled    = false;
+        bool                             m_gestureActive     = false;
+        bool                             m_gestureOpening    = false;
+        bool                             m_moveGestureActive = false;
+        float                            m_gestureStart      = 0.F;
         PHLMONITORREF                    m_monitor;
         WP<Monitor::CMonitorResources>   m_resources;
         PHLANIMVAR<float>                m_progress;

--- a/src/overview/hyprland/Overview.hpp
+++ b/src/overview/hyprland/Overview.hpp
@@ -2,10 +2,16 @@
 
 #include "../Overview.hpp"
 #include "../../helpers/AnimatedVariable.hpp"
+#include "../../helpers/time/Timer.hpp"
+#include "../../managers/eventLoop/EventLoopTimer.hpp"
+
+#include <utility>
+#include <vector>
 
 namespace Monitor {
     class CMonitorResources;
 }
+class IKeyboard;
 
 namespace Overview::Hyprland {
     class COverviewScene;
@@ -18,10 +24,13 @@ namespace Overview::Hyprland {
         virtual void open(PHLMONITOR monitor) override;
         virtual void close() override;
         virtual bool isOpen() const override;
+        virtual bool shouldRenderWorkspace(PHLWORKSPACE workspace) const override;
 
       private:
         void                           finishClose(bool emitEvent = true);
         void                           closeImmediately();
+        void                           installListeners();
+        void                           recheckDrag();
 
         bool                           m_isOpen         = false;
         bool                           m_sceneInstalled = false;
@@ -34,8 +43,20 @@ namespace Overview::Hyprland {
             CHyprSignalListener monitorDisconnect;
             CHyprSignalListener monitorModeChanged;
             CHyprSignalListener monitorPreRender;
+            CHyprSignalListener mouseButton;
+            CHyprSignalListener mouseMove;
             CHyprSignalListener sessionLock;
+            CHyprSignalListener keyboardKey;
         } m_listeners;
+
+        struct {
+            CTimer debouncer;
+            // met criteria
+            bool                isWithin = false;
+            SP<CEventLoopTimer> eventLoopTimer;
+        } m_drag;
+
+        std::vector<std::pair<WP<IKeyboard>, uint32_t>> m_interceptedKeys;
 
         friend class COverviewScene;
     };

--- a/src/overview/hyprland/Query.cpp
+++ b/src/overview/hyprland/Query.cpp
@@ -1,0 +1,59 @@
+#include "Query.hpp"
+
+#include "mode/CombinedQueryMode.hpp"
+#include "mode/WindowQueryMode.hpp"
+#include "mode/WorkspaceQueryMode.hpp"
+
+using namespace Overview::Hyprland;
+
+CQuery::CQuery(std::string raw, const SQueryConfig& config) :
+    m_raw(std::move(raw)), m_term(m_raw), m_config(config),
+    m_modes{makeUnique<Mode::CCombinedQueryMode>(), makeUnique<Mode::CWindowQueryMode>(), makeUnique<Mode::CWorkspaceQueryMode>()} {
+    if (!m_raw.empty() && m_raw.front() == m_config.windowPrefix)
+        m_term = m_raw.substr(1);
+    else if (!m_raw.empty() && m_raw.front() == m_config.workspacePrefix)
+        m_term = m_raw.substr(1);
+}
+
+CQuery::~CQuery() = default;
+
+Mode::eWorkspaceMatch CQuery::matchWorkspace(std::string_view name, const Mode::FWorkspaceSelector& selector) const {
+    if (m_term.empty())
+        return Mode::eWorkspaceMatch::MATCH;
+
+    return m_modes[sc<size_t>(mode())]->matchWorkspace(name, m_term, selector);
+}
+
+bool CQuery::matchesWindow(std::string_view appID, std::string_view title) const {
+    return !m_term.empty() && m_modes[sc<size_t>(mode())]->matchesWindow(appID, title, m_term);
+}
+
+bool CQuery::usesWindowMetadata() const {
+    return !m_term.empty() && mode() != eQueryMode::WORKSPACE;
+}
+
+bool CQuery::empty() const {
+    return m_term.empty();
+}
+
+eQueryMode CQuery::mode() const {
+    return mode(m_raw);
+}
+
+eQueryMode CQuery::mode(std::string_view query) const {
+    if (!query.empty() && query.front() == m_config.windowPrefix)
+        return m_modes[sc<size_t>(eQueryMode::WINDOW)]->type();
+    if (!query.empty() && query.front() == m_config.workspacePrefix)
+        return m_modes[sc<size_t>(eQueryMode::WORKSPACE)]->type();
+
+    const auto DEFAULT = sc<size_t>(m_config.defaultMode);
+    return m_modes[DEFAULT < m_modes.size() ? DEFAULT : sc<size_t>(eQueryMode::ALL)]->type();
+}
+
+const std::string& CQuery::raw() const {
+    return m_raw;
+}
+
+const std::string& CQuery::term() const {
+    return m_term;
+}

--- a/src/overview/hyprland/Query.hpp
+++ b/src/overview/hyprland/Query.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../../helpers/memory/Memory.hpp"
+#include "mode/IQueryMode.hpp"
+
+#include <array>
+#include <string>
+#include <string_view>
+
+namespace Overview::Hyprland {
+    struct SQueryConfig {
+        char       windowPrefix    = '/';
+        char       workspacePrefix = '.';
+        eQueryMode defaultMode     = eQueryMode::ALL;
+    };
+
+    class CQuery {
+      public:
+        CQuery(std::string raw, const SQueryConfig& config = {});
+        ~CQuery();
+
+        Mode::eWorkspaceMatch matchWorkspace(std::string_view name, const Mode::FWorkspaceSelector& selector = {}) const;
+        bool                  matchesWindow(std::string_view appID, std::string_view title) const;
+        bool                  usesWindowMetadata() const;
+        bool                  empty() const;
+        eQueryMode            mode() const;
+        eQueryMode            mode(std::string_view query) const;
+        const std::string&    raw() const;
+        const std::string&    term() const;
+
+      private:
+        std::string                         m_raw;
+        std::string                         m_term;
+        SQueryConfig                        m_config;
+        std::array<UP<Mode::IQueryMode>, 3> m_modes;
+    };
+}

--- a/src/overview/hyprland/StringUtils.hpp
+++ b/src/overview/hyprland/StringUtils.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <algorithm>
+#include <string_view>
+
+#include "../../helpers/memory/Memory.hpp"
+
+namespace Overview::Hyprland::StringUtils {
+    inline uint8_t foldASCII(uint8_t character) {
+        if (character >= 'A' && character <= 'Z')
+            return character + ('a' - 'A');
+        return character;
+    }
+
+    inline bool matchesName(std::string_view name, std::string_view query) {
+        if (query.empty())
+            return true;
+
+        return std::ranges::search(name, query, [](char lhs, char rhs) { return foldASCII(sc<unsigned char>(lhs)) == foldASCII(sc<unsigned char>(rhs)); }).begin() != name.end();
+    }
+
+    inline bool fullMatchCaseIns(std::string_view a, std::string_view b) {
+        return std::ranges::equal(a, b, [](char x, char y) { return foldASCII(x) == foldASCII(y); });
+    }
+};

--- a/src/overview/hyprland/mode/CombinedQueryMode.cpp
+++ b/src/overview/hyprland/mode/CombinedQueryMode.cpp
@@ -1,0 +1,22 @@
+#include "CombinedQueryMode.hpp"
+
+#include "WindowQueryMode.hpp"
+#include "WorkspaceQueryMode.hpp"
+
+using namespace Overview::Hyprland::Mode;
+
+CCombinedQueryMode::~CCombinedQueryMode() = default;
+
+Overview::Hyprland::eQueryMode CCombinedQueryMode::type() const {
+    return Overview::Hyprland::eQueryMode::ALL;
+}
+
+eWorkspaceMatch CCombinedQueryMode::matchWorkspace(std::string_view name, std::string_view query, const FWorkspaceSelector& selector) const {
+    static const CWorkspaceQueryMode WORKSPACE_MODE;
+    return WORKSPACE_MODE.matchWorkspace(name, query, selector);
+}
+
+bool CCombinedQueryMode::matchesWindow(std::string_view appID, std::string_view title, std::string_view query) const {
+    static const CWindowQueryMode WINDOW_MODE;
+    return WINDOW_MODE.matchesWindow(appID, title, query);
+}

--- a/src/overview/hyprland/mode/CombinedQueryMode.hpp
+++ b/src/overview/hyprland/mode/CombinedQueryMode.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "IQueryMode.hpp"
+
+namespace Overview::Hyprland::Mode {
+    class CCombinedQueryMode : public IQueryMode {
+      public:
+        virtual ~CCombinedQueryMode() override;
+
+        virtual eQueryMode      type() const override;
+        virtual eWorkspaceMatch matchWorkspace(std::string_view name, std::string_view query, const FWorkspaceSelector& selector) const override;
+        virtual bool            matchesWindow(std::string_view appID, std::string_view title, std::string_view query) const override;
+    };
+}

--- a/src/overview/hyprland/mode/IQueryMode.cpp
+++ b/src/overview/hyprland/mode/IQueryMode.cpp
@@ -1,0 +1,5 @@
+#include "IQueryMode.hpp"
+
+using namespace Overview::Hyprland::Mode;
+
+IQueryMode::~IQueryMode() = default;

--- a/src/overview/hyprland/mode/IQueryMode.hpp
+++ b/src/overview/hyprland/mode/IQueryMode.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string_view>
+
+namespace Overview::Hyprland {
+    enum class eQueryMode : uint8_t {
+        ALL       = 0,
+        WINDOW    = 1,
+        WORKSPACE = 2,
+    };
+
+    namespace Mode {
+        enum class eWorkspaceMatch : uint8_t {
+            NONE,
+            MATCH,
+            EXACT,
+        };
+
+        using FWorkspaceSelector = std::function<bool(std::string_view)>;
+
+        class IQueryMode {
+          public:
+            virtual ~IQueryMode();
+
+            virtual eQueryMode      type() const                                                                                            = 0;
+            virtual eWorkspaceMatch matchWorkspace(std::string_view name, std::string_view query, const FWorkspaceSelector& selector) const = 0;
+            virtual bool            matchesWindow(std::string_view appID, std::string_view title, std::string_view query) const             = 0;
+        };
+    }
+}

--- a/src/overview/hyprland/mode/WindowQueryMode.cpp
+++ b/src/overview/hyprland/mode/WindowQueryMode.cpp
@@ -1,0 +1,19 @@
+#include "WindowQueryMode.hpp"
+
+#include "../StringUtils.hpp"
+
+using namespace Overview::Hyprland::Mode;
+
+CWindowQueryMode::~CWindowQueryMode() = default;
+
+Overview::Hyprland::eQueryMode CWindowQueryMode::type() const {
+    return Overview::Hyprland::eQueryMode::WINDOW;
+}
+
+eWorkspaceMatch CWindowQueryMode::matchWorkspace(std::string_view, std::string_view, const FWorkspaceSelector&) const {
+    return eWorkspaceMatch::NONE;
+}
+
+bool CWindowQueryMode::matchesWindow(std::string_view appID, std::string_view title, std::string_view query) const {
+    return StringUtils::matchesName(appID, query) || StringUtils::matchesName(title, query);
+}

--- a/src/overview/hyprland/mode/WindowQueryMode.hpp
+++ b/src/overview/hyprland/mode/WindowQueryMode.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "IQueryMode.hpp"
+
+namespace Overview::Hyprland::Mode {
+    class CWindowQueryMode : public IQueryMode {
+      public:
+        virtual ~CWindowQueryMode() override;
+
+        virtual eQueryMode      type() const override;
+        virtual eWorkspaceMatch matchWorkspace(std::string_view name, std::string_view query, const FWorkspaceSelector& selector) const override;
+        virtual bool            matchesWindow(std::string_view appID, std::string_view title, std::string_view query) const override;
+    };
+}

--- a/src/overview/hyprland/mode/WorkspaceQueryMode.cpp
+++ b/src/overview/hyprland/mode/WorkspaceQueryMode.cpp
@@ -1,0 +1,52 @@
+#include "WorkspaceQueryMode.hpp"
+
+#include "../StringUtils.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+using namespace Overview::Hyprland::Mode;
+
+static bool looksLikeSelector(std::string_view query) {
+    const auto FIRST = query.find_first_not_of(" \t\n\r");
+    if (FIRST == std::string_view::npos)
+        return false;
+
+    const auto LAST = query.find_last_not_of(" \t\n\r");
+    query           = query.substr(FIRST, LAST - FIRST + 1);
+
+    if (query.starts_with("name:") || query.starts_with("special"))
+        return true;
+
+    if (!query.empty() && std::ranges::all_of(query, [](unsigned char c) { return std::isdigit(c); }))
+        return true;
+
+    if (query.size() < 2)
+        return false;
+
+    constexpr std::string_view SELECTORS = "rsnmwf";
+    return SELECTORS.contains(query.front()) && query[1] == '[';
+}
+
+CWorkspaceQueryMode::~CWorkspaceQueryMode() = default;
+
+Overview::Hyprland::eQueryMode CWorkspaceQueryMode::type() const {
+    return Overview::Hyprland::eQueryMode::WORKSPACE;
+}
+
+eWorkspaceMatch CWorkspaceQueryMode::matchWorkspace(std::string_view name, std::string_view query, const FWorkspaceSelector& selector) const {
+    if (StringUtils::fullMatchCaseIns(name, query))
+        return eWorkspaceMatch::EXACT;
+
+    if (StringUtils::matchesName(name, query))
+        return eWorkspaceMatch::MATCH;
+
+    if (selector && looksLikeSelector(query) && selector(query))
+        return eWorkspaceMatch::MATCH;
+
+    return eWorkspaceMatch::NONE;
+}
+
+bool CWorkspaceQueryMode::matchesWindow(std::string_view, std::string_view, std::string_view) const {
+    return false;
+}

--- a/src/overview/hyprland/mode/WorkspaceQueryMode.hpp
+++ b/src/overview/hyprland/mode/WorkspaceQueryMode.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "IQueryMode.hpp"
+
+namespace Overview::Hyprland::Mode {
+    class CWorkspaceQueryMode : public IQueryMode {
+      public:
+        virtual ~CWorkspaceQueryMode() override;
+
+        virtual eQueryMode      type() const override;
+        virtual eWorkspaceMatch matchWorkspace(std::string_view name, std::string_view query, const FWorkspaceSelector& selector) const override;
+        virtual bool            matchesWindow(std::string_view appID, std::string_view title, std::string_view query) const override;
+    };
+}

--- a/src/overview/hyprland/scene/OverviewLayout.cpp
+++ b/src/overview/hyprland/scene/OverviewLayout.cpp
@@ -1,0 +1,45 @@
+#include "OverviewLayout.hpp"
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+using Hyprutils::Math::Vector2D;
+
+static constexpr float  SEARCH_TOP_SCALE       = 0.01F;
+static constexpr float  SEARCH_WIDTH_SCALE     = 0.2F;
+static constexpr float  SEARCH_HEIGHT_SCALE    = 0.03F;
+static constexpr float  SEARCH_MINI_GAP_SCALE  = 0.015F;
+static constexpr float  MINI_HEIGHT_SCALE      = 0.11F;
+static constexpr float  MINI_SIDE_MARGIN_SCALE = 0.025F;
+static constexpr float  MINI_MAIN_GAP_SCALE    = 0.025F;
+static constexpr float  MAIN_SIDE_MARGIN_SCALE = 0.05F;
+static constexpr float  MAIN_BOTTOM_SCALE      = 0.025F;
+
+OverviewLayout::SLayout OverviewLayout::calculate(const Vector2D& logicalMonitorSize, float scale) {
+    if (logicalMonitorSize.x <= 0.F || logicalMonitorSize.y <= 0.F || scale <= 0.F)
+        return {};
+
+    const float SEARCH_WIDTH  = logicalMonitorSize.x * SEARCH_WIDTH_SCALE;
+    const float SEARCH_HEIGHT = logicalMonitorSize.y * SEARCH_HEIGHT_SCALE;
+    const float SEARCH_Y      = logicalMonitorSize.y * SEARCH_TOP_SCALE;
+    const CBox  SEARCH        = {{(logicalMonitorSize.x - SEARCH_WIDTH) / 2.F, SEARCH_Y}, {SEARCH_WIDTH, SEARCH_HEIGHT}};
+
+    const float MINI_Y      = SEARCH_Y + SEARCH_HEIGHT + logicalMonitorSize.y * SEARCH_MINI_GAP_SCALE;
+    const float MINI_MARGIN = logicalMonitorSize.x * MINI_SIDE_MARGIN_SCALE;
+    const CBox  MINI_STRIP  = {{MINI_MARGIN, MINI_Y}, {logicalMonitorSize.x - 2.F * MINI_MARGIN, logicalMonitorSize.y * MINI_HEIGHT_SCALE}};
+
+    const float MAIN_Y      = MINI_STRIP.y + MINI_STRIP.h + logicalMonitorSize.y * MINI_MAIN_GAP_SCALE;
+    const float MAIN_MARGIN = logicalMonitorSize.x * MAIN_SIDE_MARGIN_SCALE;
+    const CBox  MAIN        = {{MAIN_MARGIN, MAIN_Y}, {logicalMonitorSize.x - 2.F * MAIN_MARGIN, logicalMonitorSize.y - MAIN_Y - logicalMonitorSize.y * MAIN_BOTTOM_SCALE}};
+
+    if (SEARCH.empty() || MINI_STRIP.empty() || MAIN.empty())
+        return {};
+
+    return {
+        .logicalSearch    = SEARCH,
+        .logicalMiniStrip = MINI_STRIP,
+        .logicalMain      = MAIN,
+        .pixelSearch      = SEARCH.copy().scale(scale).round(),
+        .pixelMiniStrip   = MINI_STRIP.copy().scale(scale).round(),
+        .pixelMain        = MAIN.copy().scale(scale).round(),
+    };
+}

--- a/src/overview/hyprland/scene/OverviewLayout.hpp
+++ b/src/overview/hyprland/scene/OverviewLayout.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+
+namespace Overview::Hyprland::OverviewLayout {
+    struct SLayout {
+        Hyprutils::Math::CBox logicalSearch;
+        Hyprutils::Math::CBox logicalMiniStrip;
+        Hyprutils::Math::CBox logicalMain;
+        Hyprutils::Math::CBox pixelSearch;
+        Hyprutils::Math::CBox pixelMiniStrip;
+        Hyprutils::Math::CBox pixelMain;
+    };
+
+    SLayout calculate(const Hyprutils::Math::Vector2D& logicalMonitorSize, float scale);
+}

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -1,0 +1,53 @@
+#include "OverviewScene.hpp"
+
+#include "../Overview.hpp"
+#include "../../../output/Monitor.hpp"
+#include "../../../output/MonitorResources.hpp"
+#include "../../../render/Renderer.hpp"
+#include "../../../render/pass/ClearPassElement.hpp"
+#include "../../../render/pass/TexPassElement.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Overview::Hyprland;
+
+static constexpr float OVERVIEW_SCALE    = 0.9F;
+static constexpr float OVERVIEW_ROUNDING = 20.F;
+static constexpr float OVERVIEW_GRAY     = 0.16F;
+
+COverviewScene::COverviewScene(COverview& parent) : m_parent(parent) {
+    ;
+}
+
+void COverviewScene::draw(Time::steady_tp tp) {
+    const auto MONITOR   = m_parent.m_monitor.lock();
+    const auto RESOURCES = m_parent.m_resources;
+    if (!MONITOR || !RESOURCES || !m_parent.m_progress)
+        return;
+
+    if (!m_framebuffer || m_framebuffer->m_size != MONITOR->m_transformedSize)
+        m_framebuffer = RESOURCES->getUnusedWorkBuffer();
+
+    if (!m_framebuffer || !g_pHyprRenderer->renderMonitorToBuffer(MONITOR, m_framebuffer, tp)) {
+        g_pHyprRenderer->addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
+        return;
+    }
+
+    const float    PROGRESS = std::clamp(m_parent.m_progress->value(), 0.F, 1.F);
+    const float    SCALE    = 1.F - (1.F - OVERVIEW_SCALE) * PROGRESS;
+    const Vector2D SIZE     = MONITOR->m_transformedSize * SCALE;
+    const Vector2D POS      = (MONITOR->m_transformedSize - SIZE) / 2.F;
+
+    g_pHyprRenderer->addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
+
+    CTexPassElement::SRenderData data;
+    data.tex   = m_framebuffer->getTexture();
+    data.box   = CBox{POS, SIZE};
+    data.round = std::lround(OVERVIEW_ROUNDING * MONITOR->m_scale * PROGRESS);
+    g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+}
+
+void COverviewScene::reset() {
+    m_framebuffer.reset();
+}

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -165,3 +165,7 @@ void COverviewScene::reset() {
 void COverviewScene::setTextboxFocus(bool x) {
     m_workspaceSearch->setFocused(x);
 }
+
+std::string COverviewScene::currentQuery() const {
+    return m_workspaceSearch->query();
+}

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -107,6 +107,10 @@ PHLWORKSPACE COverviewScene::selectedWorkspace() const {
     return m_workspaceTape->selectedWorkspace();
 }
 
+Vector2D COverviewScene::transformPointer(const Vector2D& global) const {
+    return m_workspaceTape->transformPointer(global);
+}
+
 PHLWORKSPACE COverviewScene::miniWorkspaceAt(const Vector2D& monitorLocal) const {
     return m_workspaceTape->miniWorkspaceAt(monitorLocal);
 }

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -1,53 +1,49 @@
 #include "OverviewScene.hpp"
 
+#include "WorkspaceTapeController.hpp"
 #include "../Overview.hpp"
 #include "../../../output/Monitor.hpp"
 #include "../../../output/MonitorResources.hpp"
 #include "../../../render/Renderer.hpp"
 #include "../../../render/pass/ClearPassElement.hpp"
-#include "../../../render/pass/TexPassElement.hpp"
 
 #include <algorithm>
-#include <cmath>
 
 using namespace Overview::Hyprland;
 
-static constexpr float OVERVIEW_SCALE    = 0.9F;
-static constexpr float OVERVIEW_ROUNDING = 20.F;
-static constexpr float OVERVIEW_GRAY     = 0.16F;
+static constexpr float OVERVIEW_GRAY = 0.16F;
 
-COverviewScene::COverviewScene(COverview& parent) : m_parent(parent) {
+COverviewScene::COverviewScene(COverview& parent) : m_parent(parent), m_workspaceTape(makeUnique<CWorkspaceTapeController>()) {
     ;
 }
 
+COverviewScene::~COverviewScene() = default;
+
 void COverviewScene::draw(Time::steady_tp tp) {
-    const auto MONITOR   = m_parent.m_monitor.lock();
-    const auto RESOURCES = m_parent.m_resources;
-    if (!MONITOR || !RESOURCES || !m_parent.m_progress)
+    const auto MONITOR = m_parent.m_monitor.lock();
+    if (!MONITOR || !m_parent.m_progress || !g_pHyprRenderer)
         return;
-
-    if (!m_framebuffer || m_framebuffer->m_size != MONITOR->m_transformedSize)
-        m_framebuffer = RESOURCES->getUnusedWorkBuffer();
-
-    if (!m_framebuffer || !g_pHyprRenderer->renderMonitorToBuffer(MONITOR, m_framebuffer, tp)) {
-        g_pHyprRenderer->addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
-        return;
-    }
-
-    const float    PROGRESS = std::clamp(m_parent.m_progress->value(), 0.F, 1.F);
-    const float    SCALE    = 1.F - (1.F - OVERVIEW_SCALE) * PROGRESS;
-    const Vector2D SIZE     = MONITOR->m_transformedSize * SCALE;
-    const Vector2D POS      = (MONITOR->m_transformedSize - SIZE) / 2.F;
 
     g_pHyprRenderer->addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
+    m_workspaceTape->draw(tp, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
+}
 
-    CTexPassElement::SRenderData data;
-    data.tex   = m_framebuffer->getTexture();
-    data.box   = CBox{POS, SIZE};
-    data.round = std::lround(OVERVIEW_ROUNDING * MONITOR->m_scale * PROGRESS);
-    g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+void COverviewScene::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {
+    m_workspaceTape->start(monitor, resources);
+}
+
+bool COverviewScene::navigateLeft() {
+    return m_workspaceTape->navigateLeft();
+}
+
+bool COverviewScene::navigateRight() {
+    return m_workspaceTape->navigateRight();
+}
+
+PHLWORKSPACE COverviewScene::selectedWorkspace() const {
+    return m_workspaceTape->selectedWorkspace();
 }
 
 void COverviewScene::reset() {
-    m_framebuffer.reset();
+    m_workspaceTape->reset();
 }

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -158,6 +158,18 @@ void COverviewScene::useSelectedWorkspaceForFullscreen(bool x) {
     m_workspaceTape->useSelectedWorkspaceForFullscreen(x);
 }
 
+bool COverviewScene::beginMoveGesture() {
+    return m_workspaceTape->beginMoveGesture();
+}
+
+void COverviewScene::updateMoveGesture(float delta) {
+    m_workspaceTape->updateMoveGesture(delta);
+}
+
+void COverviewScene::endMoveGesture() {
+    m_workspaceTape->endMoveGesture();
+}
+
 void COverviewScene::resetQuery() const {
     m_workspaceSearch->resetQuery();
 }

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -102,8 +102,8 @@ bool COverviewScene::navigateLeft() {
     return m_workspaceTape->navigateLeft();
 }
 
-bool COverviewScene::navigateRight() {
-    return m_workspaceTape->navigateRight();
+eWorkspaceNavigationResult COverviewScene::navigateRight(bool allowCreate, bool willReceiveWindow) {
+    return m_workspaceTape->navigateRight(allowCreate && (!m_query || m_query->empty()), willReceiveWindow);
 }
 
 bool COverviewScene::selectWorkspace(PHLWORKSPACE workspace) {

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -191,8 +191,13 @@ void COverviewScene::endMoveGesture() {
     m_workspaceTape->endMoveGesture();
 }
 
-void COverviewScene::resetQuery() const {
-    m_workspaceSearch->resetQuery();
+void COverviewScene::setQuery(const std::string& query) {
+    m_workspaceSearch->setQuery(query);
+    updateQuery(query);
+}
+
+void COverviewScene::resetQuery() {
+    setQuery("");
 }
 
 std::string COverviewScene::currentQuery() const {

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -19,13 +19,13 @@ COverviewScene::COverviewScene(COverview& parent) : m_parent(parent), m_workspac
 
 COverviewScene::~COverviewScene() = default;
 
-void COverviewScene::draw(Time::steady_tp tp) {
+void COverviewScene::draw(Render::CRenderingContext& context, Time::steady_tp tp) {
     const auto MONITOR = m_parent.m_monitor.lock();
     if (!MONITOR || !m_parent.m_progress || !g_pHyprRenderer)
         return;
 
-    g_pHyprRenderer->addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
-    m_workspaceTape->draw(tp, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
+    m_workspaceTape->draw(context, tp, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
 }
 
 void COverviewScene::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -1,7 +1,14 @@
 #include "OverviewScene.hpp"
 
 #include "WorkspaceTapeController.hpp"
+#include "WorkspaceSearch.hpp"
+#include "WorkspaceSearchController.hpp"
 #include "../Overview.hpp"
+#include "../../../desktop/Workspace.hpp"
+#include "../../../desktop/DesktopTypes.hpp"
+#include "../../../desktop/state/WindowState.hpp"
+#include "../../../desktop/view/window/Window.hpp"
+#include "../../../desktop/view/window/WindowMetadata.hpp"
 #include "../../../output/Monitor.hpp"
 #include "../../../output/MonitorResources.hpp"
 #include "../../../config/ConfigValue.hpp"
@@ -17,7 +24,8 @@ static constexpr float  OVERVIEW_GRAY                = 0.16F;
 static constexpr float  BACKGROUND_DIM               = 0.18F;
 static constexpr size_t BACKGROUND_BLUR_WORK_BUFFERS = 2;
 
-COverviewScene::COverviewScene(COverview& parent) : m_parent(parent), m_workspaceTape(makeUnique<CWorkspaceTapeController>()) {
+COverviewScene::COverviewScene(COverview& parent) :
+    m_parent(parent), m_workspaceTape(makeUnique<CWorkspaceTapeController>()), m_workspaceSearch(makeUnique<CWorkspaceSearchController>()) {
     ;
 }
 
@@ -41,10 +49,45 @@ void COverviewScene::draw(Render::CRenderingContext& context, Time::steady_tp tp
     g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(backgroundEffect));
 
     m_workspaceTape->draw(context, tp, std::clamp(m_parent.m_progress->value(), 0.F, 1.F), *PXPMODE ? 0 : BACKGROUND_BLUR_WORK_BUFFERS);
+    m_workspaceSearch->draw(context, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
+}
+
+static uint8_t foldASCII(uint8_t character) {
+    if (character >= 'A' && character <= 'Z')
+        return character + ('a' - 'A');
+    return character;
+}
+
+bool Overview::Hyprland::matchesName(std::string_view name, std::string_view query) {
+    if (query.empty())
+        return true;
+
+    return std::ranges::search(name, query, [](char lhs, char rhs) { return foldASCII(sc<unsigned char>(lhs)) == foldASCII(sc<unsigned char>(rhs)); }).begin() != name.end();
+}
+
+static bool workspaceFilter(PHLWORKSPACE ws, const std::string& query) {
+    if (!ws)
+        return false;
+
+    if (matchesName(ws->m_name, query))
+        return true;
+
+    // check windows, we can match by title or class.
+    for (const auto& w : Desktop::windowState()->windows()) {
+        if (w->m_workspace != ws)
+            continue;
+
+        if (matchesName(w->metadata().appID(), query) || matchesName(w->metadata().title(), query))
+            return true;
+    }
+
+    return false;
 }
 
 void COverviewScene::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {
+    m_workspaceTape->setFilter([](PHLWORKSPACE) { return true; });
     m_workspaceTape->start(monitor, resources);
+    m_workspaceSearch->start(monitor, [this](const std::string& query) { m_workspaceTape->setFilter([query](PHLWORKSPACE w) { return ::workspaceFilter(w, query); }); });
 }
 
 bool COverviewScene::navigateLeft() {
@@ -59,6 +102,27 @@ PHLWORKSPACE COverviewScene::selectedWorkspace() const {
     return m_workspaceTape->selectedWorkspace();
 }
 
+bool COverviewScene::pointerMove(const Vector2D& monitorLocal) {
+    return m_workspaceSearch->pointerMove(monitorLocal);
+}
+
+bool COverviewScene::pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal) {
+    return m_workspaceSearch->pointerButton(button, pressed, monitorLocal);
+}
+
+void COverviewScene::pointerLeave() {
+    m_workspaceSearch->pointerLeave();
+}
+
+void COverviewScene::keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers) {
+    m_workspaceSearch->keyboardKey(keysym, down, repeat, std::move(utf8), modifiers);
+}
+
 void COverviewScene::reset() {
+    m_workspaceSearch->reset();
     m_workspaceTape->reset();
+}
+
+void COverviewScene::setTextboxFocus(bool x) {
+    m_workspaceSearch->setFocused(x);
 }

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -4,6 +4,7 @@
 #include "WorkspaceSearch.hpp"
 #include "WorkspaceSearchController.hpp"
 #include "../Overview.hpp"
+#include "../StringUtils.hpp"
 #include "../../../desktop/Workspace.hpp"
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../desktop/state/WindowState.hpp"
@@ -52,24 +53,11 @@ void COverviewScene::draw(Render::CRenderingContext& context, Time::steady_tp tp
     m_workspaceSearch->draw(context, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
 }
 
-static uint8_t foldASCII(uint8_t character) {
-    if (character >= 'A' && character <= 'Z')
-        return character + ('a' - 'A');
-    return character;
-}
-
-bool Overview::Hyprland::matchesName(std::string_view name, std::string_view query) {
-    if (query.empty())
-        return true;
-
-    return std::ranges::search(name, query, [](char lhs, char rhs) { return foldASCII(sc<unsigned char>(lhs)) == foldASCII(sc<unsigned char>(rhs)); }).begin() != name.end();
-}
-
 static bool workspaceFilter(PHLWORKSPACE ws, const std::string& query) {
     if (!ws)
         return false;
 
-    if (matchesName(ws->m_name, query))
+    if (StringUtils::matchesName(ws->m_name, query))
         return true;
 
     // check windows, we can match by title or class.
@@ -77,7 +65,7 @@ static bool workspaceFilter(PHLWORKSPACE ws, const std::string& query) {
         if (w->m_workspace != ws)
             continue;
 
-        if (matchesName(w->metadata().appID(), query) || matchesName(w->metadata().title(), query))
+        if (StringUtils::matchesName(w->metadata().appID(), query) || StringUtils::matchesName(w->metadata().title(), query))
             return true;
     }
 

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -4,14 +4,18 @@
 #include "../Overview.hpp"
 #include "../../../output/Monitor.hpp"
 #include "../../../output/MonitorResources.hpp"
+#include "../../../config/ConfigValue.hpp"
 #include "../../../render/Renderer.hpp"
 #include "../../../render/pass/ClearPassElement.hpp"
+#include "../../../render/pass/RectPassElement.hpp"
 
 #include <algorithm>
 
 using namespace Overview::Hyprland;
 
-static constexpr float OVERVIEW_GRAY = 0.16F;
+static constexpr float  OVERVIEW_GRAY                = 0.16F;
+static constexpr float  BACKGROUND_DIM               = 0.18F;
+static constexpr size_t BACKGROUND_BLUR_WORK_BUFFERS = 2;
 
 COverviewScene::COverviewScene(COverview& parent) : m_parent(parent), m_workspaceTape(makeUnique<CWorkspaceTapeController>()) {
     ;
@@ -25,7 +29,18 @@ void COverviewScene::draw(Render::CRenderingContext& context, Time::steady_tp tp
         return;
 
     g_pHyprRenderer->addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(OVERVIEW_GRAY, OVERVIEW_GRAY, OVERVIEW_GRAY, 1.F)}));
-    m_workspaceTape->draw(context, tp, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
+
+    static auto PXPMODE = CConfigValue<Config::INTEGER>("render:xp_mode");
+    if (!*PXPMODE)
+        g_pHyprRenderer->renderMonitorBackground(context, MONITOR, tp);
+
+    CRectPassElement::SRectData backgroundEffect;
+    backgroundEffect.box   = {{}, MONITOR->m_transformedSize};
+    backgroundEffect.color = CHyprColor(0.F, 0.F, 0.F, BACKGROUND_DIM);
+    backgroundEffect.blur  = !*PXPMODE;
+    g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(backgroundEffect));
+
+    m_workspaceTape->draw(context, tp, std::clamp(m_parent.m_progress->value(), 0.F, 1.F), *PXPMODE ? 0 : BACKGROUND_BLUR_WORK_BUFFERS);
 }
 
 void COverviewScene::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -85,8 +85,9 @@ static bool workspaceFilter(PHLWORKSPACE ws, const std::string& query) {
 }
 
 void COverviewScene::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {
+    m_layout = monitor ? OverviewLayout::calculate(monitor->m_size, monitor->m_scale) : OverviewLayout::SLayout{};
     m_workspaceTape->setFilter([](PHLWORKSPACE) { return true; });
-    m_workspaceTape->start(monitor, resources);
+    m_workspaceTape->start(monitor, resources, m_layout);
     m_workspaceSearch->start(monitor, [this](const std::string& query) { m_workspaceTape->setFilter([query](PHLWORKSPACE w) { return ::workspaceFilter(w, query); }); });
 }
 
@@ -98,8 +99,20 @@ bool COverviewScene::navigateRight() {
     return m_workspaceTape->navigateRight();
 }
 
+bool COverviewScene::selectWorkspace(PHLWORKSPACE workspace) {
+    return m_workspaceTape->selectWorkspace(workspace);
+}
+
 PHLWORKSPACE COverviewScene::selectedWorkspace() const {
     return m_workspaceTape->selectedWorkspace();
+}
+
+PHLWORKSPACE COverviewScene::miniWorkspaceAt(const Vector2D& monitorLocal) const {
+    return m_workspaceTape->miniWorkspaceAt(monitorLocal);
+}
+
+CBox COverviewScene::mainArea() const {
+    return m_layout.logicalMain;
 }
 
 bool COverviewScene::pointerMove(const Vector2D& monitorLocal) {
@@ -107,7 +120,27 @@ bool COverviewScene::pointerMove(const Vector2D& monitorLocal) {
 }
 
 bool COverviewScene::pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal) {
-    return m_workspaceSearch->pointerButton(button, pressed, monitorLocal);
+    if (!pressed) {
+        const auto TARGET = m_pointerTargets.find(button);
+        if (TARGET == m_pointerTargets.end())
+            return false;
+
+        const bool HANDLED =
+            TARGET->second == ePointerTarget::SEARCH ? m_workspaceSearch->pointerButton(button, false, monitorLocal) : m_workspaceTape->pointerButton(button, false, monitorLocal);
+        m_pointerTargets.erase(TARGET);
+        return HANDLED;
+    }
+
+    if (m_workspaceSearch->pointerButton(button, true, monitorLocal)) {
+        m_pointerTargets.insert_or_assign(button, ePointerTarget::SEARCH);
+        return true;
+    }
+
+    if (!m_workspaceTape->pointerButton(button, true, monitorLocal))
+        return false;
+
+    m_pointerTargets.insert_or_assign(button, ePointerTarget::WORKSPACE_TAPE);
+    return true;
 }
 
 void COverviewScene::pointerLeave() {
@@ -121,6 +154,8 @@ void COverviewScene::keyboardKey(uint32_t keysym, bool down, bool repeat, std::s
 void COverviewScene::reset() {
     m_workspaceSearch->reset();
     m_workspaceTape->reset();
+    m_layout = {};
+    m_pointerTargets.clear();
 }
 
 void COverviewScene::setTextboxFocus(bool x) {

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -4,7 +4,7 @@
 #include "WorkspaceSearch.hpp"
 #include "WorkspaceSearchController.hpp"
 #include "../Overview.hpp"
-#include "../StringUtils.hpp"
+#include "../Query.hpp"
 #include "../../../desktop/Workspace.hpp"
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../desktop/state/WindowState.hpp"
@@ -13,6 +13,7 @@
 #include "../../../output/Monitor.hpp"
 #include "../../../output/MonitorResources.hpp"
 #include "../../../config/ConfigValue.hpp"
+#include "../../../event/EventBus.hpp"
 #include "../../../render/Renderer.hpp"
 #include "../../../render/pass/ClearPassElement.hpp"
 #include "../../../render/pass/RectPassElement.hpp"
@@ -53,30 +54,48 @@ void COverviewScene::draw(Render::CRenderingContext& context, Time::steady_tp tp
     m_workspaceSearch->draw(context, std::clamp(m_parent.m_progress->value(), 0.F, 1.F));
 }
 
-static bool workspaceFilter(PHLWORKSPACE ws, const std::string& query) {
+static Mode::eWorkspaceMatch workspaceFilter(PHLWORKSPACE ws, const CQuery& query) {
     if (!ws)
-        return false;
+        return Mode::eWorkspaceMatch::NONE;
 
-    if (StringUtils::matchesName(ws->m_name, query))
-        return true;
+    const auto WORKSPACE_MATCH = query.matchWorkspace(ws->m_name, [ws](std::string_view selector) { return ws->matchesStaticSelector(std::string{selector}); });
+    if (WORKSPACE_MATCH != Mode::eWorkspaceMatch::NONE)
+        return WORKSPACE_MATCH;
 
-    // check windows, we can match by title or class.
     for (const auto& w : Desktop::windowState()->windows()) {
         if (w->m_workspace != ws)
             continue;
 
-        if (StringUtils::matchesName(w->metadata().appID(), query) || StringUtils::matchesName(w->metadata().title(), query))
-            return true;
+        if (query.matchesWindow(w->metadata().appID(), w->metadata().title()))
+            return Mode::eWorkspaceMatch::MATCH;
     }
 
-    return false;
+    return Mode::eWorkspaceMatch::NONE;
+}
+
+static char queryPrefix(const std::string& value, char fallback) {
+    return value.size() == 1 ? value.front() : fallback;
 }
 
 void COverviewScene::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {
     m_layout = monitor ? OverviewLayout::calculate(monitor->m_size, monitor->m_scale) : OverviewLayout::SLayout{};
-    m_workspaceTape->setFilter([](PHLWORKSPACE) { return true; });
+    updateQuery("");
     m_workspaceTape->start(monitor, resources, m_layout);
-    m_workspaceSearch->start(monitor, [this](const std::string& query) { m_workspaceTape->setFilter([query](PHLWORKSPACE w) { return ::workspaceFilter(w, query); }); });
+    m_workspaceSearch->start(monitor, [this](const std::string& query) { updateQuery(query); });
+    m_configListener = Event::bus()->m_events.config.props_refreshed.listen([this](bool) { updateQuery(currentQuery()); });
+}
+
+void COverviewScene::updateQuery(const std::string& raw) {
+    static auto PWINDOWPREFIX    = CConfigValue<Config::STRING>("overview:search:window_prefix");
+    static auto PWORKSPACEPREFIX = CConfigValue<Config::STRING>("overview:search:workspace_prefix");
+    static auto PDEFAULTMODE     = CConfigValue<Config::INTEGER>("overview:search:default_mode");
+
+    const auto  WINDOW_PREFIX    = *PWINDOWPREFIX;
+    const auto  WORKSPACE_PREFIX = *PWORKSPACEPREFIX;
+
+    m_query = makeUnique<CQuery>(
+        raw, SQueryConfig{.windowPrefix = queryPrefix(WINDOW_PREFIX, '/'), .workspacePrefix = queryPrefix(WORKSPACE_PREFIX, '.'), .defaultMode = sc<eQueryMode>(*PDEFAULTMODE)});
+    m_workspaceTape->setFilter([this](PHLWORKSPACE workspace) { return ::workspaceFilter(workspace, *m_query); }, m_query->usesWindowMetadata());
 }
 
 bool COverviewScene::navigateLeft() {
@@ -144,8 +163,10 @@ void COverviewScene::keyboardKey(uint32_t keysym, bool down, bool repeat, std::s
 }
 
 void COverviewScene::reset() {
+    m_configListener = {};
     m_workspaceSearch->reset();
     m_workspaceTape->reset();
+    m_query.reset();
     m_layout = {};
     m_pointerTargets.clear();
 }
@@ -176,4 +197,8 @@ void COverviewScene::resetQuery() const {
 
 std::string COverviewScene::currentQuery() const {
     return m_workspaceSearch->query();
+}
+
+const CQuery* COverviewScene::query() const {
+    return m_query.get();
 }

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -166,6 +166,10 @@ void COverviewScene::setTextboxFocus(bool x) {
     m_workspaceSearch->setFocused(x);
 }
 
+void COverviewScene::resetQuery() const {
+    m_workspaceSearch->resetQuery();
+}
+
 std::string COverviewScene::currentQuery() const {
     return m_workspaceSearch->query();
 }

--- a/src/overview/hyprland/scene/OverviewScene.cpp
+++ b/src/overview/hyprland/scene/OverviewScene.cpp
@@ -154,6 +154,10 @@ void COverviewScene::setTextboxFocus(bool x) {
     m_workspaceSearch->setFocused(x);
 }
 
+void COverviewScene::useSelectedWorkspaceForFullscreen(bool x) {
+    m_workspaceTape->useSelectedWorkspaceForFullscreen(x);
+}
+
 void COverviewScene::resetQuery() const {
     m_workspaceSearch->resetQuery();
 }

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -41,6 +41,7 @@ namespace Overview::Hyprland {
         void         keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
         void         reset();
         void         setTextboxFocus(bool x);
+        void         resetQuery() const;
         std::string  currentQuery() const;
 
       private:

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -4,8 +4,10 @@
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../helpers/memory/Memory.hpp"
 #include "../../../helpers/math/Math.hpp"
+#include "OverviewLayout.hpp"
 
 #include <string>
+#include <unordered_map>
 
 namespace Monitor {
     class CMonitorResources;
@@ -27,7 +29,10 @@ namespace Overview::Hyprland {
         void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
         bool         navigateLeft();
         bool         navigateRight();
+        bool         selectWorkspace(PHLWORKSPACE workspace);
         PHLWORKSPACE selectedWorkspace() const;
+        PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
+        CBox         mainArea() const;
         bool         pointerMove(const Vector2D& monitorLocal);
         bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
         void         pointerLeave();
@@ -36,8 +41,15 @@ namespace Overview::Hyprland {
         void         setTextboxFocus(bool x);
 
       private:
-        COverview&                     m_parent;
-        UP<CWorkspaceTapeController>   m_workspaceTape;
-        UP<CWorkspaceSearchController> m_workspaceSearch;
+        enum class ePointerTarget : uint8_t {
+            SEARCH,
+            WORKSPACE_TAPE,
+        };
+
+        COverview&                                   m_parent;
+        UP<CWorkspaceTapeController>                 m_workspaceTape;
+        UP<CWorkspaceSearchController>               m_workspaceSearch;
+        OverviewLayout::SLayout                      m_layout;
+        std::unordered_map<uint32_t, ePointerTarget> m_pointerTargets;
     };
 }

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../../../render/scene/Scene.hpp"
+#include "../../../helpers/memory/Memory.hpp"
+
+namespace Render {
+    class IFramebuffer;
+}
+
+namespace Overview::Hyprland {
+    class COverview;
+
+    class COverviewScene : public Render::IScene {
+      public:
+        COverviewScene(COverview& parent);
+        virtual ~COverviewScene() override = default;
+
+        virtual void draw(Time::steady_tp tp) override;
+        void         reset();
+
+      private:
+        COverview&               m_parent;
+        SP<Render::IFramebuffer> m_framebuffer;
+    };
+}

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -17,12 +17,12 @@ namespace Overview::Hyprland {
         COverviewScene(COverview& parent);
         virtual ~COverviewScene() override;
 
-        virtual void                        draw(Time::steady_tp tp) override;
-        void                                start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
-        bool                                navigateLeft();
-        bool                                navigateRight();
-        PHLWORKSPACE                        selectedWorkspace() const;
-        void                                reset();
+        virtual void draw(Render::CRenderingContext&, Time::steady_tp tp) override;
+        void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
+        bool         navigateLeft();
+        bool         navigateRight();
+        PHLWORKSPACE selectedWorkspace() const;
+        void         reset();
 
       private:
         COverview&                   m_parent;

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -6,8 +6,10 @@
 #include "../../../helpers/math/Math.hpp"
 #include "../../../helpers/signal/Signal.hpp"
 #include "OverviewLayout.hpp"
+#include "WorkspaceNavigation.hpp"
 
 #include <string>
+#include <cstdint>
 #include <unordered_map>
 
 namespace Monitor {
@@ -25,29 +27,29 @@ namespace Overview::Hyprland {
         COverviewScene(COverview& parent);
         virtual ~COverviewScene() override;
 
-        virtual void  draw(Render::CRenderingContext&, Time::steady_tp tp) override;
+        virtual void               draw(Render::CRenderingContext&, Time::steady_tp tp) override;
 
-        void          start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
-        bool          navigateLeft();
-        bool          navigateRight();
-        bool          selectWorkspace(PHLWORKSPACE workspace);
-        PHLWORKSPACE  selectedWorkspace() const;
-        Vector2D      transformPointer(const Vector2D& global) const;
-        PHLWORKSPACE  miniWorkspaceAt(const Vector2D& monitorLocal) const;
-        CBox          mainArea() const;
-        bool          pointerMove(const Vector2D& monitorLocal);
-        bool          pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
-        void          pointerLeave();
-        void          keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
-        void          reset();
-        void          setTextboxFocus(bool x);
-        void          useSelectedWorkspaceForFullscreen(bool x);
-        bool          beginMoveGesture();
-        void          updateMoveGesture(float delta);
-        void          endMoveGesture();
-        void          resetQuery() const;
-        std::string   currentQuery() const;
-        const CQuery* query() const;
+        void                       start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
+        bool                       navigateLeft();
+        eWorkspaceNavigationResult navigateRight(bool allowCreate = true, bool willReceiveWindow = false);
+        bool                       selectWorkspace(PHLWORKSPACE workspace);
+        PHLWORKSPACE               selectedWorkspace() const;
+        Vector2D                   transformPointer(const Vector2D& global) const;
+        PHLWORKSPACE               miniWorkspaceAt(const Vector2D& monitorLocal) const;
+        CBox                       mainArea() const;
+        bool                       pointerMove(const Vector2D& monitorLocal);
+        bool                       pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
+        void                       pointerLeave();
+        void                       keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
+        void                       reset();
+        void                       setTextboxFocus(bool x);
+        void                       useSelectedWorkspaceForFullscreen(bool x);
+        bool                       beginMoveGesture();
+        void                       updateMoveGesture(float delta);
+        void                       endMoveGesture();
+        void                       resetQuery() const;
+        std::string                currentQuery() const;
+        const CQuery*              query() const;
 
       private:
         enum class ePointerTarget : uint8_t {

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -47,7 +47,8 @@ namespace Overview::Hyprland {
         bool                       beginMoveGesture();
         void                       updateMoveGesture(float delta);
         void                       endMoveGesture();
-        void                       resetQuery() const;
+        void                       setQuery(const std::string& query);
+        void                       resetQuery();
         std::string                currentQuery() const;
         const CQuery*              query() const;
 

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -42,6 +42,9 @@ namespace Overview::Hyprland {
         void         reset();
         void         setTextboxFocus(bool x);
         void         useSelectedWorkspaceForFullscreen(bool x);
+        bool         beginMoveGesture();
+        void         updateMoveGesture(float delta);
+        void         endMoveGesture();
         void         resetQuery() const;
         std::string  currentQuery() const;
 

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -1,25 +1,31 @@
 #pragma once
 
 #include "../../../render/scene/Scene.hpp"
+#include "../../../desktop/DesktopTypes.hpp"
 #include "../../../helpers/memory/Memory.hpp"
 
-namespace Render {
-    class IFramebuffer;
+namespace Monitor {
+    class CMonitorResources;
 }
 
 namespace Overview::Hyprland {
     class COverview;
+    class CWorkspaceTapeController;
 
     class COverviewScene : public Render::IScene {
       public:
         COverviewScene(COverview& parent);
-        virtual ~COverviewScene() override = default;
+        virtual ~COverviewScene() override;
 
-        virtual void draw(Time::steady_tp tp) override;
-        void         reset();
+        virtual void                        draw(Time::steady_tp tp) override;
+        void                                start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
+        bool                                navigateLeft();
+        bool                                navigateRight();
+        PHLWORKSPACE                        selectedWorkspace() const;
+        void                                reset();
 
       private:
-        COverview&               m_parent;
-        SP<Render::IFramebuffer> m_framebuffer;
+        COverview&                   m_parent;
+        UP<CWorkspaceTapeController> m_workspaceTape;
     };
 }

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -31,6 +31,7 @@ namespace Overview::Hyprland {
         bool         navigateRight();
         bool         selectWorkspace(PHLWORKSPACE workspace);
         PHLWORKSPACE selectedWorkspace() const;
+        Vector2D     transformPointer(const Vector2D& global) const;
         PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
         CBox         mainArea() const;
         bool         pointerMove(const Vector2D& monitorLocal);

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -3,6 +3,9 @@
 #include "../../../render/scene/Scene.hpp"
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../helpers/memory/Memory.hpp"
+#include "../../../helpers/math/Math.hpp"
+
+#include <string>
 
 namespace Monitor {
     class CMonitorResources;
@@ -10,7 +13,10 @@ namespace Monitor {
 
 namespace Overview::Hyprland {
     class COverview;
+    class CWorkspaceSearchController;
     class CWorkspaceTapeController;
+
+    bool matchesName(std::string_view a, std::string_view b);
 
     class COverviewScene : public Render::IScene {
       public:
@@ -22,10 +28,16 @@ namespace Overview::Hyprland {
         bool         navigateLeft();
         bool         navigateRight();
         PHLWORKSPACE selectedWorkspace() const;
+        bool         pointerMove(const Vector2D& monitorLocal);
+        bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
+        void         pointerLeave();
+        void         keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
         void         reset();
+        void         setTextboxFocus(bool x);
 
       private:
-        COverview&                   m_parent;
-        UP<CWorkspaceTapeController> m_workspaceTape;
+        COverview&                     m_parent;
+        UP<CWorkspaceTapeController>   m_workspaceTape;
+        UP<CWorkspaceSearchController> m_workspaceSearch;
     };
 }

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -41,6 +41,7 @@ namespace Overview::Hyprland {
         void         keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
         void         reset();
         void         setTextboxFocus(bool x);
+        void         useSelectedWorkspaceForFullscreen(bool x);
         void         resetQuery() const;
         std::string  currentQuery() const;
 

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -4,6 +4,7 @@
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../helpers/memory/Memory.hpp"
 #include "../../../helpers/math/Math.hpp"
+#include "../../../helpers/signal/Signal.hpp"
 #include "OverviewLayout.hpp"
 
 #include <string>
@@ -15,38 +16,38 @@ namespace Monitor {
 
 namespace Overview::Hyprland {
     class COverview;
+    class CQuery;
     class CWorkspaceSearchController;
     class CWorkspaceTapeController;
-
-    bool matchesName(std::string_view a, std::string_view b);
 
     class COverviewScene : public Render::IScene {
       public:
         COverviewScene(COverview& parent);
         virtual ~COverviewScene() override;
 
-        virtual void draw(Render::CRenderingContext&, Time::steady_tp tp) override;
+        virtual void  draw(Render::CRenderingContext&, Time::steady_tp tp) override;
 
-        void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
-        bool         navigateLeft();
-        bool         navigateRight();
-        bool         selectWorkspace(PHLWORKSPACE workspace);
-        PHLWORKSPACE selectedWorkspace() const;
-        Vector2D     transformPointer(const Vector2D& global) const;
-        PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
-        CBox         mainArea() const;
-        bool         pointerMove(const Vector2D& monitorLocal);
-        bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
-        void         pointerLeave();
-        void         keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
-        void         reset();
-        void         setTextboxFocus(bool x);
-        void         useSelectedWorkspaceForFullscreen(bool x);
-        bool         beginMoveGesture();
-        void         updateMoveGesture(float delta);
-        void         endMoveGesture();
-        void         resetQuery() const;
-        std::string  currentQuery() const;
+        void          start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
+        bool          navigateLeft();
+        bool          navigateRight();
+        bool          selectWorkspace(PHLWORKSPACE workspace);
+        PHLWORKSPACE  selectedWorkspace() const;
+        Vector2D      transformPointer(const Vector2D& global) const;
+        PHLWORKSPACE  miniWorkspaceAt(const Vector2D& monitorLocal) const;
+        CBox          mainArea() const;
+        bool          pointerMove(const Vector2D& monitorLocal);
+        bool          pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
+        void          pointerLeave();
+        void          keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
+        void          reset();
+        void          setTextboxFocus(bool x);
+        void          useSelectedWorkspaceForFullscreen(bool x);
+        bool          beginMoveGesture();
+        void          updateMoveGesture(float delta);
+        void          endMoveGesture();
+        void          resetQuery() const;
+        std::string   currentQuery() const;
+        const CQuery* query() const;
 
       private:
         enum class ePointerTarget : uint8_t {
@@ -57,7 +58,11 @@ namespace Overview::Hyprland {
         COverview&                                   m_parent;
         UP<CWorkspaceTapeController>                 m_workspaceTape;
         UP<CWorkspaceSearchController>               m_workspaceSearch;
+        UP<CQuery>                                   m_query;
         OverviewLayout::SLayout                      m_layout;
         std::unordered_map<uint32_t, ePointerTarget> m_pointerTargets;
+        CHyprSignalListener                          m_configListener;
+
+        void                                         updateQuery(const std::string& raw);
     };
 }

--- a/src/overview/hyprland/scene/OverviewScene.hpp
+++ b/src/overview/hyprland/scene/OverviewScene.hpp
@@ -26,6 +26,7 @@ namespace Overview::Hyprland {
         virtual ~COverviewScene() override;
 
         virtual void draw(Render::CRenderingContext&, Time::steady_tp tp) override;
+
         void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
         bool         navigateLeft();
         bool         navigateRight();
@@ -40,6 +41,7 @@ namespace Overview::Hyprland {
         void         keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
         void         reset();
         void         setTextboxFocus(bool x);
+        std::string  currentQuery() const;
 
       private:
         enum class ePointerTarget : uint8_t {

--- a/src/overview/hyprland/scene/WorkspaceMiniStripLayout.cpp
+++ b/src/overview/hyprland/scene/WorkspaceMiniStripLayout.cpp
@@ -1,0 +1,52 @@
+#include "WorkspaceMiniStripLayout.hpp"
+
+#include <algorithm>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+using Hyprutils::Math::Vector2D;
+
+static Vector2D fittedTileSize(const CBox& bounds, const Vector2D& sourceSize) {
+    if (sourceSize.x <= 0.F || sourceSize.y <= 0.F)
+        return bounds.size();
+
+    return sourceSize * (bounds.h / sourceSize.y);
+}
+
+std::vector<CBox> WorkspaceMiniStripLayout::calculate(const CBox& bounds, std::span<const Vector2D> sourceSizes, size_t selectedIndex, float gapScale) {
+    if (bounds.empty() || sourceSizes.empty())
+        return {};
+
+    const double      GAP      = bounds.h * std::max(0.F, gapScale);
+    const size_t      SELECTED = std::min(selectedIndex, sourceSizes.size() - 1);
+
+    std::vector<CBox> boxes;
+    boxes.reserve(sourceSizes.size());
+
+    double contentWidth = 0.F;
+    for (const auto& sourceSize : sourceSizes) {
+        const auto SIZE = fittedTileSize(bounds, sourceSize);
+        boxes.emplace_back(Vector2D{}, SIZE);
+        contentWidth += SIZE.x;
+    }
+    contentWidth += GAP * (boxes.size() - 1);
+
+    double x = bounds.x + (bounds.w - contentWidth) / 2.F;
+    if (contentWidth > bounds.w) {
+        double selectedCenter = 0.F;
+        for (size_t i = 0; i < SELECTED; ++i)
+            selectedCenter += boxes.at(i).w + GAP;
+        selectedCenter += boxes.at(SELECTED).w / 2.F;
+
+        x = bounds.x + bounds.w / 2.F - selectedCenter;
+        x = std::clamp(x, bounds.x + bounds.w - contentWidth, bounds.x);
+    }
+
+    for (auto& box : boxes) {
+        box.x = x;
+        box.y = bounds.y + (bounds.h - box.h) / 2.F;
+        x += box.w + GAP;
+    }
+
+    return boxes;
+}

--- a/src/overview/hyprland/scene/WorkspaceMiniStripLayout.hpp
+++ b/src/overview/hyprland/scene/WorkspaceMiniStripLayout.hpp
@@ -7,6 +7,6 @@
 #include <hyprutils/math/Box.hpp>
 #include <hyprutils/math/Vector2D.hpp>
 
-namespace Overview::Hyprland::WorkspaceTapeLayout {
+namespace Overview::Hyprland::WorkspaceMiniStripLayout {
     std::vector<Hyprutils::Math::CBox> calculate(const Hyprutils::Math::CBox& bounds, std::span<const Hyprutils::Math::Vector2D> sourceSizes, size_t selectedIndex, float gapScale);
 }

--- a/src/overview/hyprland/scene/WorkspaceNavigation.hpp
+++ b/src/overview/hyprland/scene/WorkspaceNavigation.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Overview::Hyprland {
+    enum class eWorkspaceNavigationResult : uint8_t {
+        NONE,
+        EXISTING,
+        CREATED,
+    };
+}

--- a/src/overview/hyprland/scene/WorkspacePointerMapping.cpp
+++ b/src/overview/hyprland/scene/WorkspacePointerMapping.cpp
@@ -1,0 +1,21 @@
+#include "WorkspacePointerMapping.hpp"
+
+#include <cmath>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+using Hyprutils::Math::Vector2D;
+
+std::optional<Vector2D> WorkspacePointerMapping::mapClamped(const Vector2D& point, const CBox& tileBox, const CBox& sourceBox) {
+    if (tileBox.empty() || sourceBox.empty() || !std::isfinite(point.x) || !std::isfinite(point.y))
+        return std::nullopt;
+
+    const Vector2D NORMALIZED = Vector2D{(point.x - tileBox.x) / tileBox.w, (point.y - tileBox.y) / tileBox.h}.clamp({}, {1, 1});
+    const Vector2D SOURCE_MAX = {std::nextafter(sourceBox.x + sourceBox.w, sourceBox.x), std::nextafter(sourceBox.y + sourceBox.h, sourceBox.y)};
+    const Vector2D MAPPED     = (sourceBox.pos() + NORMALIZED * sourceBox.size()).clamp(sourceBox.pos(), SOURCE_MAX);
+
+    if (!std::isfinite(MAPPED.x) || !std::isfinite(MAPPED.y))
+        return std::nullopt;
+
+    return MAPPED;
+}

--- a/src/overview/hyprland/scene/WorkspacePointerMapping.hpp
+++ b/src/overview/hyprland/scene/WorkspacePointerMapping.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <optional>
+
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+
+namespace Overview::Hyprland::WorkspacePointerMapping {
+    std::optional<Hyprutils::Math::Vector2D> mapClamped(const Hyprutils::Math::Vector2D& point, const Hyprutils::Math::CBox& tileBox, const Hyprutils::Math::CBox& sourceBox);
+}

--- a/src/overview/hyprland/scene/WorkspaceSearch.cpp
+++ b/src/overview/hyprland/scene/WorkspaceSearch.cpp
@@ -1,0 +1,30 @@
+#include "WorkspaceSearch.hpp"
+
+#include "WorkspaceTapeController.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <ranges>
+
+using namespace Overview::Hyprland;
+using namespace Hyprutils::Memory;
+
+WorkspaceSearch::SGeometry WorkspaceSearch::calculateGeometry(const Vector2D& logicalMonitorSize, float scale) {
+    if (logicalMonitorSize.x <= 0 || logicalMonitorSize.y <= 0 || scale <= 0)
+        return {};
+
+    const auto HEIGHT_ABOVE  = (logicalMonitorSize.y * (1.F - CWorkspaceTapeController::TILE_SCALE)) / 2.F;
+    const auto SEARCH_HEIGHT = HEIGHT_ABOVE * 0.6F;
+    const auto SEARCH_WIDTH  = logicalMonitorSize.x * 0.2F;
+
+    const auto SEARCH_X = (logicalMonitorSize.x / 2.F) - (SEARCH_WIDTH / 2.F);
+    const auto SEARCH_Y = (HEIGHT_ABOVE / 2.F) - (SEARCH_HEIGHT / 2.F);
+
+    if (SEARCH_HEIGHT <= 0 || SEARCH_WIDTH <= 0)
+        return {};
+
+    const CBox LOGICAL_BOX = {{SEARCH_X, SEARCH_Y}, {SEARCH_WIDTH, SEARCH_HEIGHT}};
+    const CBox PIXEL_BOX   = LOGICAL_BOX.copy().scale(scale);
+
+    return {.logicalBox = LOGICAL_BOX, .pixelBox = PIXEL_BOX};
+}

--- a/src/overview/hyprland/scene/WorkspaceSearch.cpp
+++ b/src/overview/hyprland/scene/WorkspaceSearch.cpp
@@ -1,30 +1,16 @@
 #include "WorkspaceSearch.hpp"
 
-#include "WorkspaceTapeController.hpp"
-
-#include <algorithm>
-#include <cmath>
-#include <ranges>
+#include "OverviewLayout.hpp"
 
 using namespace Overview::Hyprland;
-using namespace Hyprutils::Memory;
 
 WorkspaceSearch::SGeometry WorkspaceSearch::calculateGeometry(const Vector2D& logicalMonitorSize, float scale) {
     if (logicalMonitorSize.x <= 0 || logicalMonitorSize.y <= 0 || scale <= 0)
         return {};
 
-    const auto HEIGHT_ABOVE  = (logicalMonitorSize.y * (1.F - CWorkspaceTapeController::TILE_SCALE)) / 2.F;
-    const auto SEARCH_HEIGHT = HEIGHT_ABOVE * 0.6F;
-    const auto SEARCH_WIDTH  = logicalMonitorSize.x * 0.2F;
-
-    const auto SEARCH_X = (logicalMonitorSize.x / 2.F) - (SEARCH_WIDTH / 2.F);
-    const auto SEARCH_Y = (HEIGHT_ABOVE / 2.F) - (SEARCH_HEIGHT / 2.F);
-
-    if (SEARCH_HEIGHT <= 0 || SEARCH_WIDTH <= 0)
+    const auto LAYOUT = OverviewLayout::calculate(logicalMonitorSize, scale);
+    if (LAYOUT.logicalSearch.empty() || LAYOUT.pixelSearch.empty())
         return {};
 
-    const CBox LOGICAL_BOX = {{SEARCH_X, SEARCH_Y}, {SEARCH_WIDTH, SEARCH_HEIGHT}};
-    const CBox PIXEL_BOX   = LOGICAL_BOX.copy().scale(scale);
-
-    return {.logicalBox = LOGICAL_BOX, .pixelBox = PIXEL_BOX};
+    return {.logicalBox = LAYOUT.logicalSearch, .pixelBox = LAYOUT.pixelSearch};
 }

--- a/src/overview/hyprland/scene/WorkspaceSearch.hpp
+++ b/src/overview/hyprland/scene/WorkspaceSearch.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../../../helpers/math/Math.hpp"
+
+namespace Overview::Hyprland::WorkspaceSearch {
+    struct SGeometry {
+        CBox logicalBox;
+        CBox pixelBox;
+    };
+
+    SGeometry calculateGeometry(const Vector2D& logicalMonitorSize, float scale);
+}

--- a/src/overview/hyprland/scene/WorkspaceSearchController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.cpp
@@ -230,3 +230,8 @@ void CWorkspaceSearchController::setFocused(bool x) {
         m_textbox->focus(x);
     }
 }
+
+void CWorkspaceSearchController::resetQuery() {
+    if (m_textbox)
+        m_textbox->setText("");
+}

--- a/src/overview/hyprland/scene/WorkspaceSearchController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.cpp
@@ -245,7 +245,7 @@ void CWorkspaceSearchController::setFocused(bool x) {
     }
 }
 
-void CWorkspaceSearchController::resetQuery() {
+void CWorkspaceSearchController::setQuery(const std::string& query) {
     if (m_textbox)
-        m_textbox->setText("");
+        m_textbox->setText(query);
 }

--- a/src/overview/hyprland/scene/WorkspaceSearchController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.cpp
@@ -80,6 +80,7 @@ void CWorkspaceSearchController::start(PHLMONITOR monitor, FTextChanged textChan
 
 void CWorkspaceSearchController::reset() {
     pointerLeave();
+    Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI);
     m_listeners = {};
     m_textbox.reset();
     m_surface.reset();
@@ -91,6 +92,7 @@ void CWorkspaceSearchController::reset() {
     m_pressedButtons = 0;
     m_needsFrame     = true;
     m_fullRedraw     = true;
+    m_focused        = false;
 }
 
 void CWorkspaceSearchController::draw(Render::CRenderingContext& context, float opacity) {
@@ -124,12 +126,15 @@ void CWorkspaceSearchController::draw(Render::CRenderingContext& context, float 
 }
 
 bool CWorkspaceSearchController::pointerMove(const Vector2D& monitorLocal) {
-    if (!m_surface || !contains(monitorLocal)) {
-        if (m_surface && m_pointerEntered && m_pressedButtons > 0) {
-            m_surface->pointerMotion(monitorLocal - m_logicalBox.pos());
-            return true;
-        }
+    if (!m_surface)
+        return false;
 
+    if (m_pointerEntered && m_pressedButtons > 0) {
+        m_surface->pointerMotion(monitorLocal - m_logicalBox.pos());
+        return true;
+    }
+
+    if (!m_focused || !contains(monitorLocal)) {
         pointerLeave();
         return false;
     }
@@ -161,13 +166,16 @@ bool CWorkspaceSearchController::pointerButton(uint32_t button, bool pressed, co
     else if (m_pressedButtons > 0)
         --m_pressedButtons;
 
-    if (!pressed && m_pressedButtons == 0 && !contains(monitorLocal))
+    if (!pressed && m_pressedButtons == 0 && (!m_focused || !contains(monitorLocal)))
         pointerLeave();
     return true;
 }
 
 void CWorkspaceSearchController::pointerLeave() {
-    if (m_surface && m_pointerEntered)
+    if (!m_pointerEntered)
+        return;
+
+    if (m_surface)
         m_surface->pointerLeave();
     Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI);
     m_pointerEntered = false;
@@ -225,9 +233,15 @@ void CWorkspaceSearchController::setFocused(bool x) {
 
     m_focused = x;
 
+    if (!x && m_pressedButtons == 0)
+        pointerLeave();
+
     if (m_textbox) {
         m_textbox->setOpacity(x ? 1.F : 0.F);
-        m_textbox->focus(x);
+        if (x)
+            m_textbox->focus();
+        else if (m_surface)
+            m_surface->keyboardLeave();
     }
 }
 

--- a/src/overview/hyprland/scene/WorkspaceSearchController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.cpp
@@ -1,0 +1,232 @@
+#include "WorkspaceSearchController.hpp"
+
+#include "WorkspaceSearch.hpp"
+#include "../../../hyprtoolkit/embedded/EmbeddedToolkitManager.hpp"
+#include "../../../output/Monitor.hpp"
+#include "../../../pointer/cursor/CursorShapeOverrideController.hpp"
+#include "../../../render/Framebuffer.hpp"
+#include "../../../render/Renderer.hpp"
+#include "../../../render/pass/TexPassElement.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include <hyprtoolkit/core/Input.hpp>
+#include <hyprtoolkit/element/Element.hpp>
+#include <hyprtoolkit/element/Textbox.hpp>
+#include <hyprtoolkit/types/SizeType.hpp>
+#include <hyprtoolkit/types/PointerShape.hpp>
+#include <hyprtoolkit/window/EmbeddedSurface.hpp>
+#include <linux/input-event-codes.h>
+
+using namespace Overview::Hyprland;
+
+static std::string cursorName(Hyprtoolkit::ePointerShape shape) {
+    switch (shape) {
+        case Hyprtoolkit::HT_POINTER_POINTER: return "pointer";
+        case Hyprtoolkit::HT_POINTER_TEXT: return "text";
+        case Hyprtoolkit::HT_POINTER_RESIZE_NS: return "ns-resize";
+        case Hyprtoolkit::HT_POINTER_RESIZE_EW: return "ew-resize";
+        case Hyprtoolkit::HT_POINTER_RESIZE_NESW: return "nesw-resize";
+        case Hyprtoolkit::HT_POINTER_RESIZE_NWSE: return "nwse-resize";
+        default: return "default";
+    }
+}
+
+CWorkspaceSearchController::CWorkspaceSearchController() = default;
+
+CWorkspaceSearchController::~CWorkspaceSearchController() {
+    reset();
+}
+
+void CWorkspaceSearchController::start(PHLMONITOR monitor, FTextChanged textChanged) {
+    reset();
+    if (!monitor || !EmbeddedToolkit::manager())
+        return;
+
+    m_monitor     = monitor;
+    m_textChanged = std::move(textChanged);
+    m_surface     = EmbeddedToolkit::manager()->createSurface();
+    if (!m_surface)
+        return;
+
+    m_textbox = Hyprtoolkit::CTextboxBuilder::begin()
+                    ->placeholder(std::string{"Search..."})
+                    ->defaultText(std::string{})
+                    ->multiline(false)
+                    ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, {1.F, 1.F}})
+                    ->onTextEdited([this](SP<Hyprtoolkit::CTextboxElement>, const std::string& text) {
+                        if (m_textChanged)
+                            m_textChanged(text);
+                    })
+                    ->commence();
+    m_textbox->setOpacity(0.F);
+    m_textbox->animateOpacity(Hyprtoolkit::AnimationPresets::Medium);
+    m_surface->rootElement()->addChild(m_textbox);
+
+    m_listeners.frameRequested = m_surface->m_events.frameRequested.listen([this] {
+        m_needsFrame = true;
+        damageMonitor();
+    });
+    m_listeners.damaged        = m_surface->m_events.damaged.listen([this](auto) {
+        m_needsFrame = true;
+        damageMonitor();
+    });
+    m_listeners.cursorChanged  = m_surface->m_events.cursorChanged.listen(
+        [](Hyprtoolkit::ePointerShape shape) { Pointer::Cursor::overrideController->setOverride(cursorName(shape), Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI); });
+
+    updateGeometry();
+}
+
+void CWorkspaceSearchController::reset() {
+    pointerLeave();
+    m_listeners = {};
+    m_textbox.reset();
+    m_surface.reset();
+    m_framebuffer.reset();
+    m_monitor.reset();
+    m_textChanged    = {};
+    m_logicalBox     = {};
+    m_pixelBox       = {};
+    m_pressedButtons = 0;
+    m_needsFrame     = true;
+    m_fullRedraw     = true;
+}
+
+void CWorkspaceSearchController::draw(Render::CRenderingContext& context, float opacity) {
+    const auto MONITOR = m_monitor.lock();
+    if (!MONITOR || !m_surface || !g_pHyprRenderer)
+        return;
+
+    updateGeometry();
+    if (m_pixelBox.empty())
+        return;
+
+    const Vector2D BUFFER_SIZE = m_pixelBox.size();
+    if (!m_framebuffer)
+        m_framebuffer = g_pHyprRenderer->createFB("overview-search");
+    if (!m_framebuffer || !m_framebuffer->alloc(std::lround(BUFFER_SIZE.x), std::lround(BUFFER_SIZE.y)))
+        return;
+
+    if (m_needsFrame) {
+        auto guard   = g_pHyprRenderer->bindTempFB(context, m_framebuffer);
+        m_needsFrame = false;
+        m_surface->render(m_fullRedraw ? 0 : 1);
+        m_fullRedraw = false;
+    }
+
+    CTexPassElement::SRenderData data;
+    data.tex     = m_framebuffer->getTexture();
+    data.box     = m_pixelBox;
+    data.a       = std::clamp(opacity, 0.F, 1.F);
+    data.clipBox = {{}, MONITOR->m_transformedSize};
+    g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
+}
+
+bool CWorkspaceSearchController::pointerMove(const Vector2D& monitorLocal) {
+    if (!m_surface || !contains(monitorLocal)) {
+        if (m_surface && m_pointerEntered && m_pressedButtons > 0) {
+            m_surface->pointerMotion(monitorLocal - m_logicalBox.pos());
+            return true;
+        }
+
+        pointerLeave();
+        return false;
+    }
+
+    const auto LOCAL = monitorLocal - m_logicalBox.pos();
+    if (!m_pointerEntered) {
+        m_surface->pointerEnter(LOCAL);
+        m_pointerEntered = true;
+    } else
+        m_surface->pointerMotion(LOCAL);
+    return true;
+}
+
+bool CWorkspaceSearchController::pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal) {
+    if (!m_surface || (pressed && !m_pointerEntered && !pointerMove(monitorLocal)))
+        return false;
+
+    Hyprtoolkit::Input::eMouseButton toolkitButton = Hyprtoolkit::Input::MOUSE_BUTTON_UNKNOWN;
+    if (button == BTN_LEFT)
+        toolkitButton = Hyprtoolkit::Input::MOUSE_BUTTON_LEFT;
+    else if (button == BTN_RIGHT)
+        toolkitButton = Hyprtoolkit::Input::MOUSE_BUTTON_RIGHT;
+    else if (button == BTN_MIDDLE)
+        toolkitButton = Hyprtoolkit::Input::MOUSE_BUTTON_MIDDLE;
+
+    m_surface->pointerButton(toolkitButton, pressed);
+    if (pressed)
+        ++m_pressedButtons;
+    else if (m_pressedButtons > 0)
+        --m_pressedButtons;
+
+    if (!pressed && m_pressedButtons == 0 && !contains(monitorLocal))
+        pointerLeave();
+    return true;
+}
+
+void CWorkspaceSearchController::pointerLeave() {
+    if (m_surface && m_pointerEntered)
+        m_surface->pointerLeave();
+    Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_INTERNAL_UI);
+    m_pointerEntered = false;
+}
+
+void CWorkspaceSearchController::keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers) {
+    if (!m_surface)
+        return;
+
+    m_surface->keyboardKey({
+        .xkbKeysym = keysym,
+        .down      = down,
+        .repeat    = repeat,
+        .utf8      = std::move(utf8),
+        .modMask   = modifiers,
+    });
+}
+
+bool CWorkspaceSearchController::contains(const Vector2D& monitorLocal) const {
+    return !m_logicalBox.empty() && m_logicalBox.containsPoint(monitorLocal);
+}
+
+std::string CWorkspaceSearchController::query() const {
+    return m_textbox ? std::string{m_textbox->currentText()} : std::string{};
+}
+
+void CWorkspaceSearchController::updateGeometry() {
+    const auto MONITOR = m_monitor.lock();
+    if (!MONITOR || !m_surface)
+        return;
+
+    const auto GEOMETRY = WorkspaceSearch::calculateGeometry(MONITOR->m_size, MONITOR->m_scale);
+    if (GEOMETRY.logicalBox == m_logicalBox && GEOMETRY.pixelBox == m_pixelBox)
+        return;
+
+    m_logicalBox = GEOMETRY.logicalBox;
+    m_pixelBox   = GEOMETRY.pixelBox;
+    if (m_logicalBox.empty() || m_pixelBox.empty())
+        return;
+
+    m_surface->resize(m_logicalBox.size(), m_pixelBox.size(), MONITOR->m_scale);
+    m_framebuffer.reset();
+    m_needsFrame = true;
+    m_fullRedraw = true;
+}
+
+void CWorkspaceSearchController::damageMonitor() const {
+    if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+void CWorkspaceSearchController::setFocused(bool x) {
+    if (m_focused == x)
+        return;
+
+    m_focused = x;
+
+    if (m_textbox) {
+        m_textbox->setOpacity(x ? 1.F : 0.F);
+        m_textbox->focus(x);
+    }
+}

--- a/src/overview/hyprland/scene/WorkspaceSearchController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "../../../desktop/DesktopTypes.hpp"
+#include "../../../helpers/memory/Memory.hpp"
+#include "../../../helpers/math/Math.hpp"
+#include "../../../helpers/signal/Signal.hpp"
+#include "../../../helpers/time/Time.hpp"
+
+#include <functional>
+#include <string>
+
+namespace Hyprtoolkit {
+    class CTextboxElement;
+    class IEmbeddedSurface;
+}
+namespace Render {
+    class CRenderingContext;
+    class IFramebuffer;
+}
+
+namespace Overview::Hyprland {
+    class CWorkspaceSearchController {
+      public:
+        using FTextChanged = std::function<void(const std::string&)>;
+
+        CWorkspaceSearchController();
+        ~CWorkspaceSearchController();
+
+        void        start(PHLMONITOR monitor, FTextChanged textChanged);
+        void        reset();
+        void        draw(Render::CRenderingContext& context, float opacity);
+
+        bool        pointerMove(const Vector2D& monitorLocal);
+        bool        pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
+        void        pointerLeave();
+        void        keyboardKey(uint32_t keysym, bool down, bool repeat, std::string utf8, uint32_t modifiers);
+
+        bool        contains(const Vector2D& monitorLocal) const;
+        std::string query() const;
+
+        void        setFocused(bool x);
+
+      private:
+        void                              updateGeometry();
+        void                              damageMonitor() const;
+
+        PHLMONITORREF                     m_monitor;
+        SP<Hyprtoolkit::IEmbeddedSurface> m_surface;
+        SP<Hyprtoolkit::CTextboxElement>  m_textbox;
+        SP<Render::IFramebuffer>          m_framebuffer;
+        FTextChanged                      m_textChanged;
+        CBox                              m_logicalBox;
+        CBox                              m_pixelBox;
+        size_t                            m_pressedButtons = 0;
+        bool                              m_pointerEntered = false;
+        bool                              m_needsFrame     = true;
+        bool                              m_fullRedraw     = true;
+        bool                              m_focused        = false;
+
+        struct {
+            CHyprSignalListener frameRequested;
+            CHyprSignalListener damaged;
+            CHyprSignalListener cursorChanged;
+        } m_listeners;
+    };
+}

--- a/src/overview/hyprland/scene/WorkspaceSearchController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.hpp
@@ -39,7 +39,7 @@ namespace Overview::Hyprland {
         std::string query() const;
 
         void        setFocused(bool x);
-        void        resetQuery();
+        void        setQuery(const std::string& query);
 
       private:
         void                              updateGeometry();

--- a/src/overview/hyprland/scene/WorkspaceSearchController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceSearchController.hpp
@@ -39,6 +39,7 @@ namespace Overview::Hyprland {
         std::string query() const;
 
         void        setFocused(bool x);
+        void        resetQuery();
 
       private:
         void                              updateGeometry();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -4,7 +4,6 @@
 #include "WorkspaceMiniStripLayout.hpp"
 #include "WorkspaceTileShadow.hpp"
 #include "WorkspacePointerMapping.hpp"
-#include "OverviewScene.hpp"
 
 #include "../../../animation/AnimationManager.hpp"
 #include "../../../config/ConfigValue.hpp"
@@ -24,10 +23,6 @@
 #include "../../../render/pass/TexPassElement.hpp"
 #include "../../../state/WorkspaceState.hpp"
 #include "../../../pointer/PointerManager.hpp"
-
-#include "../../Overview.hpp"
-#include "../Overview.hpp"
-#include "../StringUtils.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -70,7 +65,7 @@ struct CWorkspaceTapeController::SWorkspaceTile {
     } listeners;
 };
 
-CWorkspaceTapeController::CWorkspaceTapeController() : m_filter([](PHLWORKSPACE) { return true; }) {
+CWorkspaceTapeController::CWorkspaceTapeController() : m_filter([](PHLWORKSPACE) { return Mode::eWorkspaceMatch::MATCH; }) {
     ;
 }
 
@@ -93,20 +88,7 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     Animation::mgr()->createAnimation(0.F, m_mainOffset, Config::animationTree()->getAnimationPropertyConfig("overviewMove"), AVARDAMAGE_NONE);
     m_mainOffset->setUpdateCallback([this](auto) { damageMonitor(); });
 
-    m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
-        if (!g_pEventLoopManager) {
-            reconcile();
-            return;
-        }
-
-        if (m_reconcileLock)
-            return;
-
-        m_reconcileLock = g_pEventLoopManager->doLaterLock([this] {
-            m_reconcileLock.reset();
-            reconcile();
-        });
-    });
+    m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) { scheduleReconcile(); });
     m_listeners.removed              = Event::bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF) { reconcile(); });
     m_listeners.renamed              = Event::bus()->m_events.workspace.renamed.listen([this](PHLWORKSPACEREF) { reconcile(); });
     m_listeners.moved                = Event::bus()->m_events.workspace.moveToMonitor.listen([this](PHLWORKSPACE, PHLMONITOR) { reconcile(); });
@@ -163,17 +145,39 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     m_listeners.windowOpened         = Event::bus()->m_events.window.open.listen([this](PHLWINDOW window) {
         refreshWindowListeners();
         invalidateMiniature(window ? window->m_workspace : nullptr);
+        scheduleReconcile(false);
     });
     m_listeners.windowClosed         = Event::bus()->m_events.window.close.listen([this](PHLWINDOW window) {
         refreshWindowListeners();
         invalidateMiniature(window ? window->m_workspace : nullptr);
+        scheduleReconcile(false);
     });
-    m_listeners.windowMoved          = Event::bus()->m_events.window.moveToWorkspace.listen([this](PHLWINDOW, PHLWORKSPACE) { invalidateMiniatures(); });
-    m_listeners.windowFullscreen     = Event::bus()->m_events.window.fullscreen.listen([this](PHLWINDOW window) { invalidateMiniature(window ? window->m_workspace : nullptr); });
-    m_listeners.windowFloating       = Event::bus()->m_events.window.floating.listen([this](PHLWINDOW window) { invalidateMiniature(window ? window->m_workspace : nullptr); });
+    m_listeners.windowMoved          = Event::bus()->m_events.window.moveToWorkspace.listen([this](PHLWINDOW, PHLWORKSPACE) {
+        invalidateMiniatures();
+        scheduleReconcile(false);
+    });
+    m_listeners.windowTitle          = Event::bus()->m_events.window.title.listen([this](PHLWINDOW) {
+        if (m_filterUsesWindowMetadata)
+            scheduleReconcile(false);
+    });
+    m_listeners.windowClass          = Event::bus()->m_events.window.class_.listen([this](PHLWINDOW) {
+        if (m_filterUsesWindowMetadata)
+            scheduleReconcile(false);
+    });
+    m_listeners.windowFullscreen     = Event::bus()->m_events.window.fullscreen.listen([this](PHLWINDOW window) {
+        invalidateMiniature(window ? window->m_workspace : nullptr);
+        scheduleReconcile(false);
+    });
+    m_listeners.windowFloating       = Event::bus()->m_events.window.floating.listen([this](PHLWINDOW window) {
+        invalidateMiniature(window ? window->m_workspace : nullptr);
+        scheduleReconcile(false);
+    });
     m_listeners.windowActive =
         Event::bus()->m_events.window.active.listen([this](PHLWINDOW window, Desktop::eFocusReason) { invalidateMiniature(window ? window->m_workspace : nullptr); });
-    m_listeners.windowPinned = Event::bus()->m_events.window.pin.listen([this](PHLWINDOW) { invalidateMiniatures(); });
+    m_listeners.windowPinned = Event::bus()->m_events.window.pin.listen([this](PHLWINDOW) {
+        invalidateMiniatures();
+        scheduleReconcile(false);
+    });
     m_listeners.layerOpened  = Event::bus()->m_events.layer.opened.listen([this](PHLLS) { invalidateMiniatures(); });
     m_listeners.layerClosed  = Event::bus()->m_events.layer.closed.listen([this](PHLLS) { invalidateMiniatures(); });
 
@@ -186,6 +190,7 @@ void CWorkspaceTapeController::reset() {
     m_listeners = {};
     m_windowListeners.clear();
     m_reconcileLock.reset();
+    m_reconcileInvalidatesMiniatures = false;
 
     if (m_mainOffset)
         m_mainOffset->resetAllCallbacks();
@@ -210,10 +215,11 @@ void CWorkspaceTapeController::reset() {
     m_preferredWorkspace.reset();
     m_pressedWorkspace.reset();
     m_mainOffset.reset();
-    m_mainArea           = {};
-    m_miniStripArea      = {};
-    m_overviewProgress   = 0.F;
-    m_fullscreenSelected = false;
+    m_mainArea                 = {};
+    m_miniStripArea            = {};
+    m_overviewProgress         = 0.F;
+    m_fullscreenSelected       = false;
+    m_filterUsesWindowMetadata = false;
     m_resources.reset();
     m_monitor.reset();
 }
@@ -598,13 +604,35 @@ bool CWorkspaceTapeController::pointerButton(uint32_t button, bool pressed, cons
     return true;
 }
 
-void CWorkspaceTapeController::setFilter(FWorkspaceFilter filter) {
-    m_filter = filter ? std::move(filter) : FWorkspaceFilter{[](PHLWORKSPACE) { return true; }};
+void CWorkspaceTapeController::setFilter(FWorkspaceFilter filter, bool usesWindowMetadata) {
+    m_filter                   = filter ? std::move(filter) : FWorkspaceFilter{[](PHLWORKSPACE) { return Mode::eWorkspaceMatch::MATCH; }};
+    m_filterUsesWindowMetadata = usesWindowMetadata;
     reconcile();
 }
 
 void CWorkspaceTapeController::refresh() {
     reconcile();
+}
+
+void CWorkspaceTapeController::scheduleReconcile(bool invalidateMiniatures) {
+    m_reconcileInvalidatesMiniatures |= invalidateMiniatures;
+
+    if (!g_pEventLoopManager) {
+        const bool INVALIDATE            = m_reconcileInvalidatesMiniatures;
+        m_reconcileInvalidatesMiniatures = false;
+        reconcile(false, INVALIDATE);
+        return;
+    }
+
+    if (m_reconcileLock)
+        return;
+
+    m_reconcileLock = g_pEventLoopManager->doLaterLock([this] {
+        m_reconcileLock.reset();
+        const bool INVALIDATE            = m_reconcileInvalidatesMiniatures;
+        m_reconcileInvalidatesMiniatures = false;
+        reconcile(false, INVALIDATE);
+    });
 }
 
 bool CWorkspaceTapeController::navigate(int direction) {
@@ -622,12 +650,14 @@ bool CWorkspaceTapeController::navigate(int direction) {
     return selectWorkspace(TILES.at(TARGET)->workspace.lock());
 }
 
-void CWorkspaceTapeController::reconcile(bool initial) {
+void CWorkspaceTapeController::reconcile(bool initial, bool invalidateMiniatures) {
     if (!m_started)
         return;
 
-    for (const auto& tile : m_tiles)
-        tile->miniDirty = true;
+    if (invalidateMiniatures) {
+        for (const auto& tile : m_tiles)
+            tile->miniDirty = true;
+    }
 
     const auto OLD_LAYOUT   = layoutTiles();
     const auto OLD_SELECTED = selectedWorkspace();
@@ -901,14 +931,17 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
     for (const auto& workspaceRef : State::workspaceState()->workspaces()) {
         const auto WORKSPACE      = workspaceRef.lock();
         const auto SOURCE_MONITOR = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
-        if (!valid(WORKSPACE) || !SOURCE_MONITOR || !SOURCE_MONITOR->m_enabled || SOURCE_MONITOR->isMirror() || !SOURCE_MONITOR->resources() || WORKSPACE->m_isSpecialWorkspace ||
-            !m_filter(WORKSPACE))
+        if (!valid(WORKSPACE) || !SOURCE_MONITOR || !SOURCE_MONITOR->m_enabled || SOURCE_MONITOR->isMirror() || !SOURCE_MONITOR->resources() || WORKSPACE->m_isSpecialWorkspace)
             continue;
 
         if (*PONLYSAMEMON && workspaceRef->m_monitor != MONITOR)
             continue;
 
-        if (StringUtils::fullMatchCaseIns(WORKSPACE->m_name, dynamicPointerCast<Hyprland::COverview>(WP<IOverview>(Overview::overview()))->scene()->currentQuery())) {
+        const auto MATCH = m_filter(WORKSPACE);
+        if (MATCH == Mode::eWorkspaceMatch::NONE)
+            continue;
+
+        if (MATCH == Mode::eWorkspaceMatch::EXACT) {
             exactMatch = WORKSPACE;
             break;
         }

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -1,0 +1,439 @@
+#include "WorkspaceTapeController.hpp"
+
+#include "../../../animation/AnimationManager.hpp"
+#include "../../../config/shared/animation/AnimationTree.hpp"
+#include "../../../desktop/Workspace.hpp"
+#include "../../../event/EventBus.hpp"
+#include "../../../managers/eventLoop/EventLoopManager.hpp"
+#include "../../../output/Monitor.hpp"
+#include "../../../output/MonitorResources.hpp"
+#include "../../../render/Renderer.hpp"
+#include "../../../render/pass/RectPassElement.hpp"
+#include "../../../render/pass/TexPassElement.hpp"
+#include "../../../state/WorkspaceState.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <ranges>
+
+using namespace Overview::Hyprland;
+
+static constexpr float TILE_GAP         = 0.02F;
+static constexpr float TILE_ROUNDING    = 20.F;
+static constexpr float PLACEHOLDER_GRAY = 0.12F;
+
+struct CWorkspaceTapeController::SWorkspaceTile {
+    PHLWORKSPACEREF          workspace;
+    PHLANIMVAR<Vector2D>     position;
+    PHLANIMVAR<Vector2D>     size;
+    PHLANIMVAR<float>        opacity;
+    SP<Render::IFramebuffer> framebuffer;
+    bool                     inLayout            = false;
+    bool                     geometryInitialized = false;
+
+    struct {
+        CHyprSignalListener destroyed;
+        CHyprSignalListener idChanged;
+        CHyprSignalListener monitorChanged;
+    } listeners;
+};
+
+CWorkspaceTapeController::CWorkspaceTapeController() : m_filter([](PHLWORKSPACE) { return true; }) {
+    ;
+}
+
+CWorkspaceTapeController::~CWorkspaceTapeController() {
+    reset();
+}
+
+void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {
+    reset();
+
+    if (!monitor || !resources)
+        return;
+
+    m_monitor   = monitor;
+    m_resources = resources;
+    m_started   = true;
+
+    m_listeners.created = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
+        if (g_pEventLoopManager)
+            g_pEventLoopManager->doLater([this] { reconcile(); });
+        else
+            reconcile();
+    });
+    m_listeners.removed = Event::bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF) { reconcile(); });
+    m_listeners.moved   = Event::bus()->m_events.workspace.moveToMonitor.listen([this](PHLWORKSPACE, PHLMONITOR) { reconcile(); });
+    m_listeners.active  = Event::bus()->m_events.workspace.active.listen([this](PHLWORKSPACE workspace) {
+        if (workspace && workspace->m_monitor == m_monitor)
+            reconcile();
+    });
+
+    reconcile(true);
+}
+
+void CWorkspaceTapeController::reset() {
+    m_started   = false;
+    m_listeners = {};
+
+    for (const auto& tile : m_tiles) {
+        if (tile->position)
+            tile->position->resetAllCallbacks();
+        if (tile->size)
+            tile->size->resetAllCallbacks();
+        if (tile->opacity)
+            tile->opacity->resetAllCallbacks();
+    }
+
+    m_tiles.clear();
+    m_selectedWorkspace.reset();
+    m_resources.reset();
+    m_monitor.reset();
+}
+
+void CWorkspaceTapeController::draw(Time::steady_tp tp, float overviewProgress) {
+    const auto MONITOR   = m_monitor.lock();
+    const auto RESOURCES = m_resources;
+    if (!m_started || !MONITOR || !RESOURCES || !g_pHyprRenderer)
+        return;
+
+    pruneRetiredTiles();
+
+    const float    PROGRESS   = std::clamp(overviewProgress, 0.F, 1.F);
+    const CBox     MONITORBOX = {{}, MONITOR->m_transformedSize};
+    const auto     ACTIVE     = MONITOR->m_activeWorkspace;
+    const auto     SELECTED   = selectedWorkspace();
+    const Vector2D FULLSIZE   = MONITOR->m_transformedSize;
+
+    struct SDrawTile {
+        SWorkspaceTile* tile = nullptr;
+        CBox            box;
+        float           opacity  = 0.F;
+        bool            selected = false;
+    };
+
+    std::vector<SDrawTile> drawTiles;
+    drawTiles.reserve(m_tiles.size());
+
+    for (const auto& tile : m_tiles) {
+        const auto     WORKSPACE = tile->workspace.lock();
+        const bool     IS_ACTIVE = WORKSPACE && WORKSPACE == ACTIVE;
+        const auto     OPENPOS   = tile->position->value();
+        const auto     OPENSIZE  = tile->size->value();
+
+        const Vector2D POS   = IS_ACTIVE ? OPENPOS * PROGRESS : OPENPOS;
+        const Vector2D SIZE  = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * PROGRESS : OPENSIZE;
+        const float    ALPHA = IS_ACTIVE ? (1.F - PROGRESS) + tile->opacity->value() * PROGRESS : tile->opacity->value() * PROGRESS;
+        const CBox     BOX{POS, SIZE};
+
+        if (ALPHA <= 0.F || BOX.intersection(MONITORBOX).empty()) {
+            tile->framebuffer.reset();
+            continue;
+        }
+
+        drawTiles.emplace_back(SDrawTile{
+            .tile     = tile.get(),
+            .box      = BOX,
+            .opacity  = ALPHA,
+            .selected = WORKSPACE && WORKSPACE == SELECTED,
+        });
+    }
+
+    std::ranges::stable_sort(drawTiles, [](const auto& lhs, const auto& rhs) { return lhs.selected < rhs.selected; });
+
+    const int ROUNDING = std::lround(TILE_ROUNDING * MONITOR->m_scale * PROGRESS);
+    for (auto& drawTile : drawTiles) {
+        auto&      tile      = *drawTile.tile;
+        const auto WORKSPACE = tile.workspace.lock();
+
+        const bool CAN_RENDER = WORKSPACE && WORKSPACE->m_monitor == MONITOR;
+        if (!tile.framebuffer && CAN_RENDER)
+            tile.framebuffer = RESOURCES->getUnusedWorkBuffer();
+
+        bool rendered = false;
+        if (CAN_RENDER && tile.framebuffer)
+            rendered = g_pHyprRenderer->renderWorkspaceSceneToBuffer(WORKSPACE, tile.framebuffer, tp, drawTile.selected);
+
+        if (!rendered && tile.inLayout)
+            tile.framebuffer.reset();
+
+        if (!tile.framebuffer) {
+            CRectPassElement::SRectData data;
+            data.box   = drawTile.box;
+            data.color = CHyprColor(PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, drawTile.opacity);
+            data.round = ROUNDING;
+            g_pHyprRenderer->addPassElement(makeUnique<CRectPassElement>(data));
+            continue;
+        }
+
+        CTexPassElement::SRenderData data;
+        data.tex     = tile.framebuffer->getTexture();
+        data.box     = drawTile.box;
+        data.a       = drawTile.opacity;
+        data.round   = ROUNDING;
+        data.clipBox = MONITORBOX;
+        g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+    }
+}
+
+bool CWorkspaceTapeController::navigateLeft() {
+    return navigate(-1);
+}
+
+bool CWorkspaceTapeController::navigateRight() {
+    return navigate(1);
+}
+
+PHLWORKSPACE CWorkspaceTapeController::selectedWorkspace() const {
+    return m_selectedWorkspace.lock();
+}
+
+void CWorkspaceTapeController::setFilter(FWorkspaceFilter filter) {
+    m_filter = filter ? std::move(filter) : FWorkspaceFilter{[](PHLWORKSPACE) { return true; }};
+    reconcile();
+}
+
+void CWorkspaceTapeController::refresh() {
+    reconcile();
+}
+
+bool CWorkspaceTapeController::navigate(int direction) {
+    const auto TILES = layoutTiles();
+    if (!m_started || TILES.empty() || direction == 0)
+        return false;
+
+    const auto SELECTED = selectedWorkspace();
+    const auto IT       = std::ranges::find_if(TILES, [&SELECTED](const auto* tile) { return tile->workspace == SELECTED; });
+    const auto INDEX    = IT == TILES.end() ? 0L : std::ranges::distance(TILES.begin(), IT);
+    const auto TARGET   = std::clamp(INDEX + direction, 0L, sc<long>(TILES.size()) - 1L);
+    if (TARGET == INDEX)
+        return false;
+
+    m_selectedWorkspace = TILES.at(TARGET)->workspace;
+    updateLayout();
+    damageMonitor();
+    return true;
+}
+
+void CWorkspaceTapeController::reconcile(bool initial) {
+    if (!m_started)
+        return;
+
+    const auto OLD_LAYOUT   = layoutTiles();
+    const auto OLD_SELECTED = selectedWorkspace();
+    const auto OLD_IT       = std::ranges::find_if(OLD_LAYOUT, [&OLD_SELECTED](const auto* tile) { return tile->workspace == OLD_SELECTED; });
+    const auto OLD_INDEX    = OLD_IT == OLD_LAYOUT.end() ? 0L : std::ranges::distance(OLD_LAYOUT.begin(), OLD_IT);
+    const auto WORKSPACES   = filteredWorkspaces();
+
+    for (const auto& tile : m_tiles)
+        tile->inLayout = false;
+
+    for (const auto& workspace : WORKSPACES) {
+        auto* tile = tileFor(workspace);
+        if (!tile) {
+            auto newTile       = makeUnique<SWorkspaceTile>();
+            newTile->workspace = workspace;
+            ensureAnimations(*newTile);
+            installWorkspaceListeners(*newTile);
+            tile = m_tiles.emplace_back(std::move(newTile)).get();
+        }
+
+        tile->inLayout = true;
+        tile->opacity->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewFade"));
+        if (initial)
+            tile->opacity->setValueAndWarp(1.F);
+        else
+            *tile->opacity = 1.F;
+    }
+
+    for (const auto& tile : m_tiles) {
+        if (!tile->inLayout)
+            retireTile(*tile);
+    }
+
+    if (WORKSPACES.empty())
+        m_selectedWorkspace.reset();
+    else if (std::ranges::contains(WORKSPACES, OLD_SELECTED))
+        m_selectedWorkspace = OLD_SELECTED;
+    else if (const auto MONITOR = m_monitor.lock(); initial && MONITOR && std::ranges::contains(WORKSPACES, MONITOR->m_activeWorkspace))
+        m_selectedWorkspace = MONITOR->m_activeWorkspace;
+    else
+        m_selectedWorkspace = WORKSPACES.at(std::min(OLD_INDEX, sc<long>(WORKSPACES.size()) - 1L));
+
+    if (const auto MONITOR = m_monitor.lock(); MONITOR && MONITOR->m_activeWorkspace && !tileFor(MONITOR->m_activeWorkspace)) {
+        auto tile       = makeUnique<SWorkspaceTile>();
+        tile->workspace = MONITOR->m_activeWorkspace;
+        ensureAnimations(*tile);
+        installWorkspaceListeners(*tile);
+        tile->opacity->setValueAndWarp(0.F);
+        m_tiles.emplace_back(std::move(tile));
+    }
+
+    updateLayout(initial);
+    damageMonitor();
+}
+
+void CWorkspaceTapeController::updateLayout(bool warp) {
+    const auto MONITOR = m_monitor.lock();
+    const auto TILES   = layoutTiles();
+    if (!MONITOR)
+        return;
+
+    const auto SELECTED = selectedWorkspace();
+    const auto IT       = std::ranges::find_if(TILES, [&SELECTED](const auto* tile) { return tile->workspace == SELECTED; });
+    const auto INDEX    = IT == TILES.end() ? 0L : std::ranges::distance(TILES.begin(), IT);
+    const auto SIZE     = MONITOR->m_transformedSize * TILE_SCALE;
+    const auto BASEPOS  = (MONITOR->m_transformedSize - SIZE) / 2.F;
+    const auto STRIDE   = SIZE.x + MONITOR->m_transformedSize.x * TILE_GAP;
+
+    for (size_t i = 0; i < TILES.size(); ++i) {
+        auto& tile = *TILES.at(i);
+        tile.position->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
+        tile.size->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
+
+        const Vector2D POSITION = BASEPOS + Vector2D{(sc<long>(i) - INDEX) * STRIDE, 0.F};
+        if (warp || !tile.geometryInitialized) {
+            tile.position->setValueAndWarp(POSITION);
+            tile.size->setValueAndWarp(SIZE);
+            tile.geometryInitialized = true;
+        } else {
+            *tile.position = POSITION;
+            *tile.size     = SIZE;
+        }
+    }
+
+    for (const auto& tile : m_tiles) {
+        if (tile->inLayout)
+            continue;
+
+        const auto WORKSPACE = tile->workspace.lock();
+        if (!WORKSPACE || WORKSPACE != MONITOR->m_activeWorkspace)
+            continue;
+
+        const Vector2D POSITION = BASEPOS;
+        if (warp || !tile->geometryInitialized) {
+            tile->position->setValueAndWarp(POSITION);
+            tile->size->setValueAndWarp(SIZE);
+            tile->geometryInitialized = true;
+        } else {
+            *tile->position = POSITION;
+            *tile->size     = SIZE;
+        }
+    }
+}
+
+void CWorkspaceTapeController::retireTile(SWorkspaceTile& tile) {
+    if (tile.opacity->goal() == 0.F)
+        return;
+
+    tile.position->setValueAndWarp(tile.position->value());
+    tile.size->setValueAndWarp(tile.size->value());
+    tile.opacity->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewFade"));
+    *tile.opacity = 0.F;
+}
+
+void CWorkspaceTapeController::ensureAnimations(SWorkspaceTile& tile) {
+    const auto MOVE = Config::animationTree()->getAnimationPropertyConfig("overviewMove");
+    const auto FADE = Config::animationTree()->getAnimationPropertyConfig("overviewFade");
+
+    Animation::mgr()->createAnimation(Vector2D{}, tile.position, MOVE, AVARDAMAGE_NONE);
+    Animation::mgr()->createAnimation(Vector2D{}, tile.size, MOVE, AVARDAMAGE_NONE);
+    Animation::mgr()->createAnimation(0.F, tile.opacity, FADE, AVARDAMAGE_NONE);
+
+    const auto DAMAGE = [this](auto) { damageMonitor(); };
+    tile.position->setUpdateCallback(DAMAGE);
+    tile.size->setUpdateCallback(DAMAGE);
+    tile.opacity->setUpdateCallback(DAMAGE);
+}
+
+void CWorkspaceTapeController::installWorkspaceListeners(SWorkspaceTile& tile) {
+    const auto WORKSPACE = tile.workspace.lock();
+    if (!WORKSPACE)
+        return;
+
+    tile.listeners.destroyed      = WORKSPACE->m_events.destroy.listen([this] { reconcile(); });
+    tile.listeners.idChanged      = WORKSPACE->m_events.idChanged.listen([this] { reconcile(); });
+    tile.listeners.monitorChanged = WORKSPACE->m_events.monitorChanged.listen([this] { reconcile(); });
+}
+
+void CWorkspaceTapeController::damageMonitor() const {
+    if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileFor(PHLWORKSPACE workspace) const {
+    if (!workspace)
+        return nullptr;
+
+    return tileFor(PHLWORKSPACEREF{workspace});
+}
+
+CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileFor(PHLWORKSPACEREF workspace) const {
+    const auto IT = std::ranges::find_if(m_tiles, [&workspace](const auto& tile) { return tile->workspace == workspace; });
+    return IT == m_tiles.end() ? nullptr : IT->get();
+}
+
+std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
+    std::vector<PHLWORKSPACE> workspaces;
+    const auto                MONITOR = m_monitor.lock();
+    if (!MONITOR)
+        return workspaces;
+
+    for (const auto& workspaceRef : State::workspaceState()->workspaces()) {
+        const auto WORKSPACE = workspaceRef.lock();
+        if (!valid(WORKSPACE) || WORKSPACE->m_monitor != MONITOR || WORKSPACE->m_isSpecialWorkspace || !m_filter(WORKSPACE))
+            continue;
+
+        workspaces.emplace_back(WORKSPACE);
+    }
+
+    std::ranges::stable_sort(workspaces, [](const auto& lhs, const auto& rhs) {
+        const bool LHS_NUMERIC = lhs->m_id > 0;
+        const bool RHS_NUMERIC = rhs->m_id > 0;
+        if (LHS_NUMERIC != RHS_NUMERIC)
+            return LHS_NUMERIC;
+        if (LHS_NUMERIC)
+            return lhs->m_id < rhs->m_id;
+        return false;
+    });
+
+    return workspaces;
+}
+
+std::vector<CWorkspaceTapeController::SWorkspaceTile*> CWorkspaceTapeController::layoutTiles() const {
+    std::vector<SWorkspaceTile*> tiles;
+    tiles.reserve(m_tiles.size());
+
+    for (const auto& tile : m_tiles) {
+        if (tile->inLayout)
+            tiles.emplace_back(tile.get());
+    }
+
+    std::ranges::stable_sort(tiles, [](const auto* lhs, const auto* rhs) {
+        const auto LHS = lhs->workspace.lock();
+        const auto RHS = rhs->workspace.lock();
+        if (!LHS || !RHS)
+            return !!LHS;
+
+        const bool LHS_NUMERIC = LHS->m_id > 0;
+        const bool RHS_NUMERIC = RHS->m_id > 0;
+        if (LHS_NUMERIC != RHS_NUMERIC)
+            return LHS_NUMERIC;
+        if (LHS_NUMERIC)
+            return LHS->m_id < RHS->m_id;
+        return false;
+    });
+
+    return tiles;
+}
+
+void CWorkspaceTapeController::pruneRetiredTiles() {
+    const auto MONITOR = m_monitor.lock();
+    std::erase_if(m_tiles, [&MONITOR](const auto& tile) {
+        if (tile->inLayout || tile->opacity->isBeingAnimated() || tile->opacity->value() > 0.F)
+            return false;
+
+        const auto WORKSPACE = tile->workspace.lock();
+        return !MONITOR || !WORKSPACE || WORKSPACE != MONITOR->m_activeWorkspace;
+    });
+}

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -26,6 +26,7 @@
 
 #include "../../Overview.hpp"
 #include "../Overview.hpp"
+#include "../StringUtils.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -823,16 +824,6 @@ CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileFor(PHLW
     return IT == m_tiles.end() ? nullptr : IT->get();
 }
 
-static uint8_t foldASCII(uint8_t character) {
-    if (character >= 'A' && character <= 'Z')
-        return character + ('a' - 'A');
-    return character;
-}
-
-static bool fullMatchCaseIns(std::string_view a, std::string_view b) {
-    return std::ranges::equal(a, b, [](char x, char y) { return foldASCII(x) == foldASCII(y); });
-}
-
 std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
     std::vector<PHLWORKSPACE> workspaces;
     const auto                MONITOR = m_monitor.lock();
@@ -853,7 +844,7 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
         if (*PONLYSAMEMON && workspaceRef->m_monitor != MONITOR)
             continue;
 
-        if (fullMatchCaseIns(WORKSPACE->m_name, dynamicPointerCast<Hyprland::COverview>(WP<IOverview>(Overview::overview()))->scene()->currentQuery())) {
+        if (StringUtils::fullMatchCaseIns(WORKSPACE->m_name, dynamicPointerCast<Hyprland::COverview>(WP<IOverview>(Overview::overview()))->scene()->currentQuery())) {
             exactMatch = WORKSPACE;
             break;
         }

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -3,6 +3,7 @@
 #include "WorkspaceTapeLayout.hpp"
 #include "WorkspaceMiniStripLayout.hpp"
 #include "WorkspaceTileShadow.hpp"
+#include "WorkspacePointerMapping.hpp"
 
 #include "../../../animation/AnimationManager.hpp"
 #include "../../../config/ConfigValue.hpp"
@@ -200,6 +201,34 @@ void CWorkspaceTapeController::reset() {
     m_monitor.reset();
 }
 
+CBox CWorkspaceTapeController::mainBoxFor(const SWorkspaceTile& tile, PHLMONITOR monitor) const {
+    if (!monitor || !tile.position || !tile.size)
+        return {};
+
+    const auto     WORKSPACE = tile.workspace.lock();
+    const bool     IS_ACTIVE = WORKSPACE && WORKSPACE == monitor->m_activeWorkspace;
+    const Vector2D OPENPOS   = tile.position->value();
+    const Vector2D OPENSIZE  = tile.size->value();
+    const Vector2D FULLSIZE  = monitor->m_transformedSize;
+    const Vector2D POS       = IS_ACTIVE ? OPENPOS * m_overviewProgress : OPENPOS;
+    const Vector2D SIZE      = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * m_overviewProgress : OPENSIZE;
+
+    return CBox{POS, SIZE}.round();
+}
+
+Vector2D CWorkspaceTapeController::transformPointer(const Vector2D& global) const {
+    const auto MONITOR   = m_monitor.lock();
+    const auto WORKSPACE = selectedWorkspace();
+    const auto TILE      = tileFor(WORKSPACE);
+    const auto SOURCE    = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
+    if (!m_started || !MONITOR || !MONITOR->logicalBox().containsPoint(global) || !TILE || !TILE->inLayout || !SOURCE)
+        return global;
+
+    const auto PIXEL  = (global - MONITOR->logicalBox().pos()) * MONITOR->m_scale;
+    const auto MAPPED = WorkspacePointerMapping::mapClamped(PIXEL, mainBoxFor(*TILE, MONITOR), SOURCE->logicalBox());
+    return MAPPED.value_or(global);
+}
+
 void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::steady_tp tp, float overviewProgress, size_t reservedWorkBuffers) {
     const auto MONITOR   = m_monitor.lock();
     const auto RESOURCES = m_resources;
@@ -208,12 +237,11 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
 
     pruneRetiredTiles();
 
-    const float    PROGRESS   = std::clamp(overviewProgress, 0.F, 1.F);
-    const CBox     MONITORBOX = {{}, MONITOR->m_transformedSize};
-    const auto     ACTIVE     = MONITOR->m_activeWorkspace;
-    const auto     SELECTED   = selectedWorkspace();
-    const Vector2D FULLSIZE   = MONITOR->m_transformedSize;
-    m_overviewProgress        = PROGRESS;
+    const float PROGRESS   = std::clamp(overviewProgress, 0.F, 1.F);
+    const CBox  MONITORBOX = {{}, MONITOR->m_transformedSize};
+    const auto  ACTIVE     = MONITOR->m_activeWorkspace;
+    const auto  SELECTED   = selectedWorkspace();
+    m_overviewProgress     = PROGRESS;
 
     struct SDrawTile {
         SWorkspaceTile* tile = nullptr;
@@ -230,19 +258,14 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
     drawTiles.reserve(m_tiles.size());
 
     for (const auto& tile : m_tiles) {
-        const auto     WORKSPACE = tile->workspace.lock();
-        const bool     IS_ACTIVE = WORKSPACE && WORKSPACE == ACTIVE;
-        const auto     OPENPOS   = tile->position->value();
-        const auto     OPENSIZE  = tile->size->value();
-
-        const Vector2D POS          = IS_ACTIVE ? OPENPOS * PROGRESS : OPENPOS;
-        const Vector2D SIZE         = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * PROGRESS : OPENSIZE;
-        const float    ALPHA        = IS_ACTIVE ? (1.F - PROGRESS) + tile->opacity->value() * PROGRESS : tile->opacity->value() * PROGRESS;
-        const CBox     MAIN_BOX     = CBox{POS, SIZE}.round();
-        const CBox     MINI_BOX     = CBox{tile->miniPosition->value(), tile->miniSize->value()}.round();
-        const float    MINI_ALPHA   = tile->opacity->value() * PROGRESS;
-        const bool     MAIN_VISIBLE = ALPHA > 0.F && !MAIN_BOX.intersection(MONITORBOX).empty();
-        const bool     MINI_VISIBLE = MINI_ALPHA > 0.F && !MINI_BOX.intersection(m_miniStripArea).empty();
+        const auto  WORKSPACE    = tile->workspace.lock();
+        const bool  IS_ACTIVE    = WORKSPACE && WORKSPACE == ACTIVE;
+        const float ALPHA        = IS_ACTIVE ? (1.F - PROGRESS) + tile->opacity->value() * PROGRESS : tile->opacity->value() * PROGRESS;
+        const CBox  MAIN_BOX     = mainBoxFor(*tile, MONITOR);
+        const CBox  MINI_BOX     = CBox{tile->miniPosition->value(), tile->miniSize->value()}.round();
+        const float MINI_ALPHA   = tile->opacity->value() * PROGRESS;
+        const bool  MAIN_VISIBLE = ALPHA > 0.F && !MAIN_BOX.intersection(MONITORBOX).empty();
+        const bool  MINI_VISIBLE = MINI_ALPHA > 0.F && !MINI_BOX.intersection(m_miniStripArea).empty();
 
         if (!MAIN_VISIBLE && !MINI_VISIBLE) {
             tile->framebuffer.reset();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -202,24 +202,37 @@ void CWorkspaceTapeController::reset() {
     m_selectedWorkspace.reset();
     m_preferredWorkspace.reset();
     m_pressedMiniWorkspace.reset();
-    m_mainArea         = {};
-    m_miniStripArea    = {};
-    m_overviewProgress = 0.F;
+    m_mainArea           = {};
+    m_miniStripArea      = {};
+    m_overviewProgress   = 0.F;
+    m_fullscreenSelected = false;
     m_resources.reset();
     m_monitor.reset();
+}
+
+PHLWORKSPACE CWorkspaceTapeController::fullscreenWorkspace(PHLMONITOR monitor) const {
+    if (!monitor)
+        return nullptr;
+
+    const auto SELECTED = selectedWorkspace();
+    if (m_fullscreenSelected && SELECTED && SELECTED->m_monitor == monitor)
+        return SELECTED;
+
+    return monitor->m_activeWorkspace;
 }
 
 CBox CWorkspaceTapeController::mainBoxFor(const SWorkspaceTile& tile, PHLMONITOR monitor) const {
     if (!monitor || !tile.position || !tile.size)
         return {};
 
-    const auto     WORKSPACE = tile.workspace.lock();
-    const bool     IS_ACTIVE = WORKSPACE && WORKSPACE == monitor->m_activeWorkspace;
-    const Vector2D OPENPOS   = tile.position->value();
-    const Vector2D OPENSIZE  = tile.size->value();
-    const Vector2D FULLSIZE  = monitor->m_transformedSize;
-    const Vector2D POS       = IS_ACTIVE ? OPENPOS * m_overviewProgress : OPENPOS;
-    const Vector2D SIZE      = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * m_overviewProgress : OPENSIZE;
+    const auto     WORKSPACE  = tile.workspace.lock();
+    const auto     FULLSCREEN = fullscreenWorkspace(monitor);
+    const bool     IS_ACTIVE  = WORKSPACE && WORKSPACE == FULLSCREEN;
+    const Vector2D OPENPOS    = tile.position->value();
+    const Vector2D OPENSIZE   = tile.size->value();
+    const Vector2D FULLSIZE   = monitor->m_transformedSize;
+    const Vector2D POS        = IS_ACTIVE ? OPENPOS * m_overviewProgress : OPENPOS;
+    const Vector2D SIZE       = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * m_overviewProgress : OPENSIZE;
 
     return CBox{POS, SIZE}.round();
 }
@@ -247,7 +260,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
 
     const float PROGRESS   = std::clamp(overviewProgress, 0.F, 1.F);
     const CBox  MONITORBOX = {{}, MONITOR->m_transformedSize};
-    const auto  ACTIVE     = MONITOR->m_activeWorkspace;
+    const auto  ACTIVE     = fullscreenWorkspace(MONITOR);
     const auto  SELECTED   = selectedWorkspace();
     m_overviewProgress     = PROGRESS;
 
@@ -460,6 +473,10 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         border.roundingPower = 2.F;
         g_pHyprRenderer->addPassElement(context, makeUnique<CBorderPassElement>(border));
     }
+}
+
+void CWorkspaceTapeController::useSelectedWorkspaceForFullscreen(bool x) {
+    m_fullscreenSelected = x;
 }
 
 bool CWorkspaceTapeController::navigateLeft() {

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -1,5 +1,6 @@
 #include "WorkspaceTapeController.hpp"
 #include "WorkspaceTapeLayout.hpp"
+#include "WorkspaceTileShadow.hpp"
 
 #include "../../../animation/AnimationManager.hpp"
 #include "../../../config/shared/animation/AnimationTree.hpp"
@@ -9,6 +10,7 @@
 #include "../../../output/Monitor.hpp"
 #include "../../../output/MonitorResources.hpp"
 #include "../../../render/Renderer.hpp"
+#include "../../../render/pass/BoxShadowPassElement.hpp"
 #include "../../../render/pass/RectPassElement.hpp"
 #include "../../../render/pass/TexPassElement.hpp"
 #include "../../../state/WorkspaceState.hpp"
@@ -19,9 +21,11 @@
 
 using namespace Overview::Hyprland;
 
-static constexpr float TILE_GAP         = 0.02F;
-static constexpr float TILE_ROUNDING    = 20.F;
-static constexpr float PLACEHOLDER_GRAY = 0.12F;
+static constexpr float TILE_GAP          = 0.02F;
+static constexpr float TILE_ROUNDING     = 20.F;
+static constexpr float TILE_SHADOW_RANGE = 14.F;
+static constexpr float TILE_SHADOW_ALPHA = 0.45F;
+static constexpr float PLACEHOLDER_GRAY  = 0.12F;
 
 struct CWorkspaceTapeController::SWorkspaceTile {
     PHLWORKSPACEREF          workspace;
@@ -109,7 +113,7 @@ void CWorkspaceTapeController::reset() {
     m_monitor.reset();
 }
 
-void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::steady_tp tp, float overviewProgress) {
+void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::steady_tp tp, float overviewProgress, size_t reservedWorkBuffers) {
     const auto MONITOR   = m_monitor.lock();
     const auto RESOURCES = m_resources;
     if (!m_started || !MONITOR || !RESOURCES || !g_pHyprRenderer)
@@ -178,9 +182,12 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
             tile.framebuffer.reset();
 
         const auto ACQUIRE_BUFFER = [&] {
-            if (SOURCE_MONITOR == MONITOR)
+            if (SOURCE_MONITOR == MONITOR) {
+                if (RESOURCES->availableWorkBufferCount() <= reservedWorkBuffers)
+                    return;
+
                 tile.framebuffer = RESOURCES->getUnusedWorkBuffer();
-            else
+            } else
                 tile.framebuffer = RESOURCES->getUnusedWorkBuffer(BUFFER_SIZE);
         };
 
@@ -212,6 +219,21 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
     const int ROUNDING = std::lround(TILE_ROUNDING * MONITOR->m_scale * PROGRESS);
     for (const auto& drawTile : drawTiles) {
         const auto& tile = *drawTile.tile;
+
+        const auto  SHADOW = WorkspaceTileShadow::calculate(drawTile.box, MONITOR->m_scale, drawTile.opacity, PROGRESS, TILE_SHADOW_RANGE, TILE_ROUNDING);
+        if (SHADOW) {
+            CBoxShadowPassElement::SBoxShadowData shadow;
+            shadow.box           = SHADOW->outerBox;
+            shadow.cutoutBox     = drawTile.box;
+            shadow.clipBox       = MONITORBOX;
+            shadow.color         = CHyprColor(0.F, 0.F, 0.F, TILE_SHADOW_ALPHA);
+            shadow.a             = SHADOW->opacity;
+            shadow.round         = SHADOW->rounding;
+            shadow.roundingPower = 2.F;
+            shadow.range         = SHADOW->range;
+            g_pHyprRenderer->addPassElement(context, makeUnique<CBoxShadowPassElement>(shadow));
+        }
+
         if (!tile.framebuffer) {
             CRectPassElement::SRectData data;
             data.box   = drawTile.box;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -23,6 +23,7 @@
 #include "../../../render/pass/RectPassElement.hpp"
 #include "../../../render/pass/TexPassElement.hpp"
 #include "../../../state/WorkspaceState.hpp"
+#include "../../../pointer/PointerManager.hpp"
 
 #include "../../Overview.hpp"
 #include "../Overview.hpp"
@@ -83,11 +84,11 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     if (!monitor || !resources)
         return;
 
-    m_monitor       = monitor;
-    m_resources     = resources;
-    m_mainArea      = layout.pixelMain;
-    m_miniStripArea = layout.pixelMiniStrip;
-    m_started       = true;
+    m_monitor         = monitor;
+    m_resources       = resources;
+    m_mainArea        = layout.pixelMain;
+    m_miniStripArea   = layout.pixelMiniStrip;
+    m_started         = true;
 
     m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
         if (!g_pEventLoopManager) {
@@ -201,7 +202,7 @@ void CWorkspaceTapeController::reset() {
     m_tiles.clear();
     m_selectedWorkspace.reset();
     m_preferredWorkspace.reset();
-    m_pressedMiniWorkspace.reset();
+    m_pressedWorkspace.reset();
     m_mainArea           = {};
     m_miniStripArea      = {};
     m_overviewProgress   = 0.F;
@@ -532,22 +533,33 @@ bool CWorkspaceTapeController::pointerButton(uint32_t button, bool pressed, cons
     if (button != BTN_LEFT)
         return false;
 
-    const auto WORKSPACE = miniWorkspaceAt(monitorLocal);
+    auto workspace = miniWorkspaceAt(monitorLocal);
+    if (!workspace) {
+        // mega workspace pointer logic
+
+        const auto CURSOR    = Pointer::mgr()->untransformedPosition();
+        const auto TILE = tileAt(CURSOR);
+
+        if (TILE)
+            workspace = TILE->workspace.lock();
+    }
+
     if (pressed) {
-        if (!WORKSPACE)
+        if (!workspace)
             return false;
 
-        m_pressedMiniWorkspace = WORKSPACE;
+        m_pressedWorkspace = workspace;
         return true;
     }
 
-    const auto PRESSED = m_pressedMiniWorkspace.lock();
-    m_pressedMiniWorkspace.reset();
+    const auto PRESSED = m_pressedWorkspace.lock();
+    m_pressedWorkspace.reset();
     if (!PRESSED)
         return false;
 
-    if (WORKSPACE == PRESSED)
+    if (workspace == PRESSED)
         selectWorkspace(PRESSED);
+
     return true;
 }
 
@@ -884,6 +896,17 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
     }
 
     return workspaces;
+}
+
+CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileAt(const Vector2D& monitorLocal) const {
+    auto tiles = layoutTiles();
+
+    for (const auto& t : tiles) {
+        if (CBox{t->position->goal(), t->size->goal()}.containsPoint(monitorLocal))
+            return t;
+    }
+
+    return nullptr;
 }
 
 std::vector<CWorkspaceTapeController::SWorkspaceTile*> CWorkspaceTapeController::layoutTiles() const {

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -68,6 +68,7 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
             reconcile();
     });
     m_listeners.removed              = Event::bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF) { reconcile(); });
+    m_listeners.renamed              = Event::bus()->m_events.workspace.renamed.listen([this](PHLWORKSPACEREF) { reconcile(); });
     m_listeners.moved                = Event::bus()->m_events.workspace.moveToMonitor.listen([this](PHLWORKSPACE, PHLMONITOR) { reconcile(); });
     m_listeners.active               = Event::bus()->m_events.workspace.active.listen([this](PHLWORKSPACE workspace) {
         if (workspace && workspace->m_monitor == m_monitor)
@@ -109,6 +110,7 @@ void CWorkspaceTapeController::reset() {
 
     m_tiles.clear();
     m_selectedWorkspace.reset();
+    m_preferredWorkspace.reset();
     m_resources.reset();
     m_monitor.reset();
 }
@@ -146,7 +148,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         const Vector2D POS   = IS_ACTIVE ? OPENPOS * PROGRESS : OPENPOS;
         const Vector2D SIZE  = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * PROGRESS : OPENSIZE;
         const float    ALPHA = IS_ACTIVE ? (1.F - PROGRESS) + tile->opacity->value() * PROGRESS : tile->opacity->value() * PROGRESS;
-        const CBox     BOX{POS, SIZE};
+        const CBox     BOX = CBox{POS, SIZE}.round();
 
         if (ALPHA <= 0.F || BOX.intersection(MONITORBOX).empty()) {
             tile->framebuffer.reset();
@@ -286,7 +288,8 @@ bool CWorkspaceTapeController::navigate(int direction) {
     if (TARGET == INDEX)
         return false;
 
-    m_selectedWorkspace = TILES.at(TARGET)->workspace;
+    m_selectedWorkspace  = TILES.at(TARGET)->workspace;
+    m_preferredWorkspace = m_selectedWorkspace;
     updateLayout();
     damageMonitor();
     return true;
@@ -328,14 +331,22 @@ void CWorkspaceTapeController::reconcile(bool initial) {
             retireTile(*tile);
     }
 
+    if (initial) {
+        if (const auto MONITOR = m_monitor.lock(); MONITOR)
+            m_preferredWorkspace = MONITOR->m_activeWorkspace;
+    }
+
     if (WORKSPACES.empty())
         m_selectedWorkspace.reset();
     else if (std::ranges::contains(WORKSPACES, OLD_SELECTED))
         m_selectedWorkspace = OLD_SELECTED;
-    else if (const auto MONITOR = m_monitor.lock(); initial && MONITOR && std::ranges::contains(WORKSPACES, MONITOR->m_activeWorkspace))
-        m_selectedWorkspace = MONITOR->m_activeWorkspace;
+    else if (const auto PREFERRED = m_preferredWorkspace.lock(); PREFERRED && std::ranges::contains(WORKSPACES, PREFERRED))
+        m_selectedWorkspace = PREFERRED;
     else
         m_selectedWorkspace = WORKSPACES.at(std::min(OLD_INDEX, sc<long>(WORKSPACES.size()) - 1L));
+
+    if (const auto SELECTED = selectedWorkspace(); SELECTED)
+        m_preferredWorkspace = SELECTED;
 
     if (const auto MONITOR = m_monitor.lock(); MONITOR && MONITOR->m_activeWorkspace && !tileFor(MONITOR->m_activeWorkspace)) {
         auto tile       = makeUnique<SWorkspaceTile>();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -8,6 +8,8 @@
 #include "../../../config/ConfigValue.hpp"
 #include "../../../config/shared/animation/AnimationTree.hpp"
 #include "../../../desktop/Workspace.hpp"
+#include "../../../desktop/state/WindowState.hpp"
+#include "../../../desktop/view/window/Window.hpp"
 #include "../../../event/EventBus.hpp"
 #include "../../../managers/eventLoop/EventLoopManager.hpp"
 #include "../../../output/Monitor.hpp"
@@ -46,6 +48,8 @@ struct CWorkspaceTapeController::SWorkspaceTile {
     PHLANIMVAR<float>        opacity;
     SP<Render::IFramebuffer> framebuffer;
     SP<Render::IFramebuffer> miniFramebuffer;
+    bool                     miniDirty           = true;
+    bool                     miniValid           = false;
     bool                     inLayout            = false;
     bool                     geometryInitialized = false;
 
@@ -77,10 +81,18 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     m_started       = true;
 
     m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
-        if (g_pEventLoopManager)
-            g_pEventLoopManager->doLater([this] { reconcile(); });
-        else
+        if (!g_pEventLoopManager) {
             reconcile();
+            return;
+        }
+
+        if (m_reconcileLock)
+            return;
+
+        m_reconcileLock = g_pEventLoopManager->doLaterLock([this] {
+            m_reconcileLock.reset();
+            reconcile();
+        });
     });
     m_listeners.removed              = Event::bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF) { reconcile(); });
     m_listeners.renamed              = Event::bus()->m_events.workspace.renamed.listen([this](PHLWORKSPACEREF) { reconcile(); });
@@ -94,26 +106,73 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     m_listeners.monitorLayoutChanged = Event::bus()->m_events.monitor.layoutChanged.listen([this] { reconcile(); });
     m_listeners.monitorPreRender     = Event::bus()->m_events.render.preChecks.listen([this](PHLMONITOR monitor) {
         const auto OVERVIEW_MONITOR = m_monitor.lock();
-        if (!monitor || monitor == OVERVIEW_MONITOR || !monitor->m_damage.hasChanged())
+        if (!monitor || !monitor->m_damage.hasChanged())
             return;
 
-        const auto TILES = layoutTiles();
-        if (std::ranges::none_of(TILES, [&monitor](const auto* tile) {
+        if (monitor == OVERVIEW_MONITOR) {
+            const bool LAYOUT_ANIMATING = m_overviewProgress < 1.F ||
+                std::ranges::any_of(
+                                              m_tiles,
+                                              [](const auto& tile) {
+                                                  return tile->position->isBeingAnimated() || tile->size->isBeingAnimated() || tile->miniPosition->isBeingAnimated() ||
+                                                      tile->miniSize->isBeingAnimated() || tile->miniBorderColor->isBeingAnimated() || tile->opacity->isBeingAnimated();
+                                              });
+            if (LAYOUT_ANIMATING)
+                return;
+
+            for (const auto& tile : m_tiles) {
                 const auto WORKSPACE = tile->workspace.lock();
-                return WORKSPACE && WORKSPACE->m_monitor == monitor;
-            }))
+                if (tile->inLayout && WORKSPACE && WORKSPACE->m_monitor == monitor)
+                    tile->miniDirty = true;
+            }
+            return;
+        }
+
+        bool invalidated = false;
+        for (const auto& tile : m_tiles) {
+            const auto WORKSPACE = tile->workspace.lock();
+            if (!tile->inLayout || !WORKSPACE || WORKSPACE->m_monitor != monitor)
+                continue;
+
+            tile->miniDirty = true;
+            invalidated     = true;
+        }
+
+        if (!invalidated)
             return;
 
         damageMonitor();
     });
-    m_listeners.configRefreshed      = Event::bus()->m_events.config.props_refreshed.listen([this](bool) { updateMiniBorderColors(); });
+    m_listeners.configRefreshed      = Event::bus()->m_events.config.props_refreshed.listen([this](bool) {
+        updateMiniBorderColors();
+        invalidateMiniatures();
+    });
+    m_listeners.windowOpened         = Event::bus()->m_events.window.open.listen([this](PHLWINDOW window) {
+        refreshWindowListeners();
+        invalidateMiniature(window ? window->m_workspace : nullptr);
+    });
+    m_listeners.windowClosed         = Event::bus()->m_events.window.close.listen([this](PHLWINDOW window) {
+        refreshWindowListeners();
+        invalidateMiniature(window ? window->m_workspace : nullptr);
+    });
+    m_listeners.windowMoved          = Event::bus()->m_events.window.moveToWorkspace.listen([this](PHLWINDOW, PHLWORKSPACE) { invalidateMiniatures(); });
+    m_listeners.windowFullscreen     = Event::bus()->m_events.window.fullscreen.listen([this](PHLWINDOW window) { invalidateMiniature(window ? window->m_workspace : nullptr); });
+    m_listeners.windowFloating       = Event::bus()->m_events.window.floating.listen([this](PHLWINDOW window) { invalidateMiniature(window ? window->m_workspace : nullptr); });
+    m_listeners.windowActive =
+        Event::bus()->m_events.window.active.listen([this](PHLWINDOW window, Desktop::eFocusReason) { invalidateMiniature(window ? window->m_workspace : nullptr); });
+    m_listeners.windowPinned = Event::bus()->m_events.window.pin.listen([this](PHLWINDOW) { invalidateMiniatures(); });
+    m_listeners.layerOpened  = Event::bus()->m_events.layer.opened.listen([this](PHLLS) { invalidateMiniatures(); });
+    m_listeners.layerClosed  = Event::bus()->m_events.layer.closed.listen([this](PHLLS) { invalidateMiniatures(); });
 
+    refreshWindowListeners();
     reconcile(true);
 }
 
 void CWorkspaceTapeController::reset() {
     m_started   = false;
     m_listeners = {};
+    m_windowListeners.clear();
+    m_reconcileLock.reset();
 
     for (const auto& tile : m_tiles) {
         if (tile->position)
@@ -134,8 +193,9 @@ void CWorkspaceTapeController::reset() {
     m_selectedWorkspace.reset();
     m_preferredWorkspace.reset();
     m_pressedMiniWorkspace.reset();
-    m_mainArea      = {};
-    m_miniStripArea = {};
+    m_mainArea         = {};
+    m_miniStripArea    = {};
+    m_overviewProgress = 0.F;
     m_resources.reset();
     m_monitor.reset();
 }
@@ -153,6 +213,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
     const auto     ACTIVE     = MONITOR->m_activeWorkspace;
     const auto     SELECTED   = selectedWorkspace();
     const Vector2D FULLSIZE   = MONITOR->m_transformedSize;
+    m_overviewProgress        = PROGRESS;
 
     struct SDrawTile {
         SWorkspaceTile* tile = nullptr;
@@ -185,7 +246,6 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
 
         if (!MAIN_VISIBLE && !MINI_VISIBLE) {
             tile->framebuffer.reset();
-            tile->miniFramebuffer.reset();
             continue;
         }
 
@@ -225,23 +285,45 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         const bool CAN_RENDER = SOURCE_MONITOR && SOURCE_MONITOR->m_enabled && !SOURCE_MONITOR->isMirror() && SOURCE_MONITOR->resources() && BUFFER_SIZE.x > 0 && BUFFER_SIZE.y > 0;
         if (tile.framebuffer && (!CAN_RENDER || tile.framebuffer->m_size != BUFFER_SIZE))
             tile.framebuffer.reset();
-        if (tile.miniFramebuffer && (!CAN_RENDER || tile.miniFramebuffer->m_size != MINI_BUFFER_SIZE))
+        if (tile.miniFramebuffer && CAN_RENDER && tile.miniFramebuffer->m_size != MINI_BUFFER_SIZE) {
             tile.miniFramebuffer.reset();
+            tile.miniDirty = true;
+            tile.miniValid = false;
+        }
         if (!drawTile.mainVisible)
             tile.framebuffer.reset();
 
-        const auto ACQUIRE_BUFFER = [&] {
+        const auto ACQUIRE_BUFFER = [&]() -> SP<Render::IFramebuffer> {
             if (SOURCE_MONITOR == MONITOR) {
                 if (RESOURCES->availableWorkBufferCount() <= reservedWorkBuffers)
-                    return;
+                    return nullptr;
 
-                tile.framebuffer = RESOURCES->getUnusedWorkBuffer();
-            } else
-                tile.framebuffer = RESOURCES->getUnusedWorkBuffer(BUFFER_SIZE);
+                return RESOURCES->getUnusedWorkBuffer();
+            }
+
+            return RESOURCES->getUnusedWorkBuffer(BUFFER_SIZE);
+        };
+
+        const auto UPDATE_MINIATURE = [&](SP<Render::IFramebuffer> source) {
+            if (!source || !source->getTexture() || MINI_BUFFER_SIZE.x <= 0 || MINI_BUFFER_SIZE.y <= 0)
+                return false;
+
+            if (!tile.miniFramebuffer)
+                tile.miniFramebuffer = g_pHyprRenderer->createFB("overview-mini-workspace");
+            if (!tile.miniFramebuffer || !tile.miniFramebuffer->alloc(std::lround(MINI_BUFFER_SIZE.x), std::lround(MINI_BUFFER_SIZE.y)) ||
+                !g_pHyprRenderer->renderTextureToBuffer(context, source->getTexture(), tile.miniFramebuffer)) {
+                if (!tile.miniValid)
+                    tile.miniFramebuffer.reset();
+                return false;
+            }
+
+            tile.miniDirty = false;
+            tile.miniValid = true;
+            return true;
         };
 
         if (drawTile.mainVisible && !tile.framebuffer && CAN_RENDER) {
-            ACQUIRE_BUFFER();
+            tile.framebuffer = ACQUIRE_BUFFER();
 
             for (size_t candidateIndex = drawTiles.size(); !tile.framebuffer && candidateIndex > i + 1; --candidateIndex) {
                 auto&      candidate           = *drawTiles.at(candidateIndex - 1).tile;
@@ -251,7 +333,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
                     continue;
 
                 candidate.framebuffer.reset();
-                ACQUIRE_BUFFER();
+                tile.framebuffer = ACQUIRE_BUFFER();
             }
         }
 
@@ -262,16 +344,12 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         if (!rendered)
             tile.framebuffer.reset();
         else
-            tile.miniFramebuffer.reset();
+            UPDATE_MINIATURE(tile.framebuffer);
 
-        if (!rendered && CAN_RENDER && MINI_BUFFER_SIZE.x > 0 && MINI_BUFFER_SIZE.y > 0) {
-            if (!tile.miniFramebuffer)
-                tile.miniFramebuffer = g_pHyprRenderer->createFB("overview-mini-workspace");
-
-            if (!tile.miniFramebuffer || !tile.miniFramebuffer->alloc(std::lround(MINI_BUFFER_SIZE.x), std::lround(MINI_BUFFER_SIZE.y)) ||
-                !g_pHyprRenderer->renderWorkspaceSceneToBufferScaled(context, WORKSPACE, tile.miniFramebuffer, tp,
-                                                                     drawTile.mainVisible && WORKSPACE->m_visible && SOURCE_MONITOR == MONITOR))
-                tile.miniFramebuffer.reset();
+        if (!rendered && CAN_RENDER && tile.miniDirty) {
+            const auto SCRATCH = ACQUIRE_BUFFER();
+            if (SCRATCH && g_pHyprRenderer->renderWorkspaceSceneToBuffer(context, WORKSPACE, SCRATCH, tp, false))
+                UPDATE_MINIATURE(SCRATCH);
         }
     }
 
@@ -298,7 +376,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
             g_pHyprRenderer->addPassElement(context, makeUnique<CBoxShadowPassElement>(shadow));
         }
 
-        const auto FRAMEBUFFER = tile.framebuffer ? tile.framebuffer : tile.miniFramebuffer;
+        const auto FRAMEBUFFER = tile.framebuffer ? tile.framebuffer : (tile.miniValid ? tile.miniFramebuffer : nullptr);
         if (!FRAMEBUFFER) {
             CRectPassElement::SRectData data;
             data.box   = drawTile.mainBox;
@@ -323,7 +401,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
             continue;
 
         const auto& tile        = *drawTile.tile;
-        const auto  FRAMEBUFFER = tile.framebuffer ? tile.framebuffer : tile.miniFramebuffer;
+        const auto  FRAMEBUFFER = tile.framebuffer ? tile.framebuffer : (tile.miniValid ? tile.miniFramebuffer : nullptr);
         if (!FRAMEBUFFER) {
             CRectPassElement::SRectData data;
             data.box     = drawTile.miniBox;
@@ -452,6 +530,9 @@ bool CWorkspaceTapeController::navigate(int direction) {
 void CWorkspaceTapeController::reconcile(bool initial) {
     if (!m_started)
         return;
+
+    for (const auto& tile : m_tiles)
+        tile->miniDirty = true;
 
     const auto OLD_LAYOUT   = layoutTiles();
     const auto OLD_SELECTED = selectedWorkspace();
@@ -660,6 +741,44 @@ void CWorkspaceTapeController::updateMiniBorderColors(bool warp) {
     }
 
     damageMiniStrip();
+}
+
+void CWorkspaceTapeController::invalidateMiniatures() {
+    if (m_tiles.empty())
+        return;
+
+    for (const auto& tile : m_tiles)
+        tile->miniDirty = true;
+
+    damageMonitor();
+}
+
+void CWorkspaceTapeController::invalidateMiniature(PHLWORKSPACE workspace) {
+    auto* tile = tileFor(workspace);
+    if (!tile)
+        return;
+
+    tile->miniDirty = true;
+    damageMonitor();
+}
+
+void CWorkspaceTapeController::refreshWindowListeners() {
+    m_windowListeners.clear();
+
+    for (const auto& window : Desktop::windowState()->windows()) {
+        if (!window)
+            continue;
+
+        const PHLWINDOWREF WINDOW = window;
+        m_windowListeners.emplace_back(window->backend().m_events.commit.listen([this, WINDOW](bool) {
+            if (const auto LOCKED = WINDOW.lock(); LOCKED)
+                invalidateMiniature(LOCKED->m_workspace);
+        }));
+        m_windowListeners.emplace_back(window->backend().m_events.geometryChanged.listen([this, WINDOW](const CBox&) {
+            if (const auto LOCKED = WINDOW.lock(); LOCKED)
+                invalidateMiniature(LOCKED->m_workspace);
+        }));
+    }
 }
 
 CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileFor(PHLWORKSPACE workspace) const {

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -91,7 +91,7 @@ void CWorkspaceTapeController::reset() {
     m_monitor.reset();
 }
 
-void CWorkspaceTapeController::draw(Time::steady_tp tp, float overviewProgress) {
+void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::steady_tp tp, float overviewProgress) {
     const auto MONITOR   = m_monitor.lock();
     const auto RESOURCES = m_resources;
     if (!m_started || !MONITOR || !RESOURCES || !g_pHyprRenderer)
@@ -152,7 +152,7 @@ void CWorkspaceTapeController::draw(Time::steady_tp tp, float overviewProgress) 
 
         bool rendered = false;
         if (CAN_RENDER && tile.framebuffer)
-            rendered = g_pHyprRenderer->renderWorkspaceSceneToBuffer(WORKSPACE, tile.framebuffer, tp, drawTile.selected);
+            rendered = g_pHyprRenderer->renderWorkspaceSceneToBuffer(context, WORKSPACE, tile.framebuffer, tp, drawTile.selected);
 
         if (!rendered && tile.inLayout)
             tile.framebuffer.reset();
@@ -162,7 +162,7 @@ void CWorkspaceTapeController::draw(Time::steady_tp tp, float overviewProgress) 
             data.box   = drawTile.box;
             data.color = CHyprColor(PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, drawTile.opacity);
             data.round = ROUNDING;
-            g_pHyprRenderer->addPassElement(makeUnique<CRectPassElement>(data));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(data));
             continue;
         }
 
@@ -172,7 +172,7 @@ void CWorkspaceTapeController::draw(Time::steady_tp tp, float overviewProgress) 
         data.a       = drawTile.opacity;
         data.round   = ROUNDING;
         data.clipBox = MONITORBOX;
-        g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+        g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -84,11 +84,14 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     if (!monitor || !resources)
         return;
 
-    m_monitor         = monitor;
-    m_resources       = resources;
-    m_mainArea        = layout.pixelMain;
-    m_miniStripArea   = layout.pixelMiniStrip;
-    m_started         = true;
+    m_monitor       = monitor;
+    m_resources     = resources;
+    m_mainArea      = layout.pixelMain;
+    m_miniStripArea = layout.pixelMiniStrip;
+    m_started       = true;
+
+    Animation::mgr()->createAnimation(0.F, m_mainOffset, Config::animationTree()->getAnimationPropertyConfig("overviewMove"), AVARDAMAGE_NONE);
+    m_mainOffset->setUpdateCallback([this](auto) { damageMonitor(); });
 
     m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
         if (!g_pEventLoopManager) {
@@ -120,7 +123,7 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
             return;
 
         if (monitor == OVERVIEW_MONITOR) {
-            const bool LAYOUT_ANIMATING = m_overviewProgress < 1.F ||
+            const bool LAYOUT_ANIMATING = m_overviewProgress < 1.F || (m_mainOffset && m_mainOffset->isBeingAnimated()) ||
                 std::ranges::any_of(
                                               m_tiles,
                                               [](const auto& tile) {
@@ -184,6 +187,9 @@ void CWorkspaceTapeController::reset() {
     m_windowListeners.clear();
     m_reconcileLock.reset();
 
+    if (m_mainOffset)
+        m_mainOffset->resetAllCallbacks();
+
     for (const auto& tile : m_tiles) {
         if (tile->position)
             tile->position->resetAllCallbacks();
@@ -203,6 +209,7 @@ void CWorkspaceTapeController::reset() {
     m_selectedWorkspace.reset();
     m_preferredWorkspace.reset();
     m_pressedWorkspace.reset();
+    m_mainOffset.reset();
     m_mainArea           = {};
     m_miniStripArea      = {};
     m_overviewProgress   = 0.F;
@@ -232,7 +239,8 @@ CBox CWorkspaceTapeController::mainBoxFor(const SWorkspaceTile& tile, PHLMONITOR
     const Vector2D OPENPOS    = tile.position->value();
     const Vector2D OPENSIZE   = tile.size->value();
     const Vector2D FULLSIZE   = monitor->m_transformedSize;
-    const Vector2D POS        = IS_ACTIVE ? OPENPOS * m_overviewProgress : OPENPOS;
+    const Vector2D OFFSET     = {m_mainOffset ? m_mainOffset->value() : 0.F, 0.F};
+    const Vector2D POS        = (IS_ACTIVE ? OPENPOS * m_overviewProgress : OPENPOS) + OFFSET;
     const Vector2D SIZE       = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * m_overviewProgress : OPENSIZE;
 
     return CBox{POS, SIZE}.round();
@@ -480,6 +488,29 @@ void CWorkspaceTapeController::useSelectedWorkspaceForFullscreen(bool x) {
     m_fullscreenSelected = x;
 }
 
+bool CWorkspaceTapeController::beginMoveGesture() {
+    if (!m_started || !m_mainOffset)
+        return false;
+
+    m_mainOffset->setValueAndWarp(m_mainOffset->value());
+    return true;
+}
+
+void CWorkspaceTapeController::updateMoveGesture(float delta) {
+    if (!m_started || !m_mainOffset || !std::isfinite(delta))
+        return;
+
+    m_mainOffset->setValueAndWarp(m_mainOffset->value() + delta);
+}
+
+void CWorkspaceTapeController::endMoveGesture() {
+    if (!m_started || !m_mainOffset)
+        return;
+
+    m_mainOffset->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
+    *m_mainOffset = 0.F;
+}
+
 bool CWorkspaceTapeController::navigateLeft() {
     return navigate(-1);
 }
@@ -537,8 +568,7 @@ bool CWorkspaceTapeController::pointerButton(uint32_t button, bool pressed, cons
     if (!workspace) {
         // mega workspace pointer logic
 
-        const auto CURSOR    = Pointer::mgr()->untransformedPosition();
-        const auto TILE = tileAt(CURSOR);
+        const auto TILE = tileAt(monitorLocal);
 
         if (TILE)
             workspace = TILE->workspace.lock();
@@ -899,11 +929,16 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
 }
 
 CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileAt(const Vector2D& monitorLocal) const {
-    auto tiles = layoutTiles();
+    const auto MONITOR = m_monitor.lock();
+    if (!MONITOR)
+        return nullptr;
 
-    for (const auto& t : tiles) {
-        if (CBox{t->position->goal(), t->size->goal()}.containsPoint(monitorLocal))
-            return t;
+    const auto PIXEL = monitorLocal * MONITOR->m_scale;
+    const auto TILES = layoutTiles();
+
+    for (const auto& tile : TILES) {
+        if (mainBoxFor(*tile, MONITOR).containsPoint(PIXEL))
+            return tile;
     }
 
     return nullptr;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -8,6 +8,7 @@
 #include "../../../animation/AnimationManager.hpp"
 #include "../../../config/ConfigValue.hpp"
 #include "../../../config/shared/animation/AnimationTree.hpp"
+#include "../../../config/shared/workspace/WorkspaceRuleManager.hpp"
 #include "../../../desktop/Workspace.hpp"
 #include "../../../desktop/state/WindowState.hpp"
 #include "../../../desktop/DesktopTypes.hpp"
@@ -27,6 +28,7 @@
 #include <algorithm>
 #include <cmath>
 #include <hyprutils/memory/WeakPtr.hpp>
+#include <limits>
 #include <ranges>
 
 #include <linux/input-event-codes.h>
@@ -214,6 +216,7 @@ void CWorkspaceTapeController::reset() {
     m_selectedWorkspace.reset();
     m_preferredWorkspace.reset();
     m_pressedWorkspace.reset();
+    m_createdWorkspace.reset();
     m_mainOffset.reset();
     m_mainArea                 = {};
     m_miniStripArea            = {};
@@ -521,8 +524,48 @@ bool CWorkspaceTapeController::navigateLeft() {
     return navigate(-1);
 }
 
-bool CWorkspaceTapeController::navigateRight() {
-    return navigate(1);
+eWorkspaceNavigationResult CWorkspaceTapeController::navigateRight(bool allowCreate, bool willReceiveWindow) {
+    if (navigate(1))
+        return eWorkspaceNavigationResult::EXISTING;
+
+    const auto TILES    = layoutTiles();
+    const auto SELECTED = selectedWorkspace();
+    const auto LAST     = TILES.empty() ? nullptr : TILES.back()->workspace.lock();
+    const auto MONITOR  = SELECTED ? SELECTED->m_monitor.lock() : nullptr;
+    if (!allowCreate || !SELECTED || SELECTED != LAST || SELECTED->m_id <= 0 || SELECTED->getWindowCount() == 0 || !MONITOR)
+        return eWorkspaceNavigationResult::NONE;
+
+    WORKSPACEID workspaceID      = SELECTED->m_id;
+    bool        availableIDFound = false;
+    while (workspaceID < std::numeric_limits<WORKSPACEID>::max()) {
+        workspaceID++;
+        if (State::workspaceState()->query().id(workspaceID).run())
+            continue;
+
+        const auto BOUND_MONITOR = Config::workspaceRuleMgr()->getBoundMonitorForWS(std::to_string(workspaceID));
+        if (BOUND_MONITOR && BOUND_MONITOR != MONITOR)
+            continue;
+
+        availableIDFound = true;
+        break;
+    }
+
+    if (!availableIDFound)
+        return eWorkspaceNavigationResult::NONE;
+
+    auto workspace = State::workspaceState()->create(workspaceID, MONITOR->m_id, "", !willReceiveWindow);
+    if (!workspace || workspace->m_monitor != MONITOR)
+        return eWorkspaceNavigationResult::NONE;
+
+    m_createdWorkspace  = workspace;
+    m_selectedWorkspace = workspace;
+    reconcile();
+    if (selectedWorkspace() != workspace) {
+        m_createdWorkspace.reset();
+        return eWorkspaceNavigationResult::NONE;
+    }
+
+    return eWorkspaceNavigationResult::CREATED;
 }
 
 bool CWorkspaceTapeController::selectWorkspace(PHLWORKSPACE workspace) {
@@ -537,6 +580,7 @@ bool CWorkspaceTapeController::selectWorkspace(PHLWORKSPACE workspace) {
     m_preferredWorkspace = workspace;
     updateLayout();
     damageMonitor();
+    releaseUnselectedCreatedWorkspace();
     return true;
 }
 
@@ -635,6 +679,13 @@ void CWorkspaceTapeController::scheduleReconcile(bool invalidateMiniatures) {
     });
 }
 
+void CWorkspaceTapeController::releaseUnselectedCreatedWorkspace() {
+    if (!m_createdWorkspace || m_createdWorkspace == selectedWorkspace())
+        return;
+
+    m_createdWorkspace.reset();
+}
+
 bool CWorkspaceTapeController::navigate(int direction) {
     const auto TILES = layoutTiles();
     if (!m_started || TILES.empty() || direction == 0)
@@ -719,6 +770,7 @@ void CWorkspaceTapeController::reconcile(bool initial, bool invalidateMiniatures
 
     updateLayout(initial);
     damageMonitor();
+    releaseUnselectedCreatedWorkspace();
 }
 
 void CWorkspaceTapeController::updateLayout(bool warp) {

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -1,8 +1,11 @@
 #include "WorkspaceTapeController.hpp"
+#include "OverviewLayout.hpp"
 #include "WorkspaceTapeLayout.hpp"
+#include "WorkspaceMiniStripLayout.hpp"
 #include "WorkspaceTileShadow.hpp"
 
 #include "../../../animation/AnimationManager.hpp"
+#include "../../../config/ConfigValue.hpp"
 #include "../../../config/shared/animation/AnimationTree.hpp"
 #include "../../../desktop/Workspace.hpp"
 #include "../../../event/EventBus.hpp"
@@ -10,6 +13,7 @@
 #include "../../../output/Monitor.hpp"
 #include "../../../output/MonitorResources.hpp"
 #include "../../../render/Renderer.hpp"
+#include "../../../render/pass/BorderPassElement.hpp"
 #include "../../../render/pass/BoxShadowPassElement.hpp"
 #include "../../../render/pass/RectPassElement.hpp"
 #include "../../../render/pass/TexPassElement.hpp"
@@ -19,20 +23,29 @@
 #include <cmath>
 #include <ranges>
 
+#include <linux/input-event-codes.h>
+
 using namespace Overview::Hyprland;
 
-static constexpr float TILE_GAP          = 0.02F;
-static constexpr float TILE_ROUNDING     = 20.F;
-static constexpr float TILE_SHADOW_RANGE = 14.F;
-static constexpr float TILE_SHADOW_ALPHA = 0.45F;
-static constexpr float PLACEHOLDER_GRAY  = 0.12F;
+static constexpr float MAIN_TILE_GAP         = 0.02F;
+static constexpr float MINI_TILE_GAP         = 0.15F;
+static constexpr float TILE_ROUNDING         = 20.F;
+static constexpr float MINI_TILE_ROUNDING    = 8.F;
+static constexpr int   MINI_TILE_BORDER_SIZE = 3;
+static constexpr float TILE_SHADOW_RANGE     = 14.F;
+static constexpr float TILE_SHADOW_ALPHA     = 0.45F;
+static constexpr float PLACEHOLDER_GRAY      = 0.12F;
 
 struct CWorkspaceTapeController::SWorkspaceTile {
     PHLWORKSPACEREF          workspace;
     PHLANIMVAR<Vector2D>     position;
     PHLANIMVAR<Vector2D>     size;
+    PHLANIMVAR<Vector2D>     miniPosition;
+    PHLANIMVAR<Vector2D>     miniSize;
+    PHLANIMVAR<CHyprColor>   miniBorderColor;
     PHLANIMVAR<float>        opacity;
     SP<Render::IFramebuffer> framebuffer;
+    SP<Render::IFramebuffer> miniFramebuffer;
     bool                     inLayout            = false;
     bool                     geometryInitialized = false;
 
@@ -51,15 +64,17 @@ CWorkspaceTapeController::~CWorkspaceTapeController() {
     reset();
 }
 
-void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources) {
+void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources, const OverviewLayout::SLayout& layout) {
     reset();
 
     if (!monitor || !resources)
         return;
 
-    m_monitor   = monitor;
-    m_resources = resources;
-    m_started   = true;
+    m_monitor       = monitor;
+    m_resources     = resources;
+    m_mainArea      = layout.pixelMain;
+    m_miniStripArea = layout.pixelMiniStrip;
+    m_started       = true;
 
     m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
         if (g_pEventLoopManager)
@@ -91,6 +106,7 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
 
         damageMonitor();
     });
+    m_listeners.configRefreshed      = Event::bus()->m_events.config.props_refreshed.listen([this](bool) { updateMiniBorderColors(); });
 
     reconcile(true);
 }
@@ -104,6 +120,12 @@ void CWorkspaceTapeController::reset() {
             tile->position->resetAllCallbacks();
         if (tile->size)
             tile->size->resetAllCallbacks();
+        if (tile->miniPosition)
+            tile->miniPosition->resetAllCallbacks();
+        if (tile->miniSize)
+            tile->miniSize->resetAllCallbacks();
+        if (tile->miniBorderColor)
+            tile->miniBorderColor->resetAllCallbacks();
         if (tile->opacity)
             tile->opacity->resetAllCallbacks();
     }
@@ -111,6 +133,9 @@ void CWorkspaceTapeController::reset() {
     m_tiles.clear();
     m_selectedWorkspace.reset();
     m_preferredWorkspace.reset();
+    m_pressedMiniWorkspace.reset();
+    m_mainArea      = {};
+    m_miniStripArea = {};
     m_resources.reset();
     m_monitor.reset();
 }
@@ -131,9 +156,13 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
 
     struct SDrawTile {
         SWorkspaceTile* tile = nullptr;
-        CBox            box;
-        float           opacity  = 0.F;
-        bool            selected = false;
+        CBox            mainBox;
+        CBox            miniBox;
+        float           mainOpacity = 0.F;
+        float           miniOpacity = 0.F;
+        bool            mainVisible = false;
+        bool            miniVisible = false;
+        bool            selected    = false;
     };
 
     std::vector<SDrawTile> drawTiles;
@@ -145,31 +174,44 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         const auto     OPENPOS   = tile->position->value();
         const auto     OPENSIZE  = tile->size->value();
 
-        const Vector2D POS   = IS_ACTIVE ? OPENPOS * PROGRESS : OPENPOS;
-        const Vector2D SIZE  = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * PROGRESS : OPENSIZE;
-        const float    ALPHA = IS_ACTIVE ? (1.F - PROGRESS) + tile->opacity->value() * PROGRESS : tile->opacity->value() * PROGRESS;
-        const CBox     BOX = CBox{POS, SIZE}.round();
+        const Vector2D POS          = IS_ACTIVE ? OPENPOS * PROGRESS : OPENPOS;
+        const Vector2D SIZE         = IS_ACTIVE ? FULLSIZE + (OPENSIZE - FULLSIZE) * PROGRESS : OPENSIZE;
+        const float    ALPHA        = IS_ACTIVE ? (1.F - PROGRESS) + tile->opacity->value() * PROGRESS : tile->opacity->value() * PROGRESS;
+        const CBox     MAIN_BOX     = CBox{POS, SIZE}.round();
+        const CBox     MINI_BOX     = CBox{tile->miniPosition->value(), tile->miniSize->value()}.round();
+        const float    MINI_ALPHA   = tile->opacity->value() * PROGRESS;
+        const bool     MAIN_VISIBLE = ALPHA > 0.F && !MAIN_BOX.intersection(MONITORBOX).empty();
+        const bool     MINI_VISIBLE = MINI_ALPHA > 0.F && !MINI_BOX.intersection(m_miniStripArea).empty();
 
-        if (ALPHA <= 0.F || BOX.intersection(MONITORBOX).empty()) {
+        if (!MAIN_VISIBLE && !MINI_VISIBLE) {
             tile->framebuffer.reset();
+            tile->miniFramebuffer.reset();
             continue;
         }
 
         drawTiles.emplace_back(SDrawTile{
-            .tile     = tile.get(),
-            .box      = BOX,
-            .opacity  = ALPHA,
-            .selected = WORKSPACE && WORKSPACE == SELECTED,
+            .tile        = tile.get(),
+            .mainBox     = MAIN_BOX,
+            .miniBox     = MINI_BOX,
+            .mainOpacity = ALPHA,
+            .miniOpacity = MINI_ALPHA,
+            .mainVisible = MAIN_VISIBLE,
+            .miniVisible = MINI_VISIBLE,
+            .selected    = WORKSPACE && WORKSPACE == SELECTED,
         });
     }
 
     std::ranges::stable_sort(drawTiles, [&MONITORBOX](const auto& lhs, const auto& rhs) {
         if (lhs.selected != rhs.selected)
             return lhs.selected;
+        if (lhs.mainVisible != rhs.mainVisible)
+            return lhs.mainVisible;
 
         const double MONITOR_CENTER = MONITORBOX.x + MONITORBOX.w / 2.0;
-        const double LHS_DISTANCE   = std::abs(lhs.box.x + lhs.box.w / 2.0 - MONITOR_CENTER);
-        const double RHS_DISTANCE   = std::abs(rhs.box.x + rhs.box.w / 2.0 - MONITOR_CENTER);
+        const auto&  LHS_BOX        = lhs.mainVisible ? lhs.mainBox : lhs.miniBox;
+        const auto&  RHS_BOX        = rhs.mainVisible ? rhs.mainBox : rhs.miniBox;
+        const double LHS_DISTANCE   = std::abs(LHS_BOX.x + LHS_BOX.w / 2.0 - MONITOR_CENTER);
+        const double RHS_DISTANCE   = std::abs(RHS_BOX.x + RHS_BOX.w / 2.0 - MONITOR_CENTER);
         return LHS_DISTANCE < RHS_DISTANCE;
     });
     for (size_t i = 0; i < drawTiles.size(); ++i) {
@@ -177,10 +219,15 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         auto&      tile      = *drawTile.tile;
         const auto WORKSPACE = tile.workspace.lock();
 
-        const auto SOURCE_MONITOR = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
-        const auto BUFFER_SIZE    = SOURCE_MONITOR ? SOURCE_MONITOR->m_transformedSize : Vector2D{};
+        const auto SOURCE_MONITOR   = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
+        const auto BUFFER_SIZE      = SOURCE_MONITOR ? SOURCE_MONITOR->m_transformedSize : Vector2D{};
+        const auto MINI_BUFFER_SIZE = drawTile.miniBox.size();
         const bool CAN_RENDER = SOURCE_MONITOR && SOURCE_MONITOR->m_enabled && !SOURCE_MONITOR->isMirror() && SOURCE_MONITOR->resources() && BUFFER_SIZE.x > 0 && BUFFER_SIZE.y > 0;
         if (tile.framebuffer && (!CAN_RENDER || tile.framebuffer->m_size != BUFFER_SIZE))
+            tile.framebuffer.reset();
+        if (tile.miniFramebuffer && (!CAN_RENDER || tile.miniFramebuffer->m_size != MINI_BUFFER_SIZE))
+            tile.miniFramebuffer.reset();
+        if (!drawTile.mainVisible)
             tile.framebuffer.reset();
 
         const auto ACQUIRE_BUFFER = [&] {
@@ -193,7 +240,7 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
                 tile.framebuffer = RESOURCES->getUnusedWorkBuffer(BUFFER_SIZE);
         };
 
-        if (!tile.framebuffer && CAN_RENDER) {
+        if (drawTile.mainVisible && !tile.framebuffer && CAN_RENDER) {
             ACQUIRE_BUFFER();
 
             for (size_t candidateIndex = drawTiles.size(); !tile.framebuffer && candidateIndex > i + 1; --candidateIndex) {
@@ -212,21 +259,36 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         if (CAN_RENDER && tile.framebuffer)
             rendered = g_pHyprRenderer->renderWorkspaceSceneToBuffer(context, WORKSPACE, tile.framebuffer, tp, WORKSPACE->m_visible && SOURCE_MONITOR == MONITOR);
 
-        if (!rendered && tile.inLayout)
+        if (!rendered)
             tile.framebuffer.reset();
+        else
+            tile.miniFramebuffer.reset();
+
+        if (!rendered && CAN_RENDER && MINI_BUFFER_SIZE.x > 0 && MINI_BUFFER_SIZE.y > 0) {
+            if (!tile.miniFramebuffer)
+                tile.miniFramebuffer = g_pHyprRenderer->createFB("overview-mini-workspace");
+
+            if (!tile.miniFramebuffer || !tile.miniFramebuffer->alloc(std::lround(MINI_BUFFER_SIZE.x), std::lround(MINI_BUFFER_SIZE.y)) ||
+                !g_pHyprRenderer->renderWorkspaceSceneToBufferScaled(context, WORKSPACE, tile.miniFramebuffer, tp,
+                                                                     drawTile.mainVisible && WORKSPACE->m_visible && SOURCE_MONITOR == MONITOR))
+                tile.miniFramebuffer.reset();
+        }
     }
 
     std::ranges::stable_sort(drawTiles, [](const auto& lhs, const auto& rhs) { return lhs.selected < rhs.selected; });
 
     const int ROUNDING = std::lround(TILE_ROUNDING * MONITOR->m_scale * PROGRESS);
     for (const auto& drawTile : drawTiles) {
+        if (!drawTile.mainVisible)
+            continue;
+
         const auto& tile = *drawTile.tile;
 
-        const auto  SHADOW = WorkspaceTileShadow::calculate(drawTile.box, MONITOR->m_scale, drawTile.opacity, PROGRESS, TILE_SHADOW_RANGE, TILE_ROUNDING);
+        const auto  SHADOW = WorkspaceTileShadow::calculate(drawTile.mainBox, MONITOR->m_scale, drawTile.mainOpacity, PROGRESS, TILE_SHADOW_RANGE, TILE_ROUNDING);
         if (SHADOW) {
             CBoxShadowPassElement::SBoxShadowData shadow;
             shadow.box           = SHADOW->outerBox;
-            shadow.cutoutBox     = drawTile.box;
+            shadow.cutoutBox     = drawTile.mainBox;
             shadow.clipBox       = MONITORBOX;
             shadow.color         = CHyprColor(0.F, 0.F, 0.F, TILE_SHADOW_ALPHA);
             shadow.a             = SHADOW->opacity;
@@ -236,22 +298,58 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
             g_pHyprRenderer->addPassElement(context, makeUnique<CBoxShadowPassElement>(shadow));
         }
 
-        if (!tile.framebuffer) {
+        const auto FRAMEBUFFER = tile.framebuffer ? tile.framebuffer : tile.miniFramebuffer;
+        if (!FRAMEBUFFER) {
             CRectPassElement::SRectData data;
-            data.box   = drawTile.box;
-            data.color = CHyprColor(PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, drawTile.opacity);
+            data.box   = drawTile.mainBox;
+            data.color = CHyprColor(PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, drawTile.mainOpacity);
             data.round = ROUNDING;
             g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(data));
             continue;
         }
 
         CTexPassElement::SRenderData data;
-        data.tex     = tile.framebuffer->getTexture();
-        data.box     = drawTile.box;
-        data.a       = drawTile.opacity;
+        data.tex     = FRAMEBUFFER->getTexture();
+        data.box     = drawTile.mainBox;
+        data.a       = drawTile.mainOpacity;
         data.round   = ROUNDING;
         data.clipBox = MONITORBOX;
         g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
+    }
+
+    const int MINI_ROUNDING = std::lround(MINI_TILE_ROUNDING * MONITOR->m_scale);
+    for (const auto& drawTile : drawTiles) {
+        if (!drawTile.miniVisible)
+            continue;
+
+        const auto& tile        = *drawTile.tile;
+        const auto  FRAMEBUFFER = tile.framebuffer ? tile.framebuffer : tile.miniFramebuffer;
+        if (!FRAMEBUFFER) {
+            CRectPassElement::SRectData data;
+            data.box     = drawTile.miniBox;
+            data.color   = CHyprColor(PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, PLACEHOLDER_GRAY, drawTile.miniOpacity);
+            data.round   = MINI_ROUNDING;
+            data.clipBox = m_miniStripArea;
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(data));
+        } else {
+            CTexPassElement::SRenderData data;
+            data.tex     = FRAMEBUFFER->getTexture();
+            data.box     = drawTile.miniBox;
+            data.a       = drawTile.miniOpacity;
+            data.round   = MINI_ROUNDING;
+            data.clipBox = m_miniStripArea;
+            g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
+        }
+
+        CBorderPassElement::SBorderData border;
+        border.box           = drawTile.miniBox;
+        border.grad1         = Config::CGradientValueData{tile.miniBorderColor->value()};
+        border.a             = drawTile.miniOpacity;
+        border.round         = MINI_ROUNDING;
+        border.outerRound    = MINI_ROUNDING;
+        border.borderSize    = MINI_TILE_BORDER_SIZE;
+        border.roundingPower = 2.F;
+        g_pHyprRenderer->addPassElement(context, makeUnique<CBorderPassElement>(border));
     }
 }
 
@@ -263,8 +361,68 @@ bool CWorkspaceTapeController::navigateRight() {
     return navigate(1);
 }
 
+bool CWorkspaceTapeController::selectWorkspace(PHLWORKSPACE workspace) {
+    if (!m_started || !workspace || workspace == selectedWorkspace())
+        return false;
+
+    const auto TILES = layoutTiles();
+    if (std::ranges::none_of(TILES, [&workspace](const auto* tile) { return tile->workspace == workspace; }))
+        return false;
+
+    m_selectedWorkspace  = workspace;
+    m_preferredWorkspace = workspace;
+    updateLayout();
+    damageMonitor();
+    return true;
+}
+
 PHLWORKSPACE CWorkspaceTapeController::selectedWorkspace() const {
     return m_selectedWorkspace.lock();
+}
+
+PHLWORKSPACE CWorkspaceTapeController::miniWorkspaceAt(const Vector2D& monitorLocal) const {
+    const auto MONITOR = m_monitor.lock();
+    if (!m_started || !MONITOR)
+        return nullptr;
+
+    const auto PIXEL = monitorLocal * MONITOR->m_scale;
+    if (!m_miniStripArea.containsPoint(PIXEL))
+        return nullptr;
+
+    for (const auto& tile : m_tiles) {
+        if (!tile->inLayout)
+            continue;
+
+        if (!CBox{tile->miniPosition->value(), tile->miniSize->value()}.containsPoint(PIXEL))
+            continue;
+
+        return tile->workspace.lock();
+    }
+
+    return nullptr;
+}
+
+bool CWorkspaceTapeController::pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal) {
+    if (button != BTN_LEFT)
+        return false;
+
+    const auto WORKSPACE = miniWorkspaceAt(monitorLocal);
+    if (pressed) {
+        if (!WORKSPACE)
+            return false;
+
+        m_pressedMiniWorkspace = WORKSPACE;
+        return true;
+    }
+
+    const auto PRESSED = m_pressedMiniWorkspace.lock();
+    m_pressedMiniWorkspace.reset();
+    if (!PRESSED)
+        return false;
+
+    if (WORKSPACE == PRESSED)
+        selectWorkspace(PRESSED);
+    return true;
 }
 
 void CWorkspaceTapeController::setFilter(FWorkspaceFilter filter) {
@@ -288,11 +446,7 @@ bool CWorkspaceTapeController::navigate(int direction) {
     if (TARGET == INDEX)
         return false;
 
-    m_selectedWorkspace  = TILES.at(TARGET)->workspace;
-    m_preferredWorkspace = m_selectedWorkspace;
-    updateLayout();
-    damageMonitor();
-    return true;
+    return selectWorkspace(TILES.at(TARGET)->workspace.lock());
 }
 
 void CWorkspaceTapeController::reconcile(bool initial) {
@@ -379,23 +533,31 @@ void CWorkspaceTapeController::updateLayout(bool warp) {
         sourceSizes.emplace_back(SOURCE ? SOURCE->m_transformedSize : MONITOR->m_transformedSize);
     }
 
-    const auto BOXES        = WorkspaceTapeLayout::calculate(MONITOR->m_transformedSize, sourceSizes, INDEX, TILE_SCALE, TILE_GAP);
-    const auto REGULAR_SIZE = MONITOR->m_transformedSize * TILE_SCALE;
+    const auto BOXES      = WorkspaceTapeLayout::calculate(m_mainArea, sourceSizes, INDEX, MAIN_TILE_GAP);
+    const auto MINI_BOXES = WorkspaceMiniStripLayout::calculate(m_miniStripArea, sourceSizes, INDEX, MINI_TILE_GAP);
 
     for (size_t i = 0; i < TILES.size(); ++i) {
         auto& tile = *TILES.at(i);
         tile.position->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
         tile.size->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
+        tile.miniPosition->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
+        tile.miniSize->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
 
-        const auto POSITION = BOXES.at(i).pos();
-        const auto SIZE     = BOXES.at(i).size();
+        const auto POSITION      = BOXES.at(i).pos();
+        const auto SIZE          = BOXES.at(i).size();
+        const auto MINI_POSITION = MINI_BOXES.at(i).pos();
+        const auto MINI_SIZE     = MINI_BOXES.at(i).size();
         if (warp || !tile.geometryInitialized) {
             tile.position->setValueAndWarp(POSITION);
             tile.size->setValueAndWarp(SIZE);
+            tile.miniPosition->setValueAndWarp(MINI_POSITION);
+            tile.miniSize->setValueAndWarp(MINI_SIZE);
             tile.geometryInitialized = true;
         } else {
-            *tile.position = POSITION;
-            *tile.size     = SIZE;
+            *tile.position     = POSITION;
+            *tile.size         = SIZE;
+            *tile.miniPosition = MINI_POSITION;
+            *tile.miniSize     = MINI_SIZE;
         }
     }
 
@@ -407,16 +569,25 @@ void CWorkspaceTapeController::updateLayout(bool warp) {
         if (!WORKSPACE || WORKSPACE != MONITOR->m_activeWorkspace)
             continue;
 
-        const Vector2D POSITION = (MONITOR->m_transformedSize - REGULAR_SIZE) / 2.F;
+        const auto SOURCE       = WORKSPACE->m_monitor.lock();
+        const auto SOURCE_SIZE  = SOURCE ? SOURCE->m_transformedSize : MONITOR->m_transformedSize;
+        const auto ACTIVE_BOXES = WorkspaceTapeLayout::calculate(m_mainArea, std::span<const Vector2D>{&SOURCE_SIZE, 1}, 0, MAIN_TILE_GAP);
+        if (ACTIVE_BOXES.empty())
+            continue;
+
+        const auto POSITION = ACTIVE_BOXES.front().pos();
+        const auto SIZE     = ACTIVE_BOXES.front().size();
         if (warp || !tile->geometryInitialized) {
             tile->position->setValueAndWarp(POSITION);
-            tile->size->setValueAndWarp(REGULAR_SIZE);
+            tile->size->setValueAndWarp(SIZE);
             tile->geometryInitialized = true;
         } else {
             *tile->position = POSITION;
-            *tile->size     = REGULAR_SIZE;
+            *tile->size     = SIZE;
         }
     }
+
+    updateMiniBorderColors(warp);
 }
 
 void CWorkspaceTapeController::retireTile(SWorkspaceTile& tile) {
@@ -425,21 +596,30 @@ void CWorkspaceTapeController::retireTile(SWorkspaceTile& tile) {
 
     tile.position->setValueAndWarp(tile.position->value());
     tile.size->setValueAndWarp(tile.size->value());
+    tile.miniPosition->setValueAndWarp(tile.miniPosition->value());
+    tile.miniSize->setValueAndWarp(tile.miniSize->value());
     tile.opacity->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewFade"));
     *tile.opacity = 0.F;
 }
 
 void CWorkspaceTapeController::ensureAnimations(SWorkspaceTile& tile) {
-    const auto MOVE = Config::animationTree()->getAnimationPropertyConfig("overviewMove");
-    const auto FADE = Config::animationTree()->getAnimationPropertyConfig("overviewFade");
+    const auto  MOVE                 = Config::animationTree()->getAnimationPropertyConfig("overviewMove");
+    const auto  FADE                 = Config::animationTree()->getAnimationPropertyConfig("overviewFade");
+    static auto PINACTIVEBORDERCOLOR = CConfigValue<Config::INTEGER>("overview:col.inactive_border");
 
     Animation::mgr()->createAnimation(Vector2D{}, tile.position, MOVE, AVARDAMAGE_NONE);
     Animation::mgr()->createAnimation(Vector2D{}, tile.size, MOVE, AVARDAMAGE_NONE);
+    Animation::mgr()->createAnimation(Vector2D{}, tile.miniPosition, MOVE, AVARDAMAGE_NONE);
+    Animation::mgr()->createAnimation(Vector2D{}, tile.miniSize, MOVE, AVARDAMAGE_NONE);
+    Animation::mgr()->createAnimation(CHyprColor(*PINACTIVEBORDERCOLOR), tile.miniBorderColor, FADE, AVARDAMAGE_NONE);
     Animation::mgr()->createAnimation(0.F, tile.opacity, FADE, AVARDAMAGE_NONE);
 
     const auto DAMAGE = [this](auto) { damageMonitor(); };
     tile.position->setUpdateCallback(DAMAGE);
     tile.size->setUpdateCallback(DAMAGE);
+    tile.miniPosition->setUpdateCallback(DAMAGE);
+    tile.miniSize->setUpdateCallback(DAMAGE);
+    tile.miniBorderColor->setUpdateCallback([this](auto) { damageMiniStrip(); });
     tile.opacity->setUpdateCallback(DAMAGE);
 }
 
@@ -456,6 +636,30 @@ void CWorkspaceTapeController::installWorkspaceListeners(SWorkspaceTile& tile) {
 void CWorkspaceTapeController::damageMonitor() const {
     if (const auto MONITOR = m_monitor.lock(); MONITOR && g_pHyprRenderer)
         g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+void CWorkspaceTapeController::damageMiniStrip() const {
+    if (const auto MONITOR = m_monitor.lock(); MONITOR)
+        MONITOR->addDamage(m_miniStripArea.copy().expand(MINI_TILE_BORDER_SIZE * MONITOR->m_scale));
+}
+
+void CWorkspaceTapeController::updateMiniBorderColors(bool warp) {
+    static auto PACTIVEBORDERCOLOR   = CConfigValue<Config::INTEGER>("overview:col.active_border");
+    static auto PINACTIVEBORDERCOLOR = CConfigValue<Config::INTEGER>("overview:col.inactive_border");
+
+    const auto  SELECTED = selectedWorkspace();
+    for (const auto& tile : m_tiles) {
+        const auto WORKSPACE = tile->workspace.lock();
+        const auto COLOR     = CHyprColor(tile->inLayout && WORKSPACE && WORKSPACE == SELECTED ? *PACTIVEBORDERCOLOR : *PINACTIVEBORDERCOLOR);
+
+        tile->miniBorderColor->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewFade"));
+        if (warp)
+            tile->miniBorderColor->setValueAndWarp(COLOR);
+        else
+            *tile->miniBorderColor = COLOR;
+    }
+
+    damageMiniStrip();
 }
 
 CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileFor(PHLWORKSPACE workspace) const {

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -582,6 +582,11 @@ bool CWorkspaceTapeController::pointerButton(uint32_t button, bool pressed, cons
         return true;
     }
 
+    if (workspace == m_selectedWorkspace) {
+        m_selectedWorkspace.reset();
+        return false;
+    }
+
     const auto PRESSED = m_pressedWorkspace.lock();
     m_pressedWorkspace.reset();
     if (!PRESSED)

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -4,12 +4,14 @@
 #include "WorkspaceMiniStripLayout.hpp"
 #include "WorkspaceTileShadow.hpp"
 #include "WorkspacePointerMapping.hpp"
+#include "OverviewScene.hpp"
 
 #include "../../../animation/AnimationManager.hpp"
 #include "../../../config/ConfigValue.hpp"
 #include "../../../config/shared/animation/AnimationTree.hpp"
 #include "../../../desktop/Workspace.hpp"
 #include "../../../desktop/state/WindowState.hpp"
+#include "../../../desktop/DesktopTypes.hpp"
 #include "../../../desktop/view/window/Window.hpp"
 #include "../../../event/EventBus.hpp"
 #include "../../../managers/eventLoop/EventLoopManager.hpp"
@@ -22,11 +24,16 @@
 #include "../../../render/pass/TexPassElement.hpp"
 #include "../../../state/WorkspaceState.hpp"
 
+#include "../../Overview.hpp"
+#include "../Overview.hpp"
+
 #include <algorithm>
 #include <cmath>
+#include <hyprutils/memory/WeakPtr.hpp>
 #include <ranges>
 
 #include <linux/input-event-codes.h>
+#include <string_view>
 
 using namespace Overview::Hyprland;
 
@@ -816,6 +823,16 @@ CWorkspaceTapeController::SWorkspaceTile* CWorkspaceTapeController::tileFor(PHLW
     return IT == m_tiles.end() ? nullptr : IT->get();
 }
 
+static uint8_t foldASCII(uint8_t character) {
+    if (character >= 'A' && character <= 'Z')
+        return character + ('a' - 'A');
+    return character;
+}
+
+static bool fullMatchCaseIns(std::string_view a, std::string_view b) {
+    return std::ranges::equal(a, b, [](char x, char y) { return foldASCII(x) == foldASCII(y); });
+}
+
 std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
     std::vector<PHLWORKSPACE> workspaces;
     const auto                MONITOR = m_monitor.lock();
@@ -823,6 +840,8 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
         return workspaces;
 
     static const auto PONLYSAMEMON = CConfigValue<Config::BOOL>("overview:only_current_monitor");
+
+    PHLWORKSPACE      exactMatch = nullptr;
 
     for (const auto& workspaceRef : State::workspaceState()->workspaces()) {
         const auto WORKSPACE      = workspaceRef.lock();
@@ -834,18 +853,27 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
         if (*PONLYSAMEMON && workspaceRef->m_monitor != MONITOR)
             continue;
 
+        if (fullMatchCaseIns(WORKSPACE->m_name, dynamicPointerCast<Hyprland::COverview>(WP<IOverview>(Overview::overview()))->scene()->currentQuery())) {
+            exactMatch = WORKSPACE;
+            break;
+        }
+
         workspaces.emplace_back(WORKSPACE);
     }
 
-    std::ranges::stable_sort(workspaces, [](const auto& lhs, const auto& rhs) {
-        const bool LHS_NUMERIC = lhs->m_id > 0;
-        const bool RHS_NUMERIC = rhs->m_id > 0;
-        if (LHS_NUMERIC != RHS_NUMERIC)
-            return LHS_NUMERIC;
-        if (LHS_NUMERIC)
-            return lhs->m_id < rhs->m_id;
-        return false;
-    });
+    if (exactMatch)
+        workspaces = {exactMatch};
+    else {
+        std::ranges::stable_sort(workspaces, [](const auto& lhs, const auto& rhs) {
+            const bool LHS_NUMERIC = lhs->m_id > 0;
+            const bool RHS_NUMERIC = rhs->m_id > 0;
+            if (LHS_NUMERIC != RHS_NUMERIC)
+                return LHS_NUMERIC;
+            if (LHS_NUMERIC)
+                return lhs->m_id < rhs->m_id;
+            return false;
+        });
+    }
 
     return workspaces;
 }

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -1,4 +1,5 @@
 #include "WorkspaceTapeController.hpp"
+#include "WorkspaceTapeLayout.hpp"
 
 #include "../../../animation/AnimationManager.hpp"
 #include "../../../config/shared/animation/AnimationTree.hpp"
@@ -56,17 +57,34 @@ void CWorkspaceTapeController::start(PHLMONITOR monitor, WP<Monitor::CMonitorRes
     m_resources = resources;
     m_started   = true;
 
-    m_listeners.created = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
+    m_listeners.created              = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF) {
         if (g_pEventLoopManager)
             g_pEventLoopManager->doLater([this] { reconcile(); });
         else
             reconcile();
     });
-    m_listeners.removed = Event::bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF) { reconcile(); });
-    m_listeners.moved   = Event::bus()->m_events.workspace.moveToMonitor.listen([this](PHLWORKSPACE, PHLMONITOR) { reconcile(); });
-    m_listeners.active  = Event::bus()->m_events.workspace.active.listen([this](PHLWORKSPACE workspace) {
+    m_listeners.removed              = Event::bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF) { reconcile(); });
+    m_listeners.moved                = Event::bus()->m_events.workspace.moveToMonitor.listen([this](PHLWORKSPACE, PHLMONITOR) { reconcile(); });
+    m_listeners.active               = Event::bus()->m_events.workspace.active.listen([this](PHLWORKSPACE workspace) {
         if (workspace && workspace->m_monitor == m_monitor)
             reconcile();
+    });
+    m_listeners.monitorAdded         = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR) { reconcile(); });
+    m_listeners.monitorRemoved       = Event::bus()->m_events.monitor.removed.listen([this](PHLMONITOR) { reconcile(); });
+    m_listeners.monitorLayoutChanged = Event::bus()->m_events.monitor.layoutChanged.listen([this] { reconcile(); });
+    m_listeners.monitorPreRender     = Event::bus()->m_events.render.preChecks.listen([this](PHLMONITOR monitor) {
+        const auto OVERVIEW_MONITOR = m_monitor.lock();
+        if (!monitor || monitor == OVERVIEW_MONITOR || !monitor->m_damage.hasChanged())
+            return;
+
+        const auto TILES = layoutTiles();
+        if (std::ranges::none_of(TILES, [&monitor](const auto* tile) {
+                const auto WORKSPACE = tile->workspace.lock();
+                return WORKSPACE && WORKSPACE->m_monitor == monitor;
+            }))
+            return;
+
+        damageMonitor();
     });
 
     reconcile(true);
@@ -139,24 +157,61 @@ void CWorkspaceTapeController::draw(Render::CRenderingContext& context, Time::st
         });
     }
 
-    std::ranges::stable_sort(drawTiles, [](const auto& lhs, const auto& rhs) { return lhs.selected < rhs.selected; });
+    std::ranges::stable_sort(drawTiles, [&MONITORBOX](const auto& lhs, const auto& rhs) {
+        if (lhs.selected != rhs.selected)
+            return lhs.selected;
 
-    const int ROUNDING = std::lround(TILE_ROUNDING * MONITOR->m_scale * PROGRESS);
-    for (auto& drawTile : drawTiles) {
+        const double MONITOR_CENTER = MONITORBOX.x + MONITORBOX.w / 2.0;
+        const double LHS_DISTANCE   = std::abs(lhs.box.x + lhs.box.w / 2.0 - MONITOR_CENTER);
+        const double RHS_DISTANCE   = std::abs(rhs.box.x + rhs.box.w / 2.0 - MONITOR_CENTER);
+        return LHS_DISTANCE < RHS_DISTANCE;
+    });
+    for (size_t i = 0; i < drawTiles.size(); ++i) {
+        auto&      drawTile  = drawTiles.at(i);
         auto&      tile      = *drawTile.tile;
         const auto WORKSPACE = tile.workspace.lock();
 
-        const bool CAN_RENDER = WORKSPACE && WORKSPACE->m_monitor == MONITOR;
-        if (!tile.framebuffer && CAN_RENDER)
-            tile.framebuffer = RESOURCES->getUnusedWorkBuffer();
+        const auto SOURCE_MONITOR = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
+        const auto BUFFER_SIZE    = SOURCE_MONITOR ? SOURCE_MONITOR->m_transformedSize : Vector2D{};
+        const bool CAN_RENDER = SOURCE_MONITOR && SOURCE_MONITOR->m_enabled && !SOURCE_MONITOR->isMirror() && SOURCE_MONITOR->resources() && BUFFER_SIZE.x > 0 && BUFFER_SIZE.y > 0;
+        if (tile.framebuffer && (!CAN_RENDER || tile.framebuffer->m_size != BUFFER_SIZE))
+            tile.framebuffer.reset();
+
+        const auto ACQUIRE_BUFFER = [&] {
+            if (SOURCE_MONITOR == MONITOR)
+                tile.framebuffer = RESOURCES->getUnusedWorkBuffer();
+            else
+                tile.framebuffer = RESOURCES->getUnusedWorkBuffer(BUFFER_SIZE);
+        };
+
+        if (!tile.framebuffer && CAN_RENDER) {
+            ACQUIRE_BUFFER();
+
+            for (size_t candidateIndex = drawTiles.size(); !tile.framebuffer && candidateIndex > i + 1; --candidateIndex) {
+                auto&      candidate           = *drawTiles.at(candidateIndex - 1).tile;
+                const auto CANDIDATE_WORKSPACE = candidate.workspace.lock();
+                const auto CANDIDATE_MONITOR   = CANDIDATE_WORKSPACE ? CANDIDATE_WORKSPACE->m_monitor.lock() : nullptr;
+                if (!candidate.framebuffer || (CANDIDATE_MONITOR == MONITOR) != (SOURCE_MONITOR == MONITOR))
+                    continue;
+
+                candidate.framebuffer.reset();
+                ACQUIRE_BUFFER();
+            }
+        }
 
         bool rendered = false;
         if (CAN_RENDER && tile.framebuffer)
-            rendered = g_pHyprRenderer->renderWorkspaceSceneToBuffer(context, WORKSPACE, tile.framebuffer, tp, drawTile.selected);
+            rendered = g_pHyprRenderer->renderWorkspaceSceneToBuffer(context, WORKSPACE, tile.framebuffer, tp, WORKSPACE->m_visible && SOURCE_MONITOR == MONITOR);
 
         if (!rendered && tile.inLayout)
             tile.framebuffer.reset();
+    }
 
+    std::ranges::stable_sort(drawTiles, [](const auto& lhs, const auto& rhs) { return lhs.selected < rhs.selected; });
+
+    const int ROUNDING = std::lround(TILE_ROUNDING * MONITOR->m_scale * PROGRESS);
+    for (const auto& drawTile : drawTiles) {
+        const auto& tile = *drawTile.tile;
         if (!tile.framebuffer) {
             CRectPassElement::SRectData data;
             data.box   = drawTile.box;
@@ -279,19 +334,28 @@ void CWorkspaceTapeController::updateLayout(bool warp) {
     if (!MONITOR)
         return;
 
-    const auto SELECTED = selectedWorkspace();
-    const auto IT       = std::ranges::find_if(TILES, [&SELECTED](const auto* tile) { return tile->workspace == SELECTED; });
-    const auto INDEX    = IT == TILES.end() ? 0L : std::ranges::distance(TILES.begin(), IT);
-    const auto SIZE     = MONITOR->m_transformedSize * TILE_SCALE;
-    const auto BASEPOS  = (MONITOR->m_transformedSize - SIZE) / 2.F;
-    const auto STRIDE   = SIZE.x + MONITOR->m_transformedSize.x * TILE_GAP;
+    const auto            SELECTED = selectedWorkspace();
+    const auto            IT       = std::ranges::find_if(TILES, [&SELECTED](const auto* tile) { return tile->workspace == SELECTED; });
+    const auto            INDEX    = IT == TILES.end() ? 0L : std::ranges::distance(TILES.begin(), IT);
+    std::vector<Vector2D> sourceSizes;
+    sourceSizes.reserve(TILES.size());
+
+    for (const auto* tile : TILES) {
+        const auto WORKSPACE = tile->workspace.lock();
+        const auto SOURCE    = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
+        sourceSizes.emplace_back(SOURCE ? SOURCE->m_transformedSize : MONITOR->m_transformedSize);
+    }
+
+    const auto BOXES        = WorkspaceTapeLayout::calculate(MONITOR->m_transformedSize, sourceSizes, INDEX, TILE_SCALE, TILE_GAP);
+    const auto REGULAR_SIZE = MONITOR->m_transformedSize * TILE_SCALE;
 
     for (size_t i = 0; i < TILES.size(); ++i) {
         auto& tile = *TILES.at(i);
         tile.position->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
         tile.size->setConfig(Config::animationTree()->getAnimationPropertyConfig("overviewMove"));
 
-        const Vector2D POSITION = BASEPOS + Vector2D{(sc<long>(i) - INDEX) * STRIDE, 0.F};
+        const auto POSITION = BOXES.at(i).pos();
+        const auto SIZE     = BOXES.at(i).size();
         if (warp || !tile.geometryInitialized) {
             tile.position->setValueAndWarp(POSITION);
             tile.size->setValueAndWarp(SIZE);
@@ -310,14 +374,14 @@ void CWorkspaceTapeController::updateLayout(bool warp) {
         if (!WORKSPACE || WORKSPACE != MONITOR->m_activeWorkspace)
             continue;
 
-        const Vector2D POSITION = BASEPOS;
+        const Vector2D POSITION = (MONITOR->m_transformedSize - REGULAR_SIZE) / 2.F;
         if (warp || !tile->geometryInitialized) {
             tile->position->setValueAndWarp(POSITION);
-            tile->size->setValueAndWarp(SIZE);
+            tile->size->setValueAndWarp(REGULAR_SIZE);
             tile->geometryInitialized = true;
         } else {
             *tile->position = POSITION;
-            *tile->size     = SIZE;
+            *tile->size     = REGULAR_SIZE;
         }
     }
 }
@@ -380,8 +444,10 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
         return workspaces;
 
     for (const auto& workspaceRef : State::workspaceState()->workspaces()) {
-        const auto WORKSPACE = workspaceRef.lock();
-        if (!valid(WORKSPACE) || WORKSPACE->m_monitor != MONITOR || WORKSPACE->m_isSpecialWorkspace || !m_filter(WORKSPACE))
+        const auto WORKSPACE      = workspaceRef.lock();
+        const auto SOURCE_MONITOR = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
+        if (!valid(WORKSPACE) || !SOURCE_MONITOR || !SOURCE_MONITOR->m_enabled || SOURCE_MONITOR->isMirror() || !SOURCE_MONITOR->resources() || WORKSPACE->m_isSpecialWorkspace ||
+            !m_filter(WORKSPACE))
             continue;
 
         workspaces.emplace_back(WORKSPACE);

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -822,11 +822,16 @@ std::vector<PHLWORKSPACE> CWorkspaceTapeController::filteredWorkspaces() const {
     if (!MONITOR)
         return workspaces;
 
+    static const auto PONLYSAMEMON = CConfigValue<Config::BOOL>("overview:only_current_monitor");
+
     for (const auto& workspaceRef : State::workspaceState()->workspaces()) {
         const auto WORKSPACE      = workspaceRef.lock();
         const auto SOURCE_MONITOR = WORKSPACE ? WORKSPACE->m_monitor.lock() : nullptr;
         if (!valid(WORKSPACE) || !SOURCE_MONITOR || !SOURCE_MONITOR->m_enabled || SOURCE_MONITOR->isMirror() || !SOURCE_MONITOR->resources() || WORKSPACE->m_isSpecialWorkspace ||
             !m_filter(WORKSPACE))
+            continue;
+
+        if (*PONLYSAMEMON && workspaceRef->m_monitor != MONITOR)
             continue;
 
         workspaces.emplace_back(WORKSPACE);

--- a/src/overview/hyprland/scene/WorkspaceTapeController.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.cpp
@@ -574,17 +574,17 @@ bool CWorkspaceTapeController::pointerButton(uint32_t button, bool pressed, cons
             workspace = TILE->workspace.lock();
     }
 
+    if (workspace == m_selectedWorkspace || (!pressed && !m_pressedWorkspace)) {
+        m_pressedWorkspace.reset();
+        return false;
+    }
+
     if (pressed) {
         if (!workspace)
             return false;
 
         m_pressedWorkspace = workspace;
         return true;
-    }
-
-    if (workspace == m_selectedWorkspace) {
-        m_selectedWorkspace.reset();
-        return false;
     }
 
     const auto PRESSED = m_pressedWorkspace.lock();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -64,6 +64,10 @@ namespace Overview::Hyprland {
             CHyprSignalListener removed;
             CHyprSignalListener moved;
             CHyprSignalListener active;
+            CHyprSignalListener monitorAdded;
+            CHyprSignalListener monitorRemoved;
+            CHyprSignalListener monitorLayoutChanged;
+            CHyprSignalListener monitorPreRender;
         } m_listeners;
     };
 }

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -11,6 +11,9 @@
 namespace Monitor {
     class CMonitorResources;
 }
+namespace Render {
+    class CRenderingContext;
+}
 
 namespace Overview::Hyprland {
     class CWorkspaceTapeController {
@@ -24,7 +27,7 @@ namespace Overview::Hyprland {
 
         void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
         void         reset();
-        void         draw(Time::steady_tp tp, float overviewProgress);
+        void         draw(Render::CRenderingContext&, Time::steady_tp tp, float overviewProgress);
 
         bool         navigateLeft();
         bool         navigateRight();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -2,6 +2,7 @@
 
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../helpers/memory/Memory.hpp"
+#include "../../../helpers/math/Math.hpp"
 #include "../../../helpers/signal/Signal.hpp"
 #include "../../../helpers/time/Time.hpp"
 
@@ -14,24 +15,28 @@ namespace Monitor {
 namespace Render {
     class CRenderingContext;
 }
+namespace Overview::Hyprland::OverviewLayout {
+    struct SLayout;
+}
 
 namespace Overview::Hyprland {
     class CWorkspaceTapeController {
       public:
-        static constexpr float TILE_SCALE = 0.9F;
-
         using FWorkspaceFilter = std::function<bool(PHLWORKSPACE)>;
 
         CWorkspaceTapeController();
         ~CWorkspaceTapeController();
 
-        void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
+        void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources, const OverviewLayout::SLayout& layout);
         void         reset();
         void         draw(Render::CRenderingContext&, Time::steady_tp tp, float overviewProgress, size_t reservedWorkBuffers = 0);
 
         bool         navigateLeft();
         bool         navigateRight();
+        bool         selectWorkspace(PHLWORKSPACE workspace);
         PHLWORKSPACE selectedWorkspace() const;
+        PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
+        bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
 
         void         setFilter(FWorkspaceFilter filter);
         void         refresh();
@@ -46,6 +51,8 @@ namespace Overview::Hyprland {
         void                            ensureAnimations(SWorkspaceTile& tile);
         void                            installWorkspaceListeners(SWorkspaceTile& tile);
         void                            damageMonitor() const;
+        void                            damageMiniStrip() const;
+        void                            updateMiniBorderColors(bool warp = false);
         SWorkspaceTile*                 tileFor(PHLWORKSPACE workspace) const;
         SWorkspaceTile*                 tileFor(PHLWORKSPACEREF workspace) const;
         std::vector<PHLWORKSPACE>       filteredWorkspaces() const;
@@ -57,7 +64,10 @@ namespace Overview::Hyprland {
         FWorkspaceFilter                m_filter;
         PHLWORKSPACEREF                 m_selectedWorkspace;
         PHLWORKSPACEREF                 m_preferredWorkspace;
+        PHLWORKSPACEREF                 m_pressedMiniWorkspace;
         std::vector<UP<SWorkspaceTile>> m_tiles;
+        CBox                            m_mainArea;
+        CBox                            m_miniStripArea;
         bool                            m_started = false;
 
         struct {
@@ -70,6 +80,7 @@ namespace Overview::Hyprland {
             CHyprSignalListener monitorRemoved;
             CHyprSignalListener monitorLayoutChanged;
             CHyprSignalListener monitorPreRender;
+            CHyprSignalListener configRefreshed;
         } m_listeners;
     };
 }

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -39,6 +39,7 @@ namespace Overview::Hyprland {
         Vector2D     transformPointer(const Vector2D& global) const;
         PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
         bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
+        void         useSelectedWorkspaceForFullscreen(bool x);
 
         void         setFilter(FWorkspaceFilter filter);
         void         refresh();
@@ -60,6 +61,7 @@ namespace Overview::Hyprland {
         void                             refreshWindowListeners();
         SWorkspaceTile*                  tileFor(PHLWORKSPACE workspace) const;
         SWorkspaceTile*                  tileFor(PHLWORKSPACEREF workspace) const;
+        PHLWORKSPACE                     fullscreenWorkspace(PHLMONITOR monitor) const;
         CBox                             mainBoxFor(const SWorkspaceTile& tile, PHLMONITOR monitor) const;
         std::vector<PHLWORKSPACE>        filteredWorkspaces() const;
         std::vector<SWorkspaceTile*>     layoutTiles() const;
@@ -76,8 +78,9 @@ namespace Overview::Hyprland {
         CBox                             m_miniStripArea;
         std::vector<CHyprSignalListener> m_windowListeners;
         UP<SEventLoopDoLaterLock>        m_reconcileLock;
-        float                            m_overviewProgress = 0.F;
-        bool                             m_started          = false;
+        float                            m_overviewProgress   = 0.F;
+        bool                             m_started            = false;
+        bool                             m_fullscreenSelected = false;
 
         struct {
             CHyprSignalListener created;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -66,13 +66,14 @@ namespace Overview::Hyprland {
         std::vector<PHLWORKSPACE>        filteredWorkspaces() const;
         std::vector<SWorkspaceTile*>     layoutTiles() const;
         void                             pruneRetiredTiles();
+        SWorkspaceTile*                  tileAt(const Vector2D& monitorLocal) const;
 
         PHLMONITORREF                    m_monitor;
         WP<Monitor::CMonitorResources>   m_resources;
         FWorkspaceFilter                 m_filter;
         PHLWORKSPACEREF                  m_selectedWorkspace;
         PHLWORKSPACEREF                  m_preferredWorkspace;
-        PHLWORKSPACEREF                  m_pressedMiniWorkspace;
+        PHLWORKSPACEREF                  m_pressedWorkspace;
         std::vector<UP<SWorkspaceTile>>  m_tiles;
         CBox                             m_mainArea;
         CBox                             m_miniStripArea;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -36,6 +36,7 @@ namespace Overview::Hyprland {
         bool         navigateRight();
         bool         selectWorkspace(PHLWORKSPACE workspace);
         PHLWORKSPACE selectedWorkspace() const;
+        Vector2D     transformPointer(const Vector2D& global) const;
         PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
         bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
 
@@ -59,6 +60,7 @@ namespace Overview::Hyprland {
         void                             refreshWindowListeners();
         SWorkspaceTile*                  tileFor(PHLWORKSPACE workspace) const;
         SWorkspaceTile*                  tileFor(PHLWORKSPACEREF workspace) const;
+        CBox                             mainBoxFor(const SWorkspaceTile& tile, PHLMONITOR monitor) const;
         std::vector<PHLWORKSPACE>        filteredWorkspaces() const;
         std::vector<SWorkspaceTile*>     layoutTiles() const;
         void                             pruneRetiredTiles();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../../desktop/DesktopTypes.hpp"
+#include "../../../helpers/AnimatedVariable.hpp"
 #include "../../../helpers/memory/Memory.hpp"
 #include "../../../helpers/math/Math.hpp"
 #include "../../../helpers/signal/Signal.hpp"
@@ -40,6 +41,9 @@ namespace Overview::Hyprland {
         PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
         bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
         void         useSelectedWorkspaceForFullscreen(bool x);
+        bool         beginMoveGesture();
+        void         updateMoveGesture(float delta);
+        void         endMoveGesture();
 
         void         setFilter(FWorkspaceFilter filter);
         void         refresh();
@@ -77,6 +81,7 @@ namespace Overview::Hyprland {
         std::vector<UP<SWorkspaceTile>>  m_tiles;
         CBox                             m_mainArea;
         CBox                             m_miniStripArea;
+        PHLANIMVAR<float>                m_mainOffset;
         std::vector<CHyprSignalListener> m_windowListeners;
         UP<SEventLoopDoLaterLock>        m_reconcileLock;
         float                            m_overviewProgress   = 0.F;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -27,7 +27,7 @@ namespace Overview::Hyprland {
 
         void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
         void         reset();
-        void         draw(Render::CRenderingContext&, Time::steady_tp tp, float overviewProgress);
+        void         draw(Render::CRenderingContext&, Time::steady_tp tp, float overviewProgress, size_t reservedWorkBuffers = 0);
 
         bool         navigateLeft();
         bool         navigateRight();

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -18,6 +18,7 @@ namespace Render {
 namespace Overview::Hyprland::OverviewLayout {
     struct SLayout;
 }
+struct SEventLoopDoLaterLock;
 
 namespace Overview::Hyprland {
     class CWorkspaceTapeController {
@@ -44,31 +45,37 @@ namespace Overview::Hyprland {
       private:
         struct SWorkspaceTile;
 
-        bool                            navigate(int direction);
-        void                            reconcile(bool initial = false);
-        void                            updateLayout(bool warp = false);
-        void                            retireTile(SWorkspaceTile& tile);
-        void                            ensureAnimations(SWorkspaceTile& tile);
-        void                            installWorkspaceListeners(SWorkspaceTile& tile);
-        void                            damageMonitor() const;
-        void                            damageMiniStrip() const;
-        void                            updateMiniBorderColors(bool warp = false);
-        SWorkspaceTile*                 tileFor(PHLWORKSPACE workspace) const;
-        SWorkspaceTile*                 tileFor(PHLWORKSPACEREF workspace) const;
-        std::vector<PHLWORKSPACE>       filteredWorkspaces() const;
-        std::vector<SWorkspaceTile*>    layoutTiles() const;
-        void                            pruneRetiredTiles();
+        bool                             navigate(int direction);
+        void                             reconcile(bool initial = false);
+        void                             updateLayout(bool warp = false);
+        void                             retireTile(SWorkspaceTile& tile);
+        void                             ensureAnimations(SWorkspaceTile& tile);
+        void                             installWorkspaceListeners(SWorkspaceTile& tile);
+        void                             damageMonitor() const;
+        void                             damageMiniStrip() const;
+        void                             updateMiniBorderColors(bool warp = false);
+        void                             invalidateMiniatures();
+        void                             invalidateMiniature(PHLWORKSPACE workspace);
+        void                             refreshWindowListeners();
+        SWorkspaceTile*                  tileFor(PHLWORKSPACE workspace) const;
+        SWorkspaceTile*                  tileFor(PHLWORKSPACEREF workspace) const;
+        std::vector<PHLWORKSPACE>        filteredWorkspaces() const;
+        std::vector<SWorkspaceTile*>     layoutTiles() const;
+        void                             pruneRetiredTiles();
 
-        PHLMONITORREF                   m_monitor;
-        WP<Monitor::CMonitorResources>  m_resources;
-        FWorkspaceFilter                m_filter;
-        PHLWORKSPACEREF                 m_selectedWorkspace;
-        PHLWORKSPACEREF                 m_preferredWorkspace;
-        PHLWORKSPACEREF                 m_pressedMiniWorkspace;
-        std::vector<UP<SWorkspaceTile>> m_tiles;
-        CBox                            m_mainArea;
-        CBox                            m_miniStripArea;
-        bool                            m_started = false;
+        PHLMONITORREF                    m_monitor;
+        WP<Monitor::CMonitorResources>   m_resources;
+        FWorkspaceFilter                 m_filter;
+        PHLWORKSPACEREF                  m_selectedWorkspace;
+        PHLWORKSPACEREF                  m_preferredWorkspace;
+        PHLWORKSPACEREF                  m_pressedMiniWorkspace;
+        std::vector<UP<SWorkspaceTile>>  m_tiles;
+        CBox                             m_mainArea;
+        CBox                             m_miniStripArea;
+        std::vector<CHyprSignalListener> m_windowListeners;
+        UP<SEventLoopDoLaterLock>        m_reconcileLock;
+        float                            m_overviewProgress = 0.F;
+        bool                             m_started          = false;
 
         struct {
             CHyprSignalListener created;
@@ -81,6 +88,15 @@ namespace Overview::Hyprland {
             CHyprSignalListener monitorLayoutChanged;
             CHyprSignalListener monitorPreRender;
             CHyprSignalListener configRefreshed;
+            CHyprSignalListener windowOpened;
+            CHyprSignalListener windowClosed;
+            CHyprSignalListener windowMoved;
+            CHyprSignalListener windowFullscreen;
+            CHyprSignalListener windowFloating;
+            CHyprSignalListener windowActive;
+            CHyprSignalListener windowPinned;
+            CHyprSignalListener layerOpened;
+            CHyprSignalListener layerClosed;
         } m_listeners;
     };
 }

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -56,12 +56,14 @@ namespace Overview::Hyprland {
         WP<Monitor::CMonitorResources>  m_resources;
         FWorkspaceFilter                m_filter;
         PHLWORKSPACEREF                 m_selectedWorkspace;
+        PHLWORKSPACEREF                 m_preferredWorkspace;
         std::vector<UP<SWorkspaceTile>> m_tiles;
         bool                            m_started = false;
 
         struct {
             CHyprSignalListener created;
             CHyprSignalListener removed;
+            CHyprSignalListener renamed;
             CHyprSignalListener moved;
             CHyprSignalListener active;
             CHyprSignalListener monitorAdded;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -6,6 +6,7 @@
 #include "../../../helpers/math/Math.hpp"
 #include "../../../helpers/signal/Signal.hpp"
 #include "../../../helpers/time/Time.hpp"
+#include "../mode/IQueryMode.hpp"
 
 #include <functional>
 #include <vector>
@@ -24,7 +25,7 @@ struct SEventLoopDoLaterLock;
 namespace Overview::Hyprland {
     class CWorkspaceTapeController {
       public:
-        using FWorkspaceFilter = std::function<bool(PHLWORKSPACE)>;
+        using FWorkspaceFilter = std::function<Mode::eWorkspaceMatch(PHLWORKSPACE)>;
 
         CWorkspaceTapeController();
         ~CWorkspaceTapeController();
@@ -45,14 +46,14 @@ namespace Overview::Hyprland {
         void         updateMoveGesture(float delta);
         void         endMoveGesture();
 
-        void         setFilter(FWorkspaceFilter filter);
+        void         setFilter(FWorkspaceFilter filter, bool usesWindowMetadata = false);
         void         refresh();
 
       private:
         struct SWorkspaceTile;
 
         bool                             navigate(int direction);
-        void                             reconcile(bool initial = false);
+        void                             reconcile(bool initial = false, bool invalidateMiniatures = true);
         void                             updateLayout(bool warp = false);
         void                             retireTile(SWorkspaceTile& tile);
         void                             ensureAnimations(SWorkspaceTile& tile);
@@ -63,6 +64,7 @@ namespace Overview::Hyprland {
         void                             invalidateMiniatures();
         void                             invalidateMiniature(PHLWORKSPACE workspace);
         void                             refreshWindowListeners();
+        void                             scheduleReconcile(bool invalidateMiniatures = true);
         SWorkspaceTile*                  tileFor(PHLWORKSPACE workspace) const;
         SWorkspaceTile*                  tileFor(PHLWORKSPACEREF workspace) const;
         PHLWORKSPACE                     fullscreenWorkspace(PHLMONITOR monitor) const;
@@ -84,9 +86,11 @@ namespace Overview::Hyprland {
         PHLANIMVAR<float>                m_mainOffset;
         std::vector<CHyprSignalListener> m_windowListeners;
         UP<SEventLoopDoLaterLock>        m_reconcileLock;
-        float                            m_overviewProgress   = 0.F;
-        bool                             m_started            = false;
-        bool                             m_fullscreenSelected = false;
+        bool                             m_reconcileInvalidatesMiniatures = false;
+        float                            m_overviewProgress               = 0.F;
+        bool                             m_started                        = false;
+        bool                             m_fullscreenSelected             = false;
+        bool                             m_filterUsesWindowMetadata       = false;
 
         struct {
             CHyprSignalListener created;
@@ -102,6 +106,8 @@ namespace Overview::Hyprland {
             CHyprSignalListener windowOpened;
             CHyprSignalListener windowClosed;
             CHyprSignalListener windowMoved;
+            CHyprSignalListener windowTitle;
+            CHyprSignalListener windowClass;
             CHyprSignalListener windowFullscreen;
             CHyprSignalListener windowFloating;
             CHyprSignalListener windowActive;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -7,6 +7,7 @@
 #include "../../../helpers/signal/Signal.hpp"
 #include "../../../helpers/time/Time.hpp"
 #include "../mode/IQueryMode.hpp"
+#include "WorkspaceNavigation.hpp"
 
 #include <functional>
 #include <vector>
@@ -30,24 +31,24 @@ namespace Overview::Hyprland {
         CWorkspaceTapeController();
         ~CWorkspaceTapeController();
 
-        void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources, const OverviewLayout::SLayout& layout);
-        void         reset();
-        void         draw(Render::CRenderingContext&, Time::steady_tp tp, float overviewProgress, size_t reservedWorkBuffers = 0);
+        void                       start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources, const OverviewLayout::SLayout& layout);
+        void                       reset();
+        void                       draw(Render::CRenderingContext&, Time::steady_tp tp, float overviewProgress, size_t reservedWorkBuffers = 0);
 
-        bool         navigateLeft();
-        bool         navigateRight();
-        bool         selectWorkspace(PHLWORKSPACE workspace);
-        PHLWORKSPACE selectedWorkspace() const;
-        Vector2D     transformPointer(const Vector2D& global) const;
-        PHLWORKSPACE miniWorkspaceAt(const Vector2D& monitorLocal) const;
-        bool         pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
-        void         useSelectedWorkspaceForFullscreen(bool x);
-        bool         beginMoveGesture();
-        void         updateMoveGesture(float delta);
-        void         endMoveGesture();
+        bool                       navigateLeft();
+        eWorkspaceNavigationResult navigateRight(bool allowCreate, bool willReceiveWindow = false);
+        bool                       selectWorkspace(PHLWORKSPACE workspace);
+        PHLWORKSPACE               selectedWorkspace() const;
+        Vector2D                   transformPointer(const Vector2D& global) const;
+        PHLWORKSPACE               miniWorkspaceAt(const Vector2D& monitorLocal) const;
+        bool                       pointerButton(uint32_t button, bool pressed, const Vector2D& monitorLocal);
+        void                       useSelectedWorkspaceForFullscreen(bool x);
+        bool                       beginMoveGesture();
+        void                       updateMoveGesture(float delta);
+        void                       endMoveGesture();
 
-        void         setFilter(FWorkspaceFilter filter, bool usesWindowMetadata = false);
-        void         refresh();
+        void                       setFilter(FWorkspaceFilter filter, bool usesWindowMetadata = false);
+        void                       refresh();
 
       private:
         struct SWorkspaceTile;
@@ -65,6 +66,7 @@ namespace Overview::Hyprland {
         void                             invalidateMiniature(PHLWORKSPACE workspace);
         void                             refreshWindowListeners();
         void                             scheduleReconcile(bool invalidateMiniatures = true);
+        void                             releaseUnselectedCreatedWorkspace();
         SWorkspaceTile*                  tileFor(PHLWORKSPACE workspace) const;
         SWorkspaceTile*                  tileFor(PHLWORKSPACEREF workspace) const;
         PHLWORKSPACE                     fullscreenWorkspace(PHLMONITOR monitor) const;
@@ -80,6 +82,7 @@ namespace Overview::Hyprland {
         PHLWORKSPACEREF                  m_selectedWorkspace;
         PHLWORKSPACEREF                  m_preferredWorkspace;
         PHLWORKSPACEREF                  m_pressedWorkspace;
+        PHLWORKSPACE                     m_createdWorkspace;
         std::vector<UP<SWorkspaceTile>>  m_tiles;
         CBox                             m_mainArea;
         CBox                             m_miniStripArea;

--- a/src/overview/hyprland/scene/WorkspaceTapeController.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeController.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "../../../desktop/DesktopTypes.hpp"
+#include "../../../helpers/memory/Memory.hpp"
+#include "../../../helpers/signal/Signal.hpp"
+#include "../../../helpers/time/Time.hpp"
+
+#include <functional>
+#include <vector>
+
+namespace Monitor {
+    class CMonitorResources;
+}
+
+namespace Overview::Hyprland {
+    class CWorkspaceTapeController {
+      public:
+        static constexpr float TILE_SCALE = 0.9F;
+
+        using FWorkspaceFilter = std::function<bool(PHLWORKSPACE)>;
+
+        CWorkspaceTapeController();
+        ~CWorkspaceTapeController();
+
+        void         start(PHLMONITOR monitor, WP<Monitor::CMonitorResources> resources);
+        void         reset();
+        void         draw(Time::steady_tp tp, float overviewProgress);
+
+        bool         navigateLeft();
+        bool         navigateRight();
+        PHLWORKSPACE selectedWorkspace() const;
+
+        void         setFilter(FWorkspaceFilter filter);
+        void         refresh();
+
+      private:
+        struct SWorkspaceTile;
+
+        bool                            navigate(int direction);
+        void                            reconcile(bool initial = false);
+        void                            updateLayout(bool warp = false);
+        void                            retireTile(SWorkspaceTile& tile);
+        void                            ensureAnimations(SWorkspaceTile& tile);
+        void                            installWorkspaceListeners(SWorkspaceTile& tile);
+        void                            damageMonitor() const;
+        SWorkspaceTile*                 tileFor(PHLWORKSPACE workspace) const;
+        SWorkspaceTile*                 tileFor(PHLWORKSPACEREF workspace) const;
+        std::vector<PHLWORKSPACE>       filteredWorkspaces() const;
+        std::vector<SWorkspaceTile*>    layoutTiles() const;
+        void                            pruneRetiredTiles();
+
+        PHLMONITORREF                   m_monitor;
+        WP<Monitor::CMonitorResources>  m_resources;
+        FWorkspaceFilter                m_filter;
+        PHLWORKSPACEREF                 m_selectedWorkspace;
+        std::vector<UP<SWorkspaceTile>> m_tiles;
+        bool                            m_started = false;
+
+        struct {
+            CHyprSignalListener created;
+            CHyprSignalListener removed;
+            CHyprSignalListener moved;
+            CHyprSignalListener active;
+        } m_listeners;
+    };
+}

--- a/src/overview/hyprland/scene/WorkspaceTapeLayout.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeLayout.cpp
@@ -14,12 +14,12 @@ static Vector2D fittedTileSize(const Vector2D& regularSize, const Vector2D& sour
     return sourceSize * SCALE;
 }
 
-std::vector<CBox> WorkspaceTapeLayout::calculate(const Vector2D& monitorSize, std::span<const Vector2D> sourceSizes, size_t selectedIndex, float tileScale, float gapScale) {
-    if (sourceSizes.empty())
+std::vector<CBox> WorkspaceTapeLayout::calculate(const CBox& bounds, std::span<const Vector2D> sourceSizes, size_t selectedIndex, float gapScale) {
+    if (bounds.empty() || sourceSizes.empty())
         return {};
 
-    const Vector2D    REGULAR_SIZE = monitorSize * tileScale;
-    const float       GAP          = monitorSize.x * gapScale;
+    const Vector2D    REGULAR_SIZE = bounds.size();
+    const float       GAP          = bounds.w * gapScale;
     const size_t      SELECTED     = std::min(selectedIndex, sourceSizes.size() - 1);
 
     std::vector<CBox> boxes;
@@ -27,17 +27,17 @@ std::vector<CBox> WorkspaceTapeLayout::calculate(const Vector2D& monitorSize, st
     for (const auto& sourceSize : sourceSizes)
         boxes.emplace_back(Vector2D{}, fittedTileSize(REGULAR_SIZE, sourceSize));
 
-    boxes.at(SELECTED).x = (monitorSize.x - boxes.at(SELECTED).w) / 2.F;
-    boxes.at(SELECTED).y = (monitorSize.y - boxes.at(SELECTED).h) / 2.F;
+    boxes.at(SELECTED).x = bounds.x + (bounds.w - boxes.at(SELECTED).w) / 2.F;
+    boxes.at(SELECTED).y = bounds.y + (bounds.h - boxes.at(SELECTED).h) / 2.F;
 
     for (size_t i = SELECTED; i > 0; --i) {
         boxes.at(i - 1).x = boxes.at(i).x - GAP - boxes.at(i - 1).w;
-        boxes.at(i - 1).y = (monitorSize.y - boxes.at(i - 1).h) / 2.F;
+        boxes.at(i - 1).y = bounds.y + (bounds.h - boxes.at(i - 1).h) / 2.F;
     }
 
     for (size_t i = SELECTED + 1; i < boxes.size(); ++i) {
         boxes.at(i).x = boxes.at(i - 1).x + boxes.at(i - 1).w + GAP;
-        boxes.at(i).y = (monitorSize.y - boxes.at(i).h) / 2.F;
+        boxes.at(i).y = bounds.y + (bounds.h - boxes.at(i).h) / 2.F;
     }
 
     return boxes;

--- a/src/overview/hyprland/scene/WorkspaceTapeLayout.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeLayout.cpp
@@ -1,0 +1,44 @@
+#include "WorkspaceTapeLayout.hpp"
+
+#include <algorithm>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+using Hyprutils::Math::Vector2D;
+
+static Vector2D fittedTileSize(const Vector2D& regularSize, const Vector2D& sourceSize) {
+    if (sourceSize.x <= 0.F || sourceSize.y <= 0.F)
+        return regularSize;
+
+    const float SCALE = std::min(regularSize.x / sourceSize.x, regularSize.y / sourceSize.y);
+    return sourceSize * SCALE;
+}
+
+std::vector<CBox> WorkspaceTapeLayout::calculate(const Vector2D& monitorSize, std::span<const Vector2D> sourceSizes, size_t selectedIndex, float tileScale, float gapScale) {
+    if (sourceSizes.empty())
+        return {};
+
+    const Vector2D    REGULAR_SIZE = monitorSize * tileScale;
+    const float       GAP          = monitorSize.x * gapScale;
+    const size_t      SELECTED     = std::min(selectedIndex, sourceSizes.size() - 1);
+
+    std::vector<CBox> boxes;
+    boxes.reserve(sourceSizes.size());
+    for (const auto& sourceSize : sourceSizes)
+        boxes.emplace_back(Vector2D{}, fittedTileSize(REGULAR_SIZE, sourceSize));
+
+    boxes.at(SELECTED).x = (monitorSize.x - boxes.at(SELECTED).w) / 2.F;
+    boxes.at(SELECTED).y = (monitorSize.y - boxes.at(SELECTED).h) / 2.F;
+
+    for (size_t i = SELECTED; i > 0; --i) {
+        boxes.at(i - 1).x = boxes.at(i).x - GAP - boxes.at(i - 1).w;
+        boxes.at(i - 1).y = (monitorSize.y - boxes.at(i - 1).h) / 2.F;
+    }
+
+    for (size_t i = SELECTED + 1; i < boxes.size(); ++i) {
+        boxes.at(i).x = boxes.at(i - 1).x + boxes.at(i - 1).w + GAP;
+        boxes.at(i).y = (monitorSize.y - boxes.at(i).h) / 2.F;
+    }
+
+    return boxes;
+}

--- a/src/overview/hyprland/scene/WorkspaceTapeLayout.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTapeLayout.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+
+namespace Overview::Hyprland::WorkspaceTapeLayout {
+    std::vector<Hyprutils::Math::CBox> calculate(const Hyprutils::Math::Vector2D& monitorSize, std::span<const Hyprutils::Math::Vector2D> sourceSizes, size_t selectedIndex,
+                                                 float tileScale, float gapScale);
+}

--- a/src/overview/hyprland/scene/WorkspaceTileShadow.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTileShadow.cpp
@@ -18,7 +18,7 @@ std::optional<WorkspaceTileShadow::SGeometry> WorkspaceTileShadow::calculate(con
         return std::nullopt;
 
     return SGeometry{
-        .outerBox = tileBox.copy().expand(RANGE),
+        .outerBox = tileBox.copy().expand(RANGE).round(),
         .range    = RANGE,
         .rounding = std::lround(std::max(0.F, rounding) * monitorScale * PROGRESS),
         .opacity  = OPACITY,

--- a/src/overview/hyprland/scene/WorkspaceTileShadow.cpp
+++ b/src/overview/hyprland/scene/WorkspaceTileShadow.cpp
@@ -1,0 +1,26 @@
+#include "WorkspaceTileShadow.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+
+std::optional<WorkspaceTileShadow::SGeometry> WorkspaceTileShadow::calculate(const CBox& tileBox, float monitorScale, float tileOpacity, float overviewProgress, float range,
+                                                                             float rounding) {
+    if (tileBox.empty() || monitorScale <= 0.F)
+        return std::nullopt;
+
+    const float PROGRESS = std::clamp(overviewProgress, 0.F, 1.F);
+    const int   RANGE    = std::lround(std::max(0.F, range) * monitorScale * PROGRESS);
+    const float OPACITY  = std::min(std::clamp(tileOpacity, 0.F, 1.F), PROGRESS);
+    if (RANGE <= 0 || OPACITY <= 0.F)
+        return std::nullopt;
+
+    return SGeometry{
+        .outerBox = tileBox.copy().expand(RANGE),
+        .range    = RANGE,
+        .rounding = std::lround(std::max(0.F, rounding) * monitorScale * PROGRESS),
+        .opacity  = OPACITY,
+    };
+}

--- a/src/overview/hyprland/scene/WorkspaceTileShadow.hpp
+++ b/src/overview/hyprland/scene/WorkspaceTileShadow.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <optional>
+
+#include <hyprutils/math/Box.hpp>
+
+namespace Overview::Hyprland::WorkspaceTileShadow {
+    struct SGeometry {
+        Hyprutils::Math::CBox outerBox;
+        int                   range    = 0;
+        int                   rounding = 0;
+        float                 opacity  = 0.F;
+    };
+
+    std::optional<SGeometry> calculate(const Hyprutils::Math::CBox& tileBox, float monitorScale, float tileOpacity, float overviewProgress, float range, float rounding);
+}

--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -1,4 +1,5 @@
 #include "PointerManager.hpp"
+#include "PointerTransformer.hpp"
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
 #include "../config/shared/actions/ConfigActions.hpp"
@@ -107,6 +108,19 @@ bool CPointerManager::hasVisibleHWCursor(PHLMONITOR pMonitor) {
 }
 
 Vector2D CPointerManager::position() {
+    if (m_transformers.empty())
+        return m_pointerPos;
+
+    auto pos = m_pointerPos;
+
+    for (const auto& x : m_transformers) {
+        pos = x->transform(pos);
+    }
+
+    return pos;
+}
+
+Vector2D CPointerManager::untransformedPosition() const {
     return m_pointerPos;
 }
 
@@ -1179,4 +1193,15 @@ void CPointerManager::damageCursor(PHLMONITOR pMonitor, bool skipFrameSchedule) 
 
 Vector2D CPointerManager::cursorSizeLogical() {
     return m_currentCursorImage.size / m_currentCursorImage.scale;
+}
+
+void CPointerManager::addTransformer(const SP<CPointerTransformer>& transformer) {
+    if (!transformer || std::ranges::contains(m_transformers, transformer))
+        return;
+
+    m_transformers.emplace_back(transformer);
+}
+
+void CPointerManager::removeTransformer(const SP<CPointerTransformer>& transformer) {
+    std::erase(m_transformers, transformer);
 }

--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -1,4 +1,5 @@
 #include "PointerManager.hpp"
+#include "PointerTransformer.hpp"
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
 #include "../config/shared/actions/ConfigActions.hpp"
@@ -107,6 +108,19 @@ bool CPointerManager::hasVisibleHWCursor(PHLMONITOR pMonitor) {
 }
 
 Vector2D CPointerManager::position() {
+    if (m_transformers.empty())
+        return m_pointerPos;
+
+    auto pos = m_pointerPos;
+
+    for (const auto& x : m_transformers) {
+        pos = x->transform(pos);
+    }
+
+    return pos;
+}
+
+Vector2D CPointerManager::untransformedPosition() const {
     return m_pointerPos;
 }
 
@@ -1195,4 +1209,15 @@ void CPointerManager::damageCursor(PHLMONITOR pMonitor, bool skipFrameSchedule) 
 
 Vector2D CPointerManager::cursorSizeLogical() {
     return m_currentCursorImage.size / m_currentCursorImage.scale;
+}
+
+void CPointerManager::addTransformer(const SP<CPointerTransformer>& transformer) {
+    if (!transformer || std::ranges::contains(m_transformers, transformer))
+        return;
+
+    m_transformers.emplace_back(transformer);
+}
+
+void CPointerManager::removeTransformer(const SP<CPointerTransformer>& transformer) {
+    std::erase(m_transformers, transformer);
 }

--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -15,6 +15,7 @@
 #include "../render/pass/TexPassElement.hpp"
 #include "../managers/input/InputManager.hpp"
 #include "../render/Renderer.hpp"
+#include "../render/pass/Pass.hpp"
 #include "../render/OpenGL.hpp"
 #include "../desktop/state/FocusState.hpp"
 #include "../managers/SeatManager.hpp"
@@ -611,9 +612,10 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
         return buf;
     }
 
-    g_pHyprRenderer->m_renderData.pMonitor = state->monitor;
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{state->monitor, pass};
 
-    auto RBO = g_pHyprRenderer->getOrCreateRenderbuffer(buf, state->monitor->m_cursorSwapchain->currentOptions().format);
+    auto                      RBO = g_pHyprRenderer->getOrCreateRenderbuffer(buf, state->monitor->m_cursorSwapchain->currentOptions().format);
     if (!RBO) {
         Log::logger->log(Log::TRACE, "Failed to create cursor RB with format {}, mod {}", buf->dmabuf().format, buf->dmabuf().modifier);
         return nullptr;
@@ -627,27 +629,26 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
     FB->setImageDescription(state->monitor->m_imageDescription);
 
     CRegion damageRegion = {0, 0, INT_MAX, INT_MAX};
-    g_pHyprRenderer->beginFullFakeRender(state->monitor.lock(), damageRegion, FB);
-    g_pHyprRenderer->m_renderData.fbSize = FB->m_size;
-    g_pHyprRenderer->setProjectionType(Render::RPT_FB);
-    g_pHyprRenderer->m_renderData.transformDamage = true;
-    g_pHyprRenderer->startRenderPass();
-    g_pHyprRenderer->draw(CClearPassElement::SClearData{{0.F, 0.F, 0.F, 0.F}});
+    g_pHyprRenderer->beginFullFakeRender(context, damageRegion, FB);
+    context.fbSize = FB->m_size;
+    g_pHyprRenderer->setProjectionType(context, Render::RPT_FB);
+    context.transformDamage = true;
+    g_pHyprRenderer->startRenderPass(context);
+    g_pHyprRenderer->draw(context, CClearPassElement::SClearData{{0.F, 0.F, 0.F, 0.F}});
 
     CBox xbox = {{}, Vector2D{m_currentCursorImage.size / m_currentCursorImage.scale * state->monitor->m_scale}.round()};
     Log::logger->log(Log::TRACE, "[pointer] monitor: {}, size: {}, hw buf: {}, scale: {:.2f}, monscale: {:.2f}, xbox: {}", state->monitor->m_name, m_currentCursorImage.size,
                      cursorSize, m_currentCursorImage.scale, state->monitor->m_scale, xbox.size());
 
-    g_pHyprRenderer->draw(CTexPassElement::SRenderData{.tex = texture, .box = xbox}, damageRegion);
+    g_pHyprRenderer->draw(context, CTexPassElement::SRenderData{.tex = texture, .box = xbox}, damageRegion);
 
-    g_pHyprRenderer->endRender();
-    g_pHyprRenderer->m_renderData.pMonitor.reset();
+    g_pHyprRenderer->endRender(context);
 
     return buf;
 }
 
-void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage, std::optional<Vector2D> overridePos, bool screencopy,
-                                               bool forceRender) {
+void CPointerManager::renderSoftwareCursorsFor(Render::CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage,
+                                               std::optional<Vector2D> overridePos, bool screencopy, bool forceRender) {
     if (!hasCursor())
         return;
 
@@ -690,7 +691,7 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
     data.tex = texture;
     data.box = box.round();
 
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
 
     // to erase the leftover in updateCursorBackend()
     if (!screencopy) {

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -29,6 +29,8 @@ AQUAMARINE_FORWARD(IOutput);
 
 namespace Pointer {
 
+    class CPointerTransformer;
+
     class CPointerManager {
       public:
         CPointerManager();
@@ -67,10 +69,15 @@ namespace Pointer {
 
         //
         Vector2D position();
+        Vector2D untransformedPosition() const;
         Vector2D hotspot();
         Vector2D cursorSizeLogical();
 
-        void     recheckEnteredOutputs();
+        // Transformer logic
+        void addTransformer(const SP<CPointerTransformer>& transformer);
+        void removeTransformer(const SP<CPointerTransformer>& transformer);
+
+        void recheckEnteredOutputs();
 
         // returns the thing in global coords
         CBox getCursorBoxGlobal();
@@ -192,6 +199,8 @@ namespace Pointer {
         bool                                  attemptHardwareCursor(SP<SMonitorPointerState> state);
         SP<Aquamarine::IBuffer>               renderHWCursorBuffer(SP<SMonitorPointerState> state, SP<Render::ITexture> texture);
         bool                                  setHWCursorBuffer(SP<SMonitorPointerState> state, SP<Aquamarine::IBuffer> buf);
+
+        std::vector<SP<CPointerTransformer>>  m_transformers;
 
         struct {
             CHyprSignalListener monitorAdded;

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -13,6 +13,7 @@
 
 class IHID;
 namespace Render {
+    class CRenderingContext;
     class ITexture;
 }
 
@@ -55,8 +56,8 @@ namespace Pointer {
         bool softwareLockedFor(PHLMONITOR pMonitor);
         bool hasVisibleHWCursor(PHLMONITOR pMonitor);
 
-        void renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage /* logical */, std::optional<Vector2D> overridePos = {} /* monitor-local */,
-                                      bool screencopy = false, bool forceRender = false);
+        void renderSoftwareCursorsFor(Render::CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage /* logical */,
+                                      std::optional<Vector2D> overridePos = {} /* monitor-local */, bool screencopy = false, bool forceRender = false);
 
         // this is needed e.g. during screensharing where
         // the software cursors aren't locked during the cursor move, but they

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -13,6 +13,7 @@
 
 class IHID;
 namespace Render {
+    class CRenderingContext;
     class ITexture;
 }
 
@@ -56,8 +57,8 @@ namespace Pointer {
         bool softwareLockedFor(PHLMONITOR pMonitor);
         bool hasVisibleHWCursor(PHLMONITOR pMonitor);
 
-        void renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage /* logical */, std::optional<Vector2D> overridePos = {} /* monitor-local */,
-                                      bool screencopy = false, bool forceRender = false);
+        void renderSoftwareCursorsFor(Render::CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage /* logical */,
+                                      std::optional<Vector2D> overridePos = {} /* monitor-local */, bool screencopy = false, bool forceRender = false);
 
         // this is needed e.g. during screensharing where
         // the software cursors aren't locked during the cursor move, but they

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -28,6 +28,8 @@ AQUAMARINE_FORWARD(IBuffer);
 
 namespace Pointer {
 
+    class CPointerTransformer;
+
     class CPointerManager {
       public:
         CPointerManager();
@@ -66,10 +68,15 @@ namespace Pointer {
 
         //
         Vector2D position();
+        Vector2D untransformedPosition() const;
         Vector2D hotspot();
         Vector2D cursorSizeLogical();
 
-        void     recheckEnteredOutputs();
+        // Transformer logic
+        void addTransformer(const SP<CPointerTransformer>& transformer);
+        void removeTransformer(const SP<CPointerTransformer>& transformer);
+
+        void recheckEnteredOutputs();
 
         // returns the thing in global coords
         CBox getCursorBoxGlobal();
@@ -191,6 +198,8 @@ namespace Pointer {
         bool                                  attemptHardwareCursor(SP<SMonitorPointerState> state);
         SP<Aquamarine::IBuffer>               renderHWCursorBuffer(SP<SMonitorPointerState> state, SP<Render::ITexture> texture);
         bool                                  setHWCursorBuffer(SP<SMonitorPointerState> state, SP<Aquamarine::IBuffer> buf);
+
+        std::vector<SP<CPointerTransformer>>  m_transformers;
 
         struct {
             CHyprSignalListener monitorAdded;

--- a/src/pointer/PointerTransformer.cpp
+++ b/src/pointer/PointerTransformer.cpp
@@ -1,0 +1,13 @@
+#include "PointerTransformer.hpp"
+
+#include <utility>
+
+using namespace Pointer;
+
+CPointerTransformer::CPointerTransformer(std::function<Vector2D(Vector2D)> transform) : m_transform(std::move(transform)) {
+    ;
+}
+
+Vector2D CPointerTransformer::transform(Vector2D pos) const {
+    return m_transform ? m_transform(pos) : pos;
+}

--- a/src/pointer/PointerTransformer.hpp
+++ b/src/pointer/PointerTransformer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../helpers/math/Math.hpp"
+
+#include <functional>
+
+namespace Pointer {
+    /*
+     * A pointer transformer takes the absolute pointer coords and transforms them according to its own
+     * logic. Pointer::mgr()->position() will return those coords.
+     */
+    class CPointerTransformer {
+      public:
+        CPointerTransformer(std::function<Vector2D(Vector2D)> transform);
+        ~CPointerTransformer() = default;
+
+        Vector2D transform(Vector2D pos) const;
+
+      private:
+        std::function<Vector2D(Vector2D)> m_transform;
+    };
+}

--- a/src/pointer/cursor/CursorShapeOverrideController.hpp
+++ b/src/pointer/cursor/CursorShapeOverrideController.hpp
@@ -12,6 +12,8 @@ namespace Pointer::Cursor {
         CURSOR_OVERRIDE_UNKNOWN = 0,
         // window edges for resizing from edge
         CURSOR_OVERRIDE_WINDOW_EDGE,
+        // compositor-owned interactive UI
+        CURSOR_OVERRIDE_INTERNAL_UI,
         // Drag and drop
         CURSOR_OVERRIDE_DND,
         // special action: Interactive::CDrag, kill, etc.

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -91,10 +91,10 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
                     if (view) {
                         const auto& window        = view->type() == Desktop::View::VIEW_TYPE_WINDOW ? dynamicPointerCast<Desktop::View::CWindow>(view) : nullptr;
                         const auto  alphaModifier = dynamicPointerCast<Desktop::View::IAlphaModifiable>(view);
-                        const bool  isVisible     = (view->mapped() && view->acceptsInput() && (!alphaModifier || alphaModifier->alphaNonZero()) && //
-                                                     (!window || std::ranges::any_of(State::monitorState()->monitors(), [window](const auto& mon) {
-                                                    return g_pHyprRenderer->shouldRenderWindow(window, mon);
-                                                     })));
+                        const bool  isVisible     = view->mapped() && view->acceptsInput() && (!alphaModifier || alphaModifier->alphaNonZero()) &&
+                            (!window || std::ranges::any_of(State::monitorState()->monitors(), [window](const auto& monitor) {
+                                                   return g_pHyprRenderer->shouldRenderWindow(window, monitor);
+                                               }));
                         if (isVisible)
                             shouldLock = true;
                         else if (*PINVIS == 2) // never

--- a/src/protocols/ImageCopyCapture.cpp
+++ b/src/protocols/ImageCopyCapture.cpp
@@ -325,7 +325,7 @@ void CImageCopyCaptureCursorSession::sendCursorEvents() {
     if (!overlaps)
         return;
 
-    Vector2D pos = Pointer::mgr()->position() - sourceBox.pos();
+    Vector2D pos = Pointer::mgr()->untransformedPosition() - sourceBox.pos();
     if (pos != m_pos) {
         m_pos = pos;
         m_resource->sendPosition(m_pos.x, m_pos.y);

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -826,7 +826,7 @@ void CWLDataDeviceProtocol::abortDrag() {
     g_pSeatManager->resendEnterEvents();
 }
 
-void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, const Time::steady_tp& when) {
+void CWLDataDeviceProtocol::renderDND(Render::CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& when) {
     if (!m_dnd.dndSurface || !m_dnd.dndSurface->m_current.texture)
         return;
 
@@ -841,7 +841,7 @@ void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, const Time::steady_tp
     CTexPassElement::SRenderData data;
     data.tex = m_dnd.dndSurface->m_current.texture;
     data.box = box;
-    g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
 
     CBox damageBox = CBox{surfacePos, m_dnd.dndSurface->m_current.size}.expand(5);
     g_pHyprRenderer->damageBox(damageBox);

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -841,7 +841,7 @@ void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, const Time::steady_tp
     CTexPassElement::SRenderData data;
     data.tex = m_dnd.dndSurface->m_current.texture;
     data.box = box;
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+    g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
 
     CBox damageBox = CBox{surfacePos, m_dnd.dndSurface->m_current.size}.expand(5);
     g_pHyprRenderer->damageBox(damageBox);

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -23,6 +23,9 @@
 class CWLDataDeviceResource;
 class CWLDataDeviceManagerResource;
 class CWLDataSourceResource;
+namespace Render {
+    class CRenderingContext;
+}
 class CWLDataOfferResource;
 
 class CWLSurfaceResource;
@@ -139,7 +142,7 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
     // renders and damages the dnd icon, if present
-    void renderDND(PHLMONITOR pMonitor, const Time::steady_tp& when);
+    void renderDND(Render::CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& when);
     // for inputmgr to force refocus
     // TODO: move handling to seatmgr
     bool dndActive();

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -15,25 +15,25 @@
 
 using namespace Render;
 
-void IElementRenderer::drawElement(WP<IPassElement> element, const CRegion& damage) {
+void IElementRenderer::drawElement(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage) {
     if (!element)
         return;
 
     switch (element->type()) {
-        case EK_BORDER: draw(dynamicPointerCast<CBorderPassElement>(element), damage); break;
-        case EK_CLEAR: drawClear(dynamicPointerCast<CClearPassElement>(element), damage); break;
-        case EK_FRAMEBUFFER: draw(dynamicPointerCast<CFramebufferElement>(element), damage); break;
-        case EK_PRE_BLUR: drawPreBlur(dynamicPointerCast<CPreBlurElement>(element), damage); break;
-        case EK_RECT: drawRect(dynamicPointerCast<CRectPassElement>(element), damage); break;
-        case EK_HINTS: drawHints(dynamicPointerCast<CRendererHintsPassElement>(element), damage); break;
-        case EK_SHADOW: draw(dynamicPointerCast<CShadowPassElement>(element), damage); break;
-        case EK_INNER_GLOW: draw(dynamicPointerCast<CInnerGlowPassElement>(element), damage); break;
-        case EK_SURFACE: preDrawSurface(dynamicPointerCast<CSurfacePassElement>(element), damage); break;
-        case EK_TEXTURE: drawTex(dynamicPointerCast<CTexPassElement>(element), damage); break;
-        case EK_TEXTURE_MATTE: drawTexMatte(dynamicPointerCast<CTextureMatteElement>(element), damage); break;
-        case EK_TRANSFORMED_WINDOW: drawTransformedWindow(dynamicPointerCast<CTransformedWindowPassElement>(element), damage); break;
-        case EK_BACKDROP_SCOPE: drawCustom(element, damage); break;
-        case EK_CUSTOM: drawCustom(element, damage); break;
+        case EK_BORDER: draw(context, dynamicPointerCast<CBorderPassElement>(element), damage); break;
+        case EK_CLEAR: drawClear(context, dynamicPointerCast<CClearPassElement>(element), damage); break;
+        case EK_FRAMEBUFFER: draw(context, dynamicPointerCast<CFramebufferElement>(element), damage); break;
+        case EK_PRE_BLUR: drawPreBlur(context, dynamicPointerCast<CPreBlurElement>(element), damage); break;
+        case EK_RECT: drawRect(context, dynamicPointerCast<CRectPassElement>(element), damage); break;
+        case EK_HINTS: drawHints(context, dynamicPointerCast<CRendererHintsPassElement>(element), damage); break;
+        case EK_SHADOW: draw(context, dynamicPointerCast<CShadowPassElement>(element), damage); break;
+        case EK_INNER_GLOW: draw(context, dynamicPointerCast<CInnerGlowPassElement>(element), damage); break;
+        case EK_SURFACE: preDrawSurface(context, dynamicPointerCast<CSurfacePassElement>(element), damage); break;
+        case EK_TEXTURE: drawTex(context, dynamicPointerCast<CTexPassElement>(element), damage); break;
+        case EK_TEXTURE_MATTE: drawTexMatte(context, dynamicPointerCast<CTextureMatteElement>(element), damage); break;
+        case EK_TRANSFORMED_WINDOW: drawTransformedWindow(context, dynamicPointerCast<CTransformedWindowPassElement>(element), damage); break;
+        case EK_BACKDROP_SCOPE: drawCustom(context, element, damage); break;
+        case EK_CUSTOM: drawCustom(context, element, damage); break;
         default: Log::logger->log(Log::WARN, "Unimplimented draw for {}", element->passName());
     }
 }
@@ -57,10 +57,8 @@ static std::optional<Vector2D> getSurfaceExpectedSize(PHLWINDOW pWindow, SP<CWLS
     return std::nullopt;
 }
 
-void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface, PHLMONITOR pMonitor, bool main, const Vector2D& projSize,
-                                             const Vector2D& projSizeUnscaled, bool fixMisalignedFSV1) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-
+void IElementRenderer::calculateUVForSurface(CRenderingContext& context, PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface, PHLMONITOR pMonitor, bool main,
+                                             const Vector2D& projSize, const Vector2D& projSizeUnscaled, bool fixMisalignedFSV1) {
     if (!pWindow || !pWindow->backend().isX11()) {
         static auto PEXPANDEDGES = CConfigValue<Hyprlang::INT>("render:expand_undersized_textures");
 
@@ -123,13 +121,13 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
             }
         }
 
-        m_renderData.primarySurfaceUVTopLeft     = uvTL;
-        m_renderData.primarySurfaceUVBottomRight = uvBR;
+        context.primarySurfaceUVTopLeft     = uvTL;
+        context.primarySurfaceUVBottomRight = uvBR;
 
-        if (m_renderData.primarySurfaceUVTopLeft == Vector2D() && m_renderData.primarySurfaceUVBottomRight == Vector2D(1, 1)) {
+        if (context.primarySurfaceUVTopLeft == Vector2D() && context.primarySurfaceUVBottomRight == Vector2D(1, 1)) {
             // No special UV mods needed
-            m_renderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-            m_renderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
+            context.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+            context.primarySurfaceUVBottomRight = Vector2D(-1, -1);
         }
 
         if (!main || !pWindow)
@@ -151,94 +149,86 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
         //     uvTL               = uvTL + TOADDTL;
         // }
 
-        m_renderData.primarySurfaceUVTopLeft     = uvTL;
-        m_renderData.primarySurfaceUVBottomRight = uvBR;
+        context.primarySurfaceUVTopLeft     = uvTL;
+        context.primarySurfaceUVBottomRight = uvBR;
 
-        if (m_renderData.primarySurfaceUVTopLeft == Vector2D() && m_renderData.primarySurfaceUVBottomRight == Vector2D(1, 1)) {
+        if (context.primarySurfaceUVTopLeft == Vector2D() && context.primarySurfaceUVBottomRight == Vector2D(1, 1)) {
             // No special UV mods needed
-            m_renderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-            m_renderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
+            context.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+            context.primarySurfaceUVBottomRight = Vector2D(-1, -1);
         }
     } else {
-        m_renderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-        m_renderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
+        context.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+        context.primarySurfaceUVBottomRight = Vector2D(-1, -1);
     }
 }
 
-void IElementRenderer::drawRect(WP<CRectPassElement> element, const CRegion& damage) {
-    auto& data         = element->m_data;
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void IElementRenderer::drawRect(CRenderingContext& context, WP<CRectPassElement> element, const CRegion& damage) {
+    auto& data = element->m_data;
 
     if (data.box.w <= 0 || data.box.h <= 0)
         return;
 
     if (!data.clipBox.empty())
-        m_renderData.clipBox = data.clipBox;
+        context.clipBox = data.clipBox;
 
     data.modifiedBox = data.box;
-    m_renderData.renderModif.applyToBox(data.modifiedBox);
+    context.renderModif.applyToBox(data.modifiedBox);
 
     data.TOPLEFT[0]  = sc<float>(data.modifiedBox.x);
     data.TOPLEFT[1]  = sc<float>(data.modifiedBox.y);
     data.FULLSIZE[0] = sc<float>(data.modifiedBox.width);
     data.FULLSIZE[1] = sc<float>(data.modifiedBox.height);
 
-    data.drawRegion = data.color.a == 1.F || !data.blur ? damage : m_renderData.damage;
+    data.drawRegion = data.color.a == 1.F || !data.blur ? damage : context.damage;
 
-    if (m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0) {
-        CRegion damageClip{m_renderData.clipBox.x, m_renderData.clipBox.y, m_renderData.clipBox.width, m_renderData.clipBox.height};
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        CRegion damageClip{context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
         data.drawRegion = damageClip.intersect(data.drawRegion);
     }
 
-    draw(element, damage);
+    draw(context, element, damage);
 
-    m_renderData.clipBox = {};
+    context.clipBox = {};
 }
 
-void IElementRenderer::drawHints(WP<CRendererHintsPassElement> element, const CRegion& damage) {
+void IElementRenderer::drawHints(CRenderingContext& context, WP<CRendererHintsPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
     if (m_data.renderModif.has_value())
-        g_pHyprRenderer->m_renderData.renderModif = *m_data.renderModif;
+        context.renderModif = *m_data.renderModif;
 }
 
-void IElementRenderer::drawPreBlur(WP<CPreBlurElement> element, const CRegion& damage) {
+void IElementRenderer::drawPreBlur(CRenderingContext& context, WP<CPreBlurElement> element, const CRegion& damage) {
     TRACY_GPU_ZONE("RenderPreBlurForCurrentMonitor");
-    auto&      m_renderData = g_pHyprRenderer->m_renderData;
-
-    const auto SAVEDRENDERMODIF = m_renderData.renderModif;
-    const auto SAVEDDAMAGE      = m_renderData.damage;
-    m_renderData.renderModif    = {}; // fix shit
+    CRenderingContext child{context, context.renderPass()};
+    child.renderModif = {};
 
     // make the fake dmg
-    CRegion fakeDamage{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+    CRegion fakeDamage{0, 0, child.sceneMonitor->m_transformedSize.x, child.sceneMonitor->m_transformedSize.y};
 
-    m_renderData.damage = fakeDamage; // the clear inside scissors to renderData.damage, it has to match the blit
+    child.damage = fakeDamage; // the clear inside scissors to renderData.damage, it has to match the blit
 
-    draw(element, fakeDamage);
+    draw(child, element, fakeDamage);
 
-    m_renderData.pMonitor->m_blurFBDirty        = false;
-    m_renderData.pMonitor->m_blurFBShouldRender = false;
-
-    m_renderData.renderModif = SAVEDRENDERMODIF;
-    m_renderData.damage      = SAVEDDAMAGE;
+    context.sceneMonitor->m_blurFBDirty = false;
+    context.precomputeBlur              = false;
 }
 
-void IElementRenderer::drawClear(WP<CClearPassElement> element, const CRegion& damage) {
-    element->m_data.color = g_pHyprRenderer->getConvertedColor(element->m_data.color); // FIXME create element copy?
-    draw(element, damage);
+void IElementRenderer::drawClear(CRenderingContext& context, WP<CClearPassElement> element, const CRegion& damage) {
+    element->m_data.color = g_pHyprRenderer->getConvertedColor(context, element->m_data.color); // FIXME create element copy?
+    draw(context, element, damage);
 }
 
-void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegion& damage) {
-    const auto&                   m_data       = element->m_data;
-    auto&                         m_renderData = g_pHyprRenderer->m_renderData;
+void IElementRenderer::drawSurface(CRenderingContext& context, WP<CSurfacePassElement> element, const CRegion& damage) {
+    const auto&                   m_data = element->m_data;
 
-    Hyprutils::Utils::CScopeGuard x = {[]() {
-        g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-        g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
+    Hyprutils::Utils::CScopeGuard x = {[&context]() {
+        context.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+        context.primarySurfaceUVBottomRight = Vector2D(-1, -1);
     }};
 
     if (!m_data.texture) {
-        element->discard();
+        element->discard(context);
         return;
     }
 
@@ -247,7 +237,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
     // this is bad, probably has been logged elsewhere. Means the texture failed
     // uploading to the GPU.
     if (!TEXTURE->ok()) {
-        element->discard();
+        element->discard(context);
         return;
     }
 
@@ -268,7 +258,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
     windowBox.round();
 
     if (windowBox.width <= 1 || windowBox.height <= 1) {
-        element->discard();
+        element->discard(context);
         return;
     }
 
@@ -278,25 +268,25 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
         (!m_data.pWindow || (!m_data.pWindow->sizeAnimation()->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */ &&
         (!m_data.pLS || (!m_data.pLS->sizeAnimation()->isBeingAnimated())); /* not LS or not animated */
 
-    calculateUVForSurface(m_data.pWindow, m_data.surface, m_data.pMonitor->m_self.lock(), m_data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
+    calculateUVForSurface(context, m_data.pWindow, m_data.surface, m_data.pMonitor->m_self.lock(), m_data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
 
     auto    cancelRender = false;
     CRegion clipRegion;
 
-    if (!m_renderData.renderingTransformedSource) {
-        clipRegion = element->visibleRegion(cancelRender);
+    if (!context.renderingTransformedSource) {
+        clipRegion = element->visibleRegion(context, cancelRender);
         if (cancelRender) {
-            element->discard();
+            element->discard(context);
             return;
         }
     }
 
-    const auto surfaceDamage = [&m_renderData, &windowBox] {
-        if (m_renderData.renderingTransformedSource)
-            return m_renderData.damage.copy();
+    const auto surfaceDamage = [&context, &windowBox] {
+        if (context.renderingTransformedSource)
+            return context.damage.copy();
 
-        CRegion renderDamage = m_renderData.damage.copy().intersect(windowBox);
-        m_renderData.renderModif.applyToRegion(renderDamage);
+        CRegion renderDamage = context.damage.copy().intersect(windowBox);
+        context.renderModif.applyToRegion(renderDamage);
         return renderDamage;
     };
 
@@ -305,7 +295,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
     // as long as the window is not animated. During those it'd look weird.
     // UV will fixup it as well
     if (MISALIGNEDFSV1)
-        m_renderData.useNearestNeighbor = true;
+        context.useNearestNeighbor = true;
 
     float rounding      = m_data.rounding;
     float roundingPower = m_data.roundingPower;
@@ -333,7 +323,8 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
             CBox blurPatternBox = {m_data.pos.x - m_data.pMonitor->m_position.x, m_data.pos.y - m_data.pMonitor->m_position.y, m_data.w, m_data.h};
             blurPatternBox.scale(m_data.pMonitor->m_scale).round();
 
-            drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
+            drawElement(context,
+                        makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex                   = TEXTURE,
                             .box                   = windowBox,
                             .a                     = ALPHA,
@@ -357,7 +348,8 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
 
                         surfaceDamage());
         } else
-            drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
+            drawElement(context,
+                        makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex            = TEXTURE,
                             .box            = windowBox,
                             .a              = ALPHA * OVERALL_ALPHA,
@@ -376,7 +368,8 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                         surfaceDamage());
     } else {
         if (BLUR && m_data.popup)
-            drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
+            drawElement(context,
+                        makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex                   = TEXTURE,
                             .box                   = windowBox,
                             .a                     = ALPHA,
@@ -397,7 +390,8 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                         }),
                         surfaceDamage());
         else
-            drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
+            drawElement(context,
+                        makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex            = TEXTURE,
                             .box            = windowBox,
                             .a              = ALPHA * OVERALL_ALPHA,
@@ -418,52 +412,51 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
 
     g_pHyprRenderer->blend(true);
 
-    if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)
-        element->m_data.surface->presentFeedback(element->m_data.when, element->m_data.pMonitor->m_self.lock());
+    if (!context.blockSurfaceFeedback)
+        element->m_data.surface->presentFeedback(element->m_data.when, context.outputMonitor.lock());
 };
 
-void IElementRenderer::preDrawSurface(WP<CSurfacePassElement> element, const CRegion& damage) {
-    auto& m_renderData              = g_pHyprRenderer->m_renderData;
-    m_renderData.clipBox            = m_renderData.renderingTransformedSource ? CBox{} : element->m_data.clipBox;
-    m_renderData.useNearestNeighbor = element->m_data.useNearestNeighbor;
-    m_renderData.currentWindow      = element->m_data.pWindow;
+void IElementRenderer::preDrawSurface(CRenderingContext& context, WP<CSurfacePassElement> element, const CRegion& damage) {
+    context.clipBox            = context.renderingTransformedSource ? CBox{} : element->m_data.clipBox;
+    context.useNearestNeighbor = element->m_data.useNearestNeighbor;
+    context.currentWindow      = element->m_data.pWindow;
 
-    drawSurface(element, damage);
+    drawSurface(context, element, damage);
 
     // add async (dmabuf) buffers to usedBuffers so we can handle release later
     // sync (shm) buffers will be released in commitState, so no need to track them here.
-    if (element->m_data.surface->m_current.buffer && !element->m_data.surface->m_current.buffer->isSynchronous() &&
-        std::ranges::none_of(element->m_data.pMonitor->m_usedAsyncBuffers,
+    const auto OUTPUT_MONITOR = context.outputMonitor.lock();
+    if (OUTPUT_MONITOR && element->m_data.surface->m_current.buffer && !element->m_data.surface->m_current.buffer->isSynchronous() &&
+        std::ranges::none_of(OUTPUT_MONITOR->m_usedAsyncBuffers,
                              [&](const auto& e) { return e.first == element->m_data.surface && e.second == element->m_data.surface->m_current.buffer; }))
-        element->m_data.pMonitor->m_usedAsyncBuffers.emplace_back(element->m_data.surface, element->m_data.surface->m_current.buffer);
+        OUTPUT_MONITOR->m_usedAsyncBuffers.emplace_back(element->m_data.surface, element->m_data.surface->m_current.buffer);
 
-    m_renderData.clipBox            = {};
-    m_renderData.useNearestNeighbor = false;
-    m_renderData.currentWindow.reset();
+    context.clipBox            = {};
+    context.useNearestNeighbor = false;
+    context.currentWindow.reset();
 }
 
-void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damage) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void IElementRenderer::drawTex(CRenderingContext& context, WP<CTexPassElement> element, const CRegion& damage) {
     if (!element->m_data.clipBox.empty())
-        m_renderData.clipBox = element->m_data.clipBox;
+        context.clipBox = element->m_data.clipBox;
 
-    m_renderData.surface = element->m_data.surface;
+    context.surface = element->m_data.surface;
 
-    const auto transformClipRegion = [&element, &m_renderData] {
+    const auto transformClipRegion = [&element, &context] {
         CRegion clipRegion = element->m_data.clipRegion.copy();
-        m_renderData.renderModif.applyToRegion(clipRegion);
+        context.renderModif.applyToRegion(clipRegion);
         element->m_data.clipRegion = clipRegion;
     };
 
-    Hyprutils::Utils::CScopeGuard x = {[]() {
-        g_pHyprRenderer->m_renderData.surface.reset();
-        g_pHyprRenderer->m_renderData.clipBox = {};
+    Hyprutils::Utils::CScopeGuard x = {[&context]() {
+        context.surface.reset();
+        context.clipBox = {};
     }};
 
     if (element->m_data.blur) {
         // make a damage region for this window
-        CRegion texDamage = element->m_data.useProvidedDamage ? element->m_data.damage : m_renderData.damage;
-        if (!element->m_data.useProvidedDamage && !m_renderData.renderingTransformedSource)
+        CRegion texDamage = element->m_data.useProvidedDamage ? element->m_data.damage : context.damage;
+        if (!element->m_data.useProvidedDamage && !context.renderingTransformedSource)
             texDamage.intersect(element->m_data.box.x, element->m_data.box.y, element->m_data.box.width, element->m_data.box.height);
 
         // While renderTextureInternalWithDamage will clip the blur as well,
@@ -475,7 +468,7 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
             return;
 
         if (!element->m_data.useProvidedDamage)
-            m_renderData.renderModif.applyToRegion(texDamage);
+            context.renderModif.applyToRegion(texDamage);
 
         element->m_data.damage = texDamage;
 
@@ -483,8 +476,8 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
         const auto& surface = element->m_data.surface;
         const auto& box     = element->m_data.box;
         CRegion     inverseOpaque;
-        if (element->m_data.a >= 1.f && surface && std::round(surface->m_current.size.x * m_renderData.pMonitor->m_scale) == box.w &&
-            std::round(surface->m_current.size.y * m_renderData.pMonitor->m_scale) == box.h) {
+        if (element->m_data.a >= 1.f && surface && std::round(surface->m_current.size.x * context.sceneMonitor->m_scale) == box.w &&
+            std::round(surface->m_current.size.y * context.sceneMonitor->m_scale) == box.h) {
             pixman_box32_t surfbox = {0, 0, surface->m_current.size.x * surface->m_current.scale, surface->m_current.size.y * surface->m_current.scale};
             inverseOpaque          = surface->m_current.opaque;
             inverseOpaque.invert(&surfbox).intersect(0, 0, surface->m_current.size.x * surface->m_current.scale, surface->m_current.size.y * surface->m_current.scale);
@@ -492,27 +485,27 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
             if (inverseOpaque.empty()) {
                 element->m_data.blur = false;
                 transformClipRegion();
-                draw(element, damage);
+                draw(context, element, damage);
                 return;
             }
         } else
             inverseOpaque = {0, 0, element->m_data.box.width, element->m_data.box.height};
 
-        inverseOpaque.scale(m_renderData.pMonitor->m_scale);
-        element->m_data.blockBlurOptimization = element->usesLiveBlur();
+        inverseOpaque.scale(context.sceneMonitor->m_scale);
+        element->m_data.blockBlurOptimization = element->usesLiveBlur(context);
 
         //   vvv TODO: layered blur fbs?
         SP<IFramebuffer> blurredFB;
         if (element->m_data.blockBlurOptimization.value_or(false)) {
             inverseOpaque.translate(box.pos());
-            m_renderData.renderModif.applyToRegion(inverseOpaque);
+            context.renderModif.applyToRegion(inverseOpaque);
             inverseOpaque.intersect(element->m_data.damage);
             auto patternBox = element->m_data.blurPatternBox.value_or(box);
-            m_renderData.renderModif.applyToBox(patternBox);
+            context.renderModif.applyToBox(patternBox);
             std::optional<SBlurShape> shape;
             if (!element->m_data.blurShapeInvalid) {
                 auto shapeBox = box;
-                m_renderData.renderModif.applyToBox(shapeBox);
+                context.renderModif.applyToBox(shapeBox);
                 if (std::abs(shapeBox.rot) < 0.0001F)
                     shape = SBlurShape{
                         .box           = shapeBox,
@@ -520,30 +513,31 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
                         .roundingPower = element->m_data.roundingPower,
                     };
             }
-            blurredFB = g_pHyprRenderer->blurMainFramebuffer(element->m_data.a, inverseOpaque, {.patternBox = patternBox, .owner = element->m_data.blurOwner, .shape = shape});
+            blurredFB =
+                g_pHyprRenderer->blurMainFramebuffer(context, element->m_data.a, inverseOpaque, {.patternBox = patternBox, .owner = element->m_data.blurOwner, .shape = shape});
             element->m_data.blurredBG = blurredFB->getTexture();
         } else
-            element->m_data.blurredBG = m_renderData.pMonitor->resources()->m_blurFB->getTexture();
+            element->m_data.blurredBG = context.sceneMonitor->resources()->m_blurFB->getTexture();
 
         transformClipRegion();
-        draw(element, damage);
+        draw(context, element, damage);
     } else {
         transformClipRegion();
-        draw(element, damage);
+        draw(context, element, damage);
     }
 }
 
-void IElementRenderer::drawTexMatte(WP<CTextureMatteElement> element, const CRegion& damage) {
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+void IElementRenderer::drawTexMatte(CRenderingContext& context, WP<CTextureMatteElement> element, const CRegion& damage) {
+    if (context.damage.empty())
         return;
 
     const auto& m_data = element->m_data;
     if (m_data.disableTransformAndModify) {
-        g_pHyprRenderer->m_renderData.renderModif.enabled = false;
-        draw(element, damage);
-        g_pHyprRenderer->m_renderData.renderModif.enabled = true;
+        CRenderingContext child{context, context.renderPass()};
+        child.renderModif.enabled = false;
+        draw(child, element, damage);
     } else
-        draw(element, damage);
+        draw(context, element, damage);
 }
 
 static CBox motionBlurSourceBox(const SMotionBlurData& motionBlur, const CBox& outputBox, double padding) {
@@ -624,12 +618,12 @@ static bool transformPlanFits(const SWindowTransformPlan& plan, double scale, bo
     return !hasMatte || totalPixels <= MAX_TRANSFORMER_PIXELS / 2;
 }
 
-void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> element, const CRegion& damage) {
+void IElementRenderer::drawTransformedWindow(CRenderingContext& context, WP<CTransformedWindowPassElement> element, const CRegion& damage) {
     if (!element || !element->m_data.pass)
         return;
 
-    auto&      renderData = g_pHyprRenderer->m_renderData;
-    const auto pMonitor   = renderData.pMonitor;
+    auto&      renderData = context;
+    const auto pMonitor   = renderData.sceneMonitor;
     if (!pMonitor)
         return;
 
@@ -654,19 +648,14 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
         plan.outputBox = plan.sourceBox;
     }
 
-    const auto OLDRENDERDATA       = renderData;
-    const bool OLDBLURSHOULDRENDER = pMonitor->m_blurFBShouldRender;
-    const auto renderNestedDirect  = [&] {
-        {
-            auto guard               = g_pHyprRenderer->bindTempFB(OLDRENDERDATA.currentFB);
-            renderData.currentWindow = element->m_data.window;
-            renderData.surface.reset();
-            renderData.clipBox                    = {};
-            renderData.renderingTransformedSource = false;
-            element->m_data.pass->render(damage);
-        }
-        renderData                     = OLDRENDERDATA;
-        pMonitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
+    const auto renderNestedDirect = [&] {
+        CRenderingContext child{context, *element->m_data.pass};
+        child.currentWindow = element->m_data.window;
+        child.surface.reset();
+        child.clipBox                    = {};
+        child.renderingTransformedSource = false;
+        auto framebufferGuard            = g_pHyprRenderer->bindTempFB(child, context.currentFB);
+        element->m_data.pass->render(child, damage);
     };
 
     if (plan.sourceBox.empty() || !transformPlanFits(plan, pMonitor->m_scale, element->m_data.blur)) {
@@ -709,11 +698,11 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
 
     const CRegion  CANVASDAMAGE      = CRegion{0, 0, sc<int>(SOURCECANVAS.w), sc<int>(SOURCECANVAS.h)};
     const Vector2D CANVASTRANSLATION = -SOURCECANVAS.pos();
-    const auto     transformWindowFB = [&](const SWindowTransformBuffer& in) {
+    const auto     transformWindowFB = [&](CRenderingContext& transformContext, const SWindowTransformBuffer& in) {
         if (!applyTransformers)
             return in;
 
-        return PWINDOW->effects().transformers()->transform(in, plan,
+        return PWINDOW->effects().transformers()->transform(transformContext, in, plan,
                                                             SWindowTransformContext{
                                                                 .currentBox        = element->m_data.currentBox,
                                                                 .inputBox          = plan.sourceBox,
@@ -726,26 +715,26 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
 
     SWindowTransformBuffer last;
     {
-        auto guard = g_pHyprRenderer->bindTempFB(fb);
+        CRenderingContext child{context, *element->m_data.pass};
+        child.currentWindow = element->m_data.window;
+        child.surface.reset();
+        child.clipBox         = {};
+        child.damage          = CANVASDAMAGE;
+        child.transformDamage = false;
+        child.fbSize          = SOURCECANVAS.size();
+        auto framebufferGuard = g_pHyprRenderer->bindTempFB(child, fb);
+        g_pHyprRenderer->setProjectionType(child, RPT_EXPORT);
 
-        renderData.currentWindow = element->m_data.window;
-        renderData.surface.reset();
-        renderData.clipBox         = {};
-        renderData.damage          = CANVASDAMAGE;
-        renderData.transformDamage = false;
-        renderData.fbSize          = SOURCECANVAS.size();
-        g_pHyprRenderer->setProjectionType(RPT_EXPORT);
+        g_pHyprRenderer->draw(child, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
 
-        g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+        child.renderModif = {};
+        child.renderModif.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, CANVASTRANSLATION));
+        child.noSimplify                 = true;
+        child.renderingTransformedSource = true;
+        element->m_data.pass->render(child, CANVASDAMAGE);
 
-        renderData.renderModif = {};
-        renderData.renderModif.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, CANVASTRANSLATION));
-        renderData.noSimplify                 = true;
-        renderData.renderingTransformedSource = true;
-        element->m_data.pass->render(CANVASDAMAGE);
-
-        renderData.renderModif = {};
-        last                   = transformWindowFB({.framebuffer = fb, .box = SOURCECANVAS});
+        child.renderModif = {};
+        last              = transformWindowFB(child, {.framebuffer = fb, .box = SOURCECANVAS});
     }
 
     SP<IFramebuffer>     blurAlphaMatteFB;
@@ -753,32 +742,33 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
     if (matteFB) {
         SWindowTransformBuffer matteLast;
         {
-            auto guard = g_pHyprRenderer->bindTempFB(matteFB);
+            CRenderPass       mattePass;
+            CRenderingContext child{context, mattePass};
+            child.currentWindow = element->m_data.window;
+            child.surface.reset();
+            child.clipBox         = {};
+            child.damage          = CANVASDAMAGE;
+            child.transformDamage = false;
+            child.fbSize          = SOURCECANVAS.size();
+            auto framebufferGuard = g_pHyprRenderer->bindTempFB(child, matteFB);
+            g_pHyprRenderer->setProjectionType(child, RPT_EXPORT);
 
-            renderData.currentWindow = element->m_data.window;
-            renderData.surface.reset();
-            renderData.clipBox         = {};
-            renderData.damage          = CANVASDAMAGE;
-            renderData.transformDamage = false;
-            renderData.fbSize          = SOURCECANVAS.size();
-            g_pHyprRenderer->setProjectionType(RPT_EXPORT);
+            g_pHyprRenderer->draw(child, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 1)});
 
-            g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 1)});
+            child.renderModif = {};
+            child.renderModif.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, CANVASTRANSLATION));
 
-            renderData.renderModif = {};
-            renderData.renderModif.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, CANVASTRANSLATION));
+            g_pHyprRenderer->draw(child,
+                                  CRectPassElement::SRectData{
+                                      .box           = element->m_data.blurBox,
+                                      .color         = CHyprColor(1, 1, 1, 1),
+                                      .round         = element->m_data.blurRound,
+                                      .roundingPower = element->m_data.blurRoundingPower,
+                                  },
+                                  CANVASDAMAGE);
 
-            g_pHyprRenderer->draw(
-                CRectPassElement::SRectData{
-                    .box           = element->m_data.blurBox,
-                    .color         = CHyprColor(1, 1, 1, 1),
-                    .round         = element->m_data.blurRound,
-                    .roundingPower = element->m_data.blurRoundingPower,
-                },
-                CANVASDAMAGE);
-
-            renderData.renderModif = {};
-            matteLast              = transformWindowFB({.framebuffer = matteFB, .box = SOURCECANVAS});
+            child.renderModif = {};
+            matteLast         = transformWindowFB(child, {.framebuffer = matteFB, .box = SOURCECANVAS});
         }
 
         if (last.framebuffer && matteLast.framebuffer && matteLast.framebuffer->getTexture() && matteLast.success == last.success && matteLast.box == last.box &&
@@ -787,9 +777,6 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
             blurAlphaMatte   = matteLast.framebuffer->getTexture();
         }
     }
-
-    renderData                     = OLDRENDERDATA;
-    pMonitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
 
     if (!last.framebuffer || !last.framebuffer->getTexture())
         return;
@@ -833,12 +820,12 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
     }
 
     (void)blurAlphaMatteFB;
-    g_pHyprRenderer->draw(data, drawDamage);
+    drawElement(context, makeShared<CTexPassElement>(data), drawDamage);
 }
 
-void IElementRenderer::drawCustom(WP<IPassElement> element, const CRegion& damage) {
-    const auto& elements = element->draw();
+void IElementRenderer::drawCustom(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage) {
+    const auto& elements = element->draw(context);
     for (const auto& el : elements) {
-        drawElement(el, damage);
+        drawElement(context, el, damage);
     }
 }

--- a/src/render/ElementRenderer.hpp
+++ b/src/render/ElementRenderer.hpp
@@ -15,37 +15,39 @@
 #include <hyprutils/math/Region.hpp>
 
 namespace Render {
+    class CRenderingContext;
+
     class IElementRenderer {
       public:
         IElementRenderer()          = default;
         virtual ~IElementRenderer() = default;
 
-        void drawElement(WP<IPassElement> element, const CRegion& damage);
+        void drawElement(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage);
 
       protected:
-        virtual void draw(WP<CBorderPassElement> element, const CRegion& damage)    = 0;
-        virtual void draw(WP<CClearPassElement> element, const CRegion& damage)     = 0;
-        virtual void draw(WP<CFramebufferElement> element, const CRegion& damage)   = 0;
-        virtual void draw(WP<CPreBlurElement> element, const CRegion& damage)       = 0;
-        virtual void draw(WP<CRectPassElement> element, const CRegion& damage)      = 0;
-        virtual void draw(WP<CShadowPassElement> element, const CRegion& damage)    = 0;
-        virtual void draw(WP<CInnerGlowPassElement> element, const CRegion& damage) = 0;
-        virtual void draw(WP<CTexPassElement> element, const CRegion& damage)       = 0;
-        virtual void draw(WP<CTextureMatteElement> element, const CRegion& damage)  = 0;
+        virtual void draw(CRenderingContext& context, WP<CBorderPassElement> element, const CRegion& damage)    = 0;
+        virtual void draw(CRenderingContext& context, WP<CClearPassElement> element, const CRegion& damage)     = 0;
+        virtual void draw(CRenderingContext& context, WP<CFramebufferElement> element, const CRegion& damage)   = 0;
+        virtual void draw(CRenderingContext& context, WP<CPreBlurElement> element, const CRegion& damage)       = 0;
+        virtual void draw(CRenderingContext& context, WP<CRectPassElement> element, const CRegion& damage)      = 0;
+        virtual void draw(CRenderingContext& context, WP<CShadowPassElement> element, const CRegion& damage)    = 0;
+        virtual void draw(CRenderingContext& context, WP<CInnerGlowPassElement> element, const CRegion& damage) = 0;
+        virtual void draw(CRenderingContext& context, WP<CTexPassElement> element, const CRegion& damage)       = 0;
+        virtual void draw(CRenderingContext& context, WP<CTextureMatteElement> element, const CRegion& damage)  = 0;
 
       private:
-        void calculateUVForSurface(PHLWINDOW, SP<CWLSurfaceResource>, PHLMONITOR pMonitor, bool main = false, const Vector2D& projSize = {}, const Vector2D& projSizeUnscaled = {},
-                                   bool fixMisalignedFSV1 = false);
+        void calculateUVForSurface(CRenderingContext& context, PHLWINDOW, SP<CWLSurfaceResource>, PHLMONITOR pMonitor, bool main = false, const Vector2D& projSize = {},
+                                   const Vector2D& projSizeUnscaled = {}, bool fixMisalignedFSV1 = false);
 
-        void drawRect(WP<CRectPassElement> element, const CRegion& damage);
-        void drawHints(WP<CRendererHintsPassElement> element, const CRegion& damage);
-        void drawPreBlur(WP<CPreBlurElement> element, const CRegion& damage);
-        void drawClear(WP<CClearPassElement> element, const CRegion& damage);
-        void drawSurface(WP<CSurfacePassElement> element, const CRegion& damage);
-        void preDrawSurface(WP<CSurfacePassElement> element, const CRegion& damage);
-        void drawTex(WP<CTexPassElement> element, const CRegion& damage);
-        void drawTexMatte(WP<CTextureMatteElement> element, const CRegion& damage);
-        void drawTransformedWindow(WP<CTransformedWindowPassElement> element, const CRegion& damage);
-        void drawCustom(WP<IPassElement> element, const CRegion& damage);
+        void drawRect(CRenderingContext& context, WP<CRectPassElement> element, const CRegion& damage);
+        void drawHints(CRenderingContext& context, WP<CRendererHintsPassElement> element, const CRegion& damage);
+        void drawPreBlur(CRenderingContext& context, WP<CPreBlurElement> element, const CRegion& damage);
+        void drawClear(CRenderingContext& context, WP<CClearPassElement> element, const CRegion& damage);
+        void drawSurface(CRenderingContext& context, WP<CSurfacePassElement> element, const CRegion& damage);
+        void preDrawSurface(CRenderingContext& context, WP<CSurfacePassElement> element, const CRegion& damage);
+        void drawTex(CRenderingContext& context, WP<CTexPassElement> element, const CRegion& damage);
+        void drawTexMatte(CRenderingContext& context, WP<CTextureMatteElement> element, const CRegion& damage);
+        void drawTransformedWindow(CRenderingContext& context, WP<CTransformedWindowPassElement> element, const CRegion& damage);
+        void drawCustom(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage);
     };
 }

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -374,7 +374,7 @@ void CHyprGLRenderer::preRender(PHLMONITOR pMonitor) {
         const auto  PWORKSPACE = pWindow->m_workspace;
         const float A          = pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FULLSCREEN) *
             pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_LAYOUT) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_ACTIVE) *
-            PWORKSPACE->m_alpha->value();
+            g_pHyprRenderer->workspaceRenderAlpha(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock());
 
         if (A < 1.F)
             return true;

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -15,6 +15,7 @@
 #include "../desktop/view/window/WindowPresentation.hpp"
 #include "../event/EventBus.hpp"
 #include "../output/Monitor.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "pass/TexPassElement.hpp"
 #include "pass/SurfacePassElement.hpp"
 #include "../debug/log/Logger.hpp"
@@ -57,69 +58,63 @@ IHyprRenderer::eType CHyprGLRenderer::type() {
 
 void CHyprGLRenderer::initRender() {
     g_pHyprOpenGL->makeEGLCurrent();
-    g_pHyprRenderer->m_renderData.pMonitor = renderData().pMonitor;
 }
 
-bool CHyprGLRenderer::initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
+bool CHyprGLRenderer::initRenderBuffer(CRenderingContext& context, SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
     try {
-        m_currentRenderbuffer = getOrCreateRenderbuffer(m_currentBuffer, fmt);
+        context.renderbuffer = getOrCreateRenderbuffer(buffer, fmt);
     } catch (std::exception& e) {
         Log::logger->log(Log::ERR, "getOrCreateRenderbuffer failed for {}", NFormatUtils::drmFormatName(fmt));
         return false;
     }
 
-    return !!m_currentRenderbuffer;
+    return !!context.renderbuffer;
 }
 
-bool CHyprGLRenderer::beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple) {
+bool CHyprGLRenderer::beginFullFakeRenderInternal(CRenderingContext& context, CRegion& damage, SP<IFramebuffer> fb, bool simple) {
     initRender();
 
     RASSERT(fb, "Cannot render FULL_FAKE without a provided fb!");
-    bindFB(fb);
+    bindFB(context, fb);
     if (simple)
-        g_pHyprOpenGL->beginSimple(pMonitor, damage, nullptr, fb);
+        g_pHyprOpenGL->beginSimple(context, damage, nullptr, fb);
     else
-        g_pHyprOpenGL->begin(pMonitor, damage, fb);
+        g_pHyprOpenGL->begin(context, damage, fb);
     return true;
 }
 
-bool CHyprGLRenderer::beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple) {
+bool CHyprGLRenderer::beginRenderInternal(CRenderingContext& context, CRegion& damage, bool simple) {
 
-    m_currentRenderbuffer->bind();
+    context.renderbuffer->bind();
     if (simple)
-        g_pHyprOpenGL->beginSimple(pMonitor, damage, m_currentRenderbuffer);
+        g_pHyprOpenGL->beginSimple(context, damage, context.renderbuffer);
     else
-        g_pHyprOpenGL->begin(pMonitor, damage);
+        g_pHyprOpenGL->begin(context, damage);
 
     return true;
 }
 
-void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallback) {
-    const auto  PMONITOR           = g_pHyprRenderer->m_renderData.pMonitor;
+void CHyprGLRenderer::endRender(CRenderingContext& context, const std::function<void()>& renderingDoneCallback) {
+    const auto  PMONITOR           = context.outputMonitor.lock();
     static auto PNVIDIAANTIFLICKER = CConfigValue<Config::INTEGER>("opengl:nvidia_anti_flicker");
 
-    g_pHyprRenderer->m_renderData.damage = m_renderPass.render(g_pHyprRenderer->m_renderData.damage);
+    context.damage = context.renderPass().render(context, context.damage);
 
-    auto cleanup = CScopeGuard([this]() {
-        if (m_currentRenderbuffer)
-            m_currentRenderbuffer->unbind();
-        m_currentRenderbuffer = nullptr;
-        m_currentBuffer       = nullptr;
+    auto cleanup = CScopeGuard([&context]() {
+        if (context.renderbuffer)
+            context.renderbuffer->unbind();
+        context.renderbuffer.reset();
+        context.buffer.reset();
     });
 
-    if (m_renderMode != RENDER_MODE_TO_BUFFER_READ_ONLY)
-        g_pHyprOpenGL->end();
-    else {
-        g_pHyprRenderer->m_renderData.pMonitor.reset();
-        g_pHyprRenderer->m_renderData.mouseZoomFactor   = 1.f;
-        g_pHyprRenderer->m_renderData.mouseZoomUseMouse = true;
-    }
+    if (context.renderMode != RENDER_MODE_TO_BUFFER_READ_ONLY)
+        g_pHyprOpenGL->end(context);
 
-    if (m_renderMode == RENDER_MODE_FULL_FAKE)
+    if (context.renderMode == RENDER_MODE_FULL_FAKE)
         return;
 
-    if (m_renderMode == RENDER_MODE_NORMAL)
-        PMONITOR->m_output->state->setBuffer(m_currentBuffer);
+    if (context.renderMode == RENDER_MODE_NORMAL)
+        PMONITOR->m_output->state->setBuffer(context.buffer);
 
     if (!explicitSyncSupported()) {
         Log::logger->log(Log::TRACE, "renderer: Explicit sync unsupported, falling back to implicit in endRender");
@@ -159,7 +154,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
         });
         PMONITOR->m_usedAsyncBuffers.clear();
 
-        if (m_renderMode == RENDER_MODE_NORMAL) {
+        if (context.renderMode == RENDER_MODE_NORMAL) {
             PMONITOR->m_inFence = eglSync->takeFd();
             PMONITOR->m_output->state->setExplicitInFence(PMONITOR->m_inFence.get());
         }
@@ -169,7 +164,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
         // Establish an implicit synchronization point without blocking the render loop.
         glFlush();
 
-        if (m_renderMode == RENDER_MODE_NORMAL && PMONITOR) {
+        if (context.renderMode == RENDER_MODE_NORMAL && PMONITOR) {
             PMONITOR->m_inFence.reset();
             PMONITOR->m_output->state->resetExplicitFences();
         }
@@ -180,8 +175,8 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
     }
 }
 
-void CHyprGLRenderer::renderOffToMain(SP<IFramebuffer> off) {
-    g_pHyprOpenGL->renderOffToMain(off);
+void CHyprGLRenderer::renderOffToMain(CRenderingContext& context, SP<IFramebuffer> off) {
+    g_pHyprOpenGL->renderOffToMain(context, off);
 }
 
 SP<IRenderbuffer> CHyprGLRenderer::getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
@@ -295,35 +290,36 @@ SP<IFramebuffer> CHyprGLRenderer::createFB(const std::string& name) {
     return makeShared<CGLFramebuffer>(name);
 }
 
-void CHyprGLRenderer::disableScissor() {
-    g_pHyprOpenGL->scissor(nullptr);
+void CHyprGLRenderer::disableScissor(CRenderingContext& context) {
+    g_pHyprOpenGL->scissor(context, nullptr);
 }
 
 void CHyprGLRenderer::blend(bool enabled) {
     g_pHyprOpenGL->blend(enabled);
 }
 
-void CHyprGLRenderer::drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
-    g_pHyprOpenGL->renderRoundedShadow(box, round, roundingPower, range, color, a);
+void CHyprGLRenderer::drawShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
+    g_pHyprOpenGL->renderRoundedShadow(context, box, round, roundingPower, range, color, a);
 }
 
-void CHyprGLRenderer::drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                 float lerp, float a) {
-    g_pHyprOpenGL->renderRoundedShadow(box, round, roundingPower, range, grad1, grad2, lerp, a);
+void CHyprGLRenderer::drawShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                 const Config::CGradientValueData& grad2, float lerp, float a) {
+    g_pHyprOpenGL->renderRoundedShadow(context, box, round, roundingPower, range, grad1, grad2, lerp, a);
 }
 
-void CHyprGLRenderer::drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
-    g_pHyprOpenGL->renderInnerGlow(box, round, roundingPower, range, color, 0, a);
+void CHyprGLRenderer::drawGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
+    g_pHyprOpenGL->renderInnerGlow(context, box, round, roundingPower, range, color, 0, a);
 }
 
-void CHyprGLRenderer::drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                               float lerp, float a) {
-    g_pHyprOpenGL->renderInnerGlow(box, round, roundingPower, range, grad1, grad2, lerp, 0, a);
+void CHyprGLRenderer::drawGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                               const Config::CGradientValueData& grad2, float lerp, float a) {
+    g_pHyprOpenGL->renderInnerGlow(context, box, round, roundingPower, range, grad1, grad2, lerp, 0, a);
 }
 
-SP<IFramebuffer> CHyprGLRenderer::blurFramebuffer(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context) {
+SP<IFramebuffer> CHyprGLRenderer::blurFramebuffer(CRenderingContext& context, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                                  const SBlurContext& blurContext) {
     RASSERT(m_blur, "Cannot blur without a blur provider");
-    return m_blur->blur(source, strength, originalDamage, context);
+    return m_blur->blur(context, source, strength, originalDamage, blurContext);
 }
 
 void CHyprGLRenderer::refreshBlurProvider() {
@@ -341,8 +337,8 @@ void CHyprGLRenderer::expandBlurDamage(CRegion& damage, float multiplier) const 
     m_blur->expandDamage(damage, multiplier);
 }
 
-bool CHyprGLRenderer::blurProviderIsAnimated() const {
-    return m_blur && m_blur->isAnimated();
+bool CHyprGLRenderer::blurProviderIsAnimated(const CRenderingContext& context) const {
+    return m_blur && m_blur->isAnimated(context);
 }
 
 bool CHyprGLRenderer::blurProviderRequiresLiveBlur() const {
@@ -367,11 +363,12 @@ void CHyprGLRenderer::preRender(PHLMONITOR pMonitor) {
         if (pWindow->wlSurface()->small() && !pWindow->wlSurface()->m_fillIgnoreSmall)
             return true;
 
-        const auto  PSURFACE   = pWindow->wlSurface()->resource();
-        const auto  PWORKSPACE = pWindow->m_workspace;
-        const float A          = pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FULLSCREEN) *
-            pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_LAYOUT) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_ACTIVE) *
-            g_pHyprRenderer->workspaceRenderAlpha(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock());
+        const auto  PSURFACE         = pWindow->wlSurface()->resource();
+        const auto  PWORKSPACE       = pWindow->m_workspace;
+        const auto  WORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+        const float WORKSPACEALPHA   = WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->alphaValue(PWORKSPACE) : 1.F;
+        const float A = pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FULLSCREEN) *
+            pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_LAYOUT) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_ACTIVE) * WORKSPACEALPHA;
 
         if (A < 1.F)
             return true;
@@ -425,7 +422,7 @@ bool CHyprGLRenderer::reloadShaders(const std::string& path) {
     return g_pHyprOpenGL->initShaders(path);
 }
 
-SP<ITexture> CHyprGLRenderer::getBlurTexture(PHLMONITORREF pMonitor) {
+SP<ITexture> CHyprGLRenderer::getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor) {
     return pMonitor->resources()->m_blurFB->getTexture();
 }
 

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -15,6 +15,7 @@
 #include "../desktop/view/window/WindowPresentation.hpp"
 #include "../event/EventBus.hpp"
 #include "../output/Monitor.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "pass/TexPassElement.hpp"
 #include "pass/SurfacePassElement.hpp"
 #include "../debug/log/Logger.hpp"
@@ -57,69 +58,63 @@ IHyprRenderer::eType CHyprGLRenderer::type() {
 
 void CHyprGLRenderer::initRender() {
     g_pHyprOpenGL->makeEGLCurrent();
-    g_pHyprRenderer->m_renderData.pMonitor = renderData().pMonitor;
 }
 
-bool CHyprGLRenderer::initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
+bool CHyprGLRenderer::initRenderBuffer(CRenderingContext& context, SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
     try {
-        m_currentRenderbuffer = getOrCreateRenderbuffer(m_currentBuffer, fmt);
+        context.renderbuffer = getOrCreateRenderbuffer(buffer, fmt);
     } catch (std::exception& e) {
         Log::logger->log(Log::ERR, "getOrCreateRenderbuffer failed for {}", NFormatUtils::drmFormatName(fmt));
         return false;
     }
 
-    return !!m_currentRenderbuffer;
+    return !!context.renderbuffer;
 }
 
-bool CHyprGLRenderer::beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple) {
+bool CHyprGLRenderer::beginFullFakeRenderInternal(CRenderingContext& context, CRegion& damage, SP<IFramebuffer> fb, bool simple) {
     initRender();
 
     RASSERT(fb, "Cannot render FULL_FAKE without a provided fb!");
-    bindFB(fb);
+    bindFB(context, fb);
     if (simple)
-        g_pHyprOpenGL->beginSimple(pMonitor, damage, nullptr, fb);
+        g_pHyprOpenGL->beginSimple(context, damage, nullptr, fb);
     else
-        g_pHyprOpenGL->begin(pMonitor, damage, fb);
+        g_pHyprOpenGL->begin(context, damage, fb);
     return true;
 }
 
-bool CHyprGLRenderer::beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple) {
+bool CHyprGLRenderer::beginRenderInternal(CRenderingContext& context, CRegion& damage, bool simple) {
 
-    m_currentRenderbuffer->bind();
+    context.renderbuffer->bind();
     if (simple)
-        g_pHyprOpenGL->beginSimple(pMonitor, damage, m_currentRenderbuffer);
+        g_pHyprOpenGL->beginSimple(context, damage, context.renderbuffer);
     else
-        g_pHyprOpenGL->begin(pMonitor, damage);
+        g_pHyprOpenGL->begin(context, damage);
 
     return true;
 }
 
-void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallback) {
-    const auto  PMONITOR           = g_pHyprRenderer->m_renderData.pMonitor;
+void CHyprGLRenderer::endRender(CRenderingContext& context, const std::function<void()>& renderingDoneCallback) {
+    const auto  PMONITOR           = context.outputMonitor.lock();
     static auto PNVIDIAANTIFLICKER = CConfigValue<Config::INTEGER>("opengl:nvidia_anti_flicker");
 
-    g_pHyprRenderer->m_renderData.damage = m_renderPass.render(g_pHyprRenderer->m_renderData.damage);
+    context.damage = context.renderPass().render(context, context.damage);
 
-    auto cleanup = CScopeGuard([this]() {
-        if (m_currentRenderbuffer)
-            m_currentRenderbuffer->unbind();
-        m_currentRenderbuffer = nullptr;
-        m_currentBuffer       = nullptr;
+    auto cleanup = CScopeGuard([&context]() {
+        if (context.renderbuffer)
+            context.renderbuffer->unbind();
+        context.renderbuffer.reset();
+        context.buffer.reset();
     });
 
-    if (m_renderMode != RENDER_MODE_TO_BUFFER_READ_ONLY)
-        g_pHyprOpenGL->end();
-    else {
-        g_pHyprRenderer->m_renderData.pMonitor.reset();
-        g_pHyprRenderer->m_renderData.mouseZoomFactor   = 1.f;
-        g_pHyprRenderer->m_renderData.mouseZoomUseMouse = true;
-    }
+    if (context.renderMode != RENDER_MODE_TO_BUFFER_READ_ONLY)
+        g_pHyprOpenGL->end(context);
 
-    if (m_renderMode == RENDER_MODE_FULL_FAKE)
+    if (context.renderMode == RENDER_MODE_FULL_FAKE)
         return;
 
-    if (m_renderMode == RENDER_MODE_NORMAL)
-        PMONITOR->m_output->state->setBuffer(m_currentBuffer);
+    if (context.renderMode == RENDER_MODE_NORMAL)
+        PMONITOR->m_output->state->setBuffer(context.buffer);
 
     if (!explicitSyncSupported()) {
         Log::logger->log(Log::TRACE, "renderer: Explicit sync unsupported, falling back to implicit in endRender");
@@ -159,7 +154,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
         });
         PMONITOR->m_usedAsyncBuffers.clear();
 
-        if (m_renderMode == RENDER_MODE_NORMAL) {
+        if (context.renderMode == RENDER_MODE_NORMAL) {
             PMONITOR->m_inFence = eglSync->takeFd();
             PMONITOR->m_output->state->setExplicitInFence(PMONITOR->m_inFence.get());
         }
@@ -169,7 +164,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
         // Establish an implicit synchronization point without blocking the render loop.
         glFlush();
 
-        if (m_renderMode == RENDER_MODE_NORMAL && PMONITOR) {
+        if (context.renderMode == RENDER_MODE_NORMAL && PMONITOR) {
             PMONITOR->m_inFence.reset();
             PMONITOR->m_output->state->resetExplicitFences();
         }
@@ -180,8 +175,8 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
     }
 }
 
-void CHyprGLRenderer::renderOffToMain(SP<IFramebuffer> off) {
-    g_pHyprOpenGL->renderOffToMain(off);
+void CHyprGLRenderer::renderOffToMain(CRenderingContext& context, SP<IFramebuffer> off) {
+    g_pHyprOpenGL->renderOffToMain(context, off);
 }
 
 SP<IRenderbuffer> CHyprGLRenderer::getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
@@ -295,35 +290,36 @@ SP<IFramebuffer> CHyprGLRenderer::createFB(const std::string& name) {
     return makeShared<CGLFramebuffer>(name);
 }
 
-void CHyprGLRenderer::disableScissor() {
-    g_pHyprOpenGL->scissor(nullptr);
+void CHyprGLRenderer::disableScissor(CRenderingContext& context) {
+    g_pHyprOpenGL->scissor(context, nullptr);
 }
 
 void CHyprGLRenderer::blend(bool enabled) {
     g_pHyprOpenGL->blend(enabled);
 }
 
-void CHyprGLRenderer::drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
-    g_pHyprOpenGL->renderRoundedShadow(box, round, roundingPower, range, color, a);
+void CHyprGLRenderer::drawShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
+    g_pHyprOpenGL->renderRoundedShadow(context, box, round, roundingPower, range, color, a);
 }
 
-void CHyprGLRenderer::drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                 float lerp, float a) {
-    g_pHyprOpenGL->renderRoundedShadow(box, round, roundingPower, range, grad1, grad2, lerp, a);
+void CHyprGLRenderer::drawShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                 const Config::CGradientValueData& grad2, float lerp, float a) {
+    g_pHyprOpenGL->renderRoundedShadow(context, box, round, roundingPower, range, grad1, grad2, lerp, a);
 }
 
-void CHyprGLRenderer::drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
-    g_pHyprOpenGL->renderInnerGlow(box, round, roundingPower, range, color, 0, a);
+void CHyprGLRenderer::drawGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) {
+    g_pHyprOpenGL->renderInnerGlow(context, box, round, roundingPower, range, color, 0, a);
 }
 
-void CHyprGLRenderer::drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                               float lerp, float a) {
-    g_pHyprOpenGL->renderInnerGlow(box, round, roundingPower, range, grad1, grad2, lerp, 0, a);
+void CHyprGLRenderer::drawGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                               const Config::CGradientValueData& grad2, float lerp, float a) {
+    g_pHyprOpenGL->renderInnerGlow(context, box, round, roundingPower, range, grad1, grad2, lerp, 0, a);
 }
 
-SP<IFramebuffer> CHyprGLRenderer::blurFramebuffer(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context) {
+SP<IFramebuffer> CHyprGLRenderer::blurFramebuffer(CRenderingContext& context, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                                  const SBlurContext& blurContext) {
     RASSERT(m_blur, "Cannot blur without a blur provider");
-    return m_blur->blur(source, strength, originalDamage, context);
+    return m_blur->blur(context, source, strength, originalDamage, blurContext);
 }
 
 void CHyprGLRenderer::refreshBlurProvider() {
@@ -341,8 +337,8 @@ void CHyprGLRenderer::expandBlurDamage(CRegion& damage, float multiplier) const 
     m_blur->expandDamage(damage, multiplier);
 }
 
-bool CHyprGLRenderer::blurProviderIsAnimated() const {
-    return m_blur && m_blur->isAnimated();
+bool CHyprGLRenderer::blurProviderIsAnimated(const CRenderingContext& context) const {
+    return m_blur && m_blur->isAnimated(context);
 }
 
 bool CHyprGLRenderer::blurProviderRequiresLiveBlur() const {
@@ -370,11 +366,12 @@ void CHyprGLRenderer::preRender(PHLMONITOR pMonitor) {
         if (pWindow->wlSurface()->small() && !pWindow->wlSurface()->m_fillIgnoreSmall)
             return true;
 
-        const auto  PSURFACE   = pWindow->wlSurface()->resource();
-        const auto  PWORKSPACE = pWindow->m_workspace;
-        const float A          = pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FULLSCREEN) *
-            pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_LAYOUT) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_ACTIVE) *
-            g_pHyprRenderer->workspaceRenderAlpha(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock());
+        const auto  PSURFACE         = pWindow->wlSurface()->resource();
+        const auto  PWORKSPACE       = pWindow->m_workspace;
+        const auto  WORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+        const float WORKSPACEALPHA   = WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->alphaValue(PWORKSPACE) : 1.F;
+        const float A = pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FULLSCREEN) *
+            pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_LAYOUT) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_ACTIVE) * WORKSPACEALPHA;
 
         if (A < 1.F)
             return true;
@@ -428,7 +425,7 @@ bool CHyprGLRenderer::reloadShaders(const std::string& path) {
     return g_pHyprOpenGL->initShaders(path);
 }
 
-SP<ITexture> CHyprGLRenderer::getBlurTexture(PHLMONITORREF pMonitor) {
+SP<ITexture> CHyprGLRenderer::getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor) {
     return pMonitor->resources()->m_blurFB->getTexture();
 }
 

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -371,7 +371,7 @@ void CHyprGLRenderer::preRender(PHLMONITOR pMonitor) {
         const auto  PWORKSPACE = pWindow->m_workspace;
         const float A          = pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_FULLSCREEN) *
             pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_LAYOUT) * pWindow->presentation().alphaValue(Desktop::View::WINDOW_ALPHA_ACTIVE) *
-            PWORKSPACE->m_alpha->value();
+            g_pHyprRenderer->workspaceRenderAlpha(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock());
 
         if (A < 1.F)
             return true;

--- a/src/render/GLRenderer.hpp
+++ b/src/render/GLRenderer.hpp
@@ -12,7 +12,7 @@ namespace Render::GL {
         ~CHyprGLRenderer();
 
         eType                   type() override;
-        void                    endRender(const std::function<void()>& renderingDoneCallback = {}) override;
+        void                    endRender(CRenderingContext&, const std::function<void()>& renderingDoneCallback = {}) override;
         UP<ISyncFDManager>      createSyncFDManager() override;
         SP<ITexture>            createStencilTexture(const int width, const int height) override;
         SP<ITexture>            createTexture(bool opaque = false) override;
@@ -26,19 +26,20 @@ namespace Render::GL {
         std::vector<SDRMFormat> getDRMFormats() override;
         std::vector<uint64_t>   getDRMFormatModifiers(DRMFormat format) override;
         SP<IFramebuffer>        createFB(const std::string& name = "") override;
-        void                    disableScissor() override;
+        void                    disableScissor(CRenderingContext&) override;
         void                    blend(bool enabled) override;
-        void                    drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) override;
-        void drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp,
-                        float a) override;
+        void                 drawShadow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) override;
+        void                 drawShadow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                        const Config::CGradientValueData& grad2, float lerp, float a) override;
 
-        void drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) override;
-        void drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp,
-                      float a) override;
-        SP<IFramebuffer>     blurFramebuffer(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const Render::SBlurContext& context = {}) override;
+        void                 drawGlow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) override;
+        void                 drawGlow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                      const Config::CGradientValueData& grad2, float lerp, float a) override;
+        SP<IFramebuffer>     blurFramebuffer(CRenderingContext&, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                             const Render::SBlurContext& blurContext = {}) override;
         void                 refreshBlurProvider() override;
         void                 expandBlurDamage(CRegion& damage, float multiplier = 1.F) const override;
-        bool                 blurProviderIsAnimated() const override;
+        bool                 blurProviderIsAnimated(const CRenderingContext&) const override;
         bool                 blurProviderRequiresLiveBlur() const override;
         void                 setViewport(int x, int y, int width, int height) override;
         bool                 reloadShaders(const std::string& path = "") override;
@@ -48,16 +49,15 @@ namespace Render::GL {
 
       private:
         void                 preRender(PHLMONITOR pMonitor);
-        void                 renderOffToMain(SP<IFramebuffer> off) override;
+        void                 renderOffToMain(CRenderingContext&, SP<IFramebuffer> off) override;
         SP<IRenderbuffer>    getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) override;
-        bool                 beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple = false) override;
-        bool                 beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) override;
+        bool                 beginRenderInternal(CRenderingContext&, CRegion& damage, bool simple = false) override;
+        bool                 beginFullFakeRenderInternal(CRenderingContext&, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) override;
         void                 initRender() override;
-        bool                 initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) override;
+        bool                 initRenderBuffer(CRenderingContext&, SP<Aquamarine::IBuffer> buffer, uint32_t fmt) override;
 
-        SP<ITexture>         getBlurTexture(PHLMONITORREF pMonitor) override;
+        SP<ITexture>         getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor) override;
 
-        SP<IRenderbuffer>    m_currentRenderbuffer;
         UP<IElementRenderer> m_elementRenderer;
         UP<IGLBlurProvider>  m_blur;
         CHyprSignalListener  m_preRenderListener;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -152,10 +152,8 @@ static int openRenderNode(int drmFd) {
     return renderFD;
 }
 
-static ShaderFeatureFlags globalFeatures() {
-    return g_pHyprRenderer->m_renderData.pMonitor && g_pHyprRenderer->m_renderData.pMonitor->needsUnmodifiedCopy() && g_pHyprRenderer->m_renderData.currentFB->getMirrorTexture() ?
-        SH_FEAT_MIRROR :
-        0;
+static ShaderFeatureFlags globalFeatures(const CRenderingContext& context) {
+    return context.sceneMonitor && context.sceneMonitor->needsUnmodifiedCopy() && context.currentFB->getMirrorTexture() ? SH_FEAT_MIRROR : 0;
 }
 
 void CHyprOpenGLImpl::initEGL(bool gbm) {
@@ -680,9 +678,7 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
     return image;
 }
 
-void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP<IRenderbuffer> rb, SP<IFramebuffer> fb) {
-    g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
-
+void CHyprOpenGLImpl::beginSimple(CRenderingContext& context, const CRegion& damage, SP<IRenderbuffer> rb, SP<IFramebuffer> fb) {
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
     if (RESETSTATUS != GL_NO_ERROR) {
         std::string errStr = "";
@@ -705,17 +701,17 @@ void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP
     if (!m_shadersInitialized)
         initShaders();
 
-    g_pHyprRenderer->m_renderData.transformDamage = false;
-    g_pHyprRenderer->m_renderData.damage.set(damage);
-    g_pHyprRenderer->m_renderData.finalDamage.set(damage);
+    context.transformDamage = false;
+    context.damage.set(damage);
+    context.finalDamage.set(damage);
 
-    m_fakeFrame = true;
+    context.fakeFrame = true;
 
-    g_pHyprRenderer->bindFB(FBO);
-    m_offloadedFramebuffer = false;
+    g_pHyprRenderer->bindFB(context, FBO);
+    context.offloadedFramebuffer = false;
 
-    g_pHyprRenderer->m_renderData.mainFB = g_pHyprRenderer->m_renderData.currentFB;
-    g_pHyprRenderer->m_renderData.outFB  = FBO;
+    context.mainFB = context.currentFB;
+    context.outFB  = FBO;
 }
 
 void CHyprOpenGLImpl::makeEGLCurrent() {
@@ -726,9 +722,7 @@ void CHyprOpenGLImpl::makeEGLCurrent() {
         eglMakeCurrent(g_pHyprOpenGL->m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, g_pHyprOpenGL->m_eglContext);
 }
 
-void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFramebuffer> fb, std::optional<CRegion> finalDamage) {
-    g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
-
+void CHyprOpenGLImpl::begin(CRenderingContext& context, const CRegion& damage_, SP<IFramebuffer> fb, std::optional<CRegion> finalDamage) {
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
     if (RESETSTATUS != GL_NO_ERROR) {
         std::string errStr = "";
@@ -744,16 +738,16 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFra
 
     TRACY_GPU_ZONE("RenderBegin");
 
-    setViewport(0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y);
+    setViewport(0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
 
     if (!m_shadersInitialized)
         initShaders();
 
-    g_pHyprRenderer->m_renderData.transformDamage = false;
-    g_pHyprRenderer->m_renderData.damage.set(damage_);
-    g_pHyprRenderer->m_renderData.finalDamage.set(finalDamage.value_or(damage_));
+    context.transformDamage = false;
+    context.damage.set(damage_);
+    context.finalDamage.set(finalDamage.value_or(damage_));
 
-    m_fakeFrame = !!fb;
+    context.fakeFrame = !!fb;
 
     if (g_pHyprRenderer->m_reloadScreenShader) {
         g_pHyprRenderer->m_reloadScreenShader = false;
@@ -761,100 +755,99 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFra
         applyScreenShader(*PSHADER);
     }
 
-    g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
-    m_offloadedFramebuffer = true;
-    if (!g_pHyprRenderer->m_renderData.damage.empty())
-        GLFB(g_pHyprRenderer->m_renderData.currentFB)->clearAfterInvalidation();
+    g_pHyprRenderer->bindFB(context, context.sceneMonitor->resources()->getUnusedWorkBuffer());
+    context.offloadedFramebuffer = true;
+    if (!context.damage.empty())
+        GLFB(context.currentFB)->clearAfterInvalidation();
 
-    g_pHyprRenderer->m_renderData.mainFB = g_pHyprRenderer->m_renderData.currentFB;
-    g_pHyprRenderer->m_renderData.outFB  = fb ? fb : dc<CHyprGLRenderer*>(g_pHyprRenderer.get())->m_currentRenderbuffer->getFB();
+    context.mainFB = context.currentFB;
+    context.outFB  = fb ? fb : context.renderbuffer->getFB();
 
-    if UNLIKELY (g_pHyprRenderer->m_renderData.pMonitor->needsUnmodifiedCopy() && !m_fakeFrame) {
-        if (!g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex)
-            g_pHyprRenderer->m_renderData.pMonitor->resources()->enableMirror();
-        g_pHyprRenderer->m_renderData.mainFB->enableMirror(g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex);
+    if UNLIKELY (context.sceneMonitor->needsUnmodifiedCopy() && !context.fakeFrame) {
+        if (!context.sceneMonitor->resources()->m_mirrorTex)
+            context.sceneMonitor->resources()->enableMirror();
+        context.mainFB->enableMirror(context.sceneMonitor->resources()->m_mirrorTex);
     } else {
-        if (g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex)
-            g_pHyprRenderer->m_renderData.pMonitor->resources()->disableMirror();
-        g_pHyprRenderer->m_renderData.mainFB->disableMirror();
+        if (context.sceneMonitor->resources()->m_mirrorTex)
+            context.sceneMonitor->resources()->disableMirror();
+        context.mainFB->disableMirror();
     }
 }
 
-void CHyprOpenGLImpl::end() {
+void CHyprOpenGLImpl::end(CRenderingContext& context) {
     static auto PZOOMDISABLEAA = CConfigValue<Config::INTEGER>("cursor:zoom_disable_aa");
-    auto&       m_renderData   = g_pHyprRenderer->m_renderData;
-    const auto  PMONITOR       = m_renderData.pMonitor;
+    const auto  PMONITOR       = context.sceneMonitor;
     TRACY_GPU_ZONE("RenderEnd");
 
-    g_pHyprRenderer->m_renderData.currentWindow.reset();
-    g_pHyprRenderer->m_renderData.surface.reset();
-    g_pHyprRenderer->m_renderData.clipBox = {};
+    context.currentWindow.reset();
+    context.surface.reset();
+    context.clipBox = {};
 
     // end the render, copy the data to the main framebuffer
-    if LIKELY (m_offloadedFramebuffer) {
-        g_pHyprRenderer->m_renderData.damage = g_pHyprRenderer->m_renderData.finalDamage;
-        if UNLIKELY (g_pHyprRenderer->m_renderMode != RENDER_MODE_NORMAL) {
-            const auto TARGET_SIZE = g_pHyprRenderer->m_renderData.outFB->m_size;
-            const auto TEXTURE     = g_pHyprRenderer->m_renderData.currentFB->getTexture();
+    if LIKELY (context.offloadedFramebuffer) {
+        context.damage = context.finalDamage;
+        if UNLIKELY (context.renderMode != RENDER_MODE_NORMAL) {
+            const auto TARGET_SIZE = context.outFB->m_size;
+            const auto TEXTURE     = context.currentFB->getTexture();
 
-            g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.outFB);
-            g_pHyprRenderer->m_renderData.fbSize = TARGET_SIZE;
-            g_pHyprRenderer->setProjectionType(RPT_EXPORT);
-            g_pHyprRenderer->m_renderData.transformDamage = false;
-            g_pHyprRenderer->m_renderData.damage          = CRegion{0, 0, TARGET_SIZE.x, TARGET_SIZE.y};
+            g_pHyprRenderer->bindFB(context, context.outFB);
+            context.fbSize = TARGET_SIZE;
+            g_pHyprRenderer->setProjectionType(context, RPT_EXPORT);
+            context.transformDamage = false;
+            context.damage          = CRegion{0, 0, TARGET_SIZE.x, TARGET_SIZE.y};
             setViewport(0, 0, TARGET_SIZE.x, TARGET_SIZE.y);
 
             blend(false);
-            renderTexturePrimitive(TEXTURE, CBox{{}, TARGET_SIZE});
+            renderTexturePrimitive(context, TEXTURE, CBox{{}, TARGET_SIZE});
             blend(true);
         } else {
-            CBox monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+            CBox monbox = {0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y};
 
-            if LIKELY (g_pHyprRenderer->m_renderData.mouseZoomFactor == 1.0f)
-                m_renderData.pMonitor->m_zoomController.m_resetCameraState = true;
-            m_renderData.pMonitor->m_zoomController.applyZoomTransform(monbox, m_renderData);
+            if LIKELY (context.mouseZoomFactor == 1.0f)
+                context.sceneMonitor->m_zoomController.m_resetCameraState = true;
+            context.sceneMonitor->m_zoomController.applyZoomTransform(monbox, context);
 
-            if UNLIKELY (g_pHyprRenderer->m_renderData.mouseZoomFactor != 1.F && g_pHyprRenderer->m_renderData.mouseZoomUseMouse && *PZOOMDISABLEAA)
-                g_pHyprRenderer->m_renderData.useNearestNeighbor = true;
+            if UNLIKELY (context.mouseZoomFactor != 1.F && context.mouseZoomUseMouse && *PZOOMDISABLEAA)
+                context.useNearestNeighbor = true;
 
             // copy the damaged areas into the mirror buffer
             // we can't use the offloadFB for mirroring / ss, as it contains artifacts from blurring
-            if UNLIKELY (g_pHyprRenderer->m_renderData.pMonitor->needsACopyFB() && !m_fakeFrame) {
-                if (saveBufferForMirror(monbox))
-                    g_pHyprRenderer->m_renderData.pMonitor->resources()->markMirrorFBUpdated();
+            if UNLIKELY (context.sceneMonitor->needsACopyFB() && !context.fakeFrame) {
+                if (saveBufferForMirror(context, monbox))
+                    context.sceneMonitor->resources()->markMirrorFBUpdated();
                 else
-                    g_pHyprRenderer->m_renderData.pMonitor->resources()->invalidateMirrorFB();
+                    context.sceneMonitor->resources()->invalidateMirrorFB();
             }
 
             blend(false);
 
-            const bool NEEDS_CM = g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription->value() != g_pHyprRenderer->m_renderData.mainFB->imageDescription()->value();
-            const bool WANTS_FINAL_SHADER = !g_pHyprRenderer->m_renderData.blockScreenShader && (m_finalScreenShader->program() >= 1 || g_pHyprRenderer->m_crashingInProgress);
+            const bool                      NEEDS_CM           = context.sceneMonitor->m_imageDescription->value() != context.mainFB->imageDescription()->value();
+            const bool                      WANTS_FINAL_SHADER = !context.blockScreenShader && (m_finalScreenShader->program() >= 1 || g_pHyprRenderer->m_crashingInProgress);
 
-            auto       finalTexture = g_pHyprRenderer->m_renderData.currentFB->getTexture();
-            CBox       finalBox     = monbox;
-            std::array<SP<IFramebuffer>, 2>                    postProcessFBs;
+            auto                            finalTexture = context.currentFB->getTexture();
+            CBox                            finalBox     = monbox;
+            std::array<SP<IFramebuffer>, 2> postProcessFBs;
             std::array<NColorManagement::PImageDescription, 2> savedDescriptions;
             size_t                                             postProcessCount = 0;
             bool                                               finalCMComplete  = false;
 
             if (WANTS_FINAL_SHADER) {
                 if (NEEDS_CM) {
-                    postProcessFBs[postProcessCount] = g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+                    postProcessFBs[postProcessCount] = context.sceneMonitor->resources()->getUnusedWorkBuffer();
                     if (postProcessFBs[postProcessCount]) {
                         savedDescriptions[postProcessCount] = postProcessFBs[postProcessCount]->imageDescription();
-                        postProcessFBs[postProcessCount]->setImageDescription(g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription);
+                        postProcessFBs[postProcessCount]->setImageDescription(context.sceneMonitor->m_imageDescription);
 
                         {
-                            auto guard = g_pHyprRenderer->bindTempFB(postProcessFBs[postProcessCount]);
+                            auto guard = g_pHyprRenderer->bindTempFB(context, postProcessFBs[postProcessCount]);
                             GLFB(postProcessFBs[postProcessCount])->clearAfterInvalidation();
-                            g_pHyprRenderer->setProjectionType(RPT_MONITOR);
-                            g_pHyprRenderer->m_renderData.transformDamage = false;
-                            renderTexture(finalTexture, finalBox, {.finalMonitorCM = true});
+                            g_pHyprRenderer->setProjectionType(context, RPT_MONITOR);
+                            context.transformDamage = false;
+                            renderTexture(context, finalTexture, finalBox, {.finalMonitorCM = true});
                         }
 
                         finalTexture    = postProcessFBs[postProcessCount++]->getTexture();
-                        finalBox        = CBox{{}, m_renderData.pMonitor->m_transformedSize};
+                        finalBox        = CBox{{}, context.sceneMonitor->m_transformedSize};
                         finalCMComplete = true;
                     } else {
                         Log::logger->log(Log::ERR, "Failed to acquire a work buffer for final color management");
@@ -863,23 +856,23 @@ void CHyprOpenGLImpl::end() {
                 }
 
                 if (!NEEDS_CM || finalCMComplete) {
-                    postProcessFBs[postProcessCount] = g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+                    postProcessFBs[postProcessCount] = context.sceneMonitor->resources()->getUnusedWorkBuffer();
                     if (postProcessFBs[postProcessCount]) {
                         savedDescriptions[postProcessCount] = postProcessFBs[postProcessCount]->imageDescription();
-                        postProcessFBs[postProcessCount]->setImageDescription(g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription);
+                        postProcessFBs[postProcessCount]->setImageDescription(context.sceneMonitor->m_imageDescription);
 
                         {
-                            auto guard = g_pHyprRenderer->bindTempFB(postProcessFBs[postProcessCount]);
+                            auto guard = g_pHyprRenderer->bindTempFB(context, postProcessFBs[postProcessCount]);
                             GLFB(postProcessFBs[postProcessCount])->clearAfterInvalidation();
-                            g_pHyprRenderer->setProjectionType(RPT_MONITOR);
-                            g_pHyprRenderer->m_renderData.transformDamage = false;
-                            m_applyFinalShader                            = true;
-                            renderTexture(finalTexture, finalBox, {.finalMonitorCM = true});
-                            m_applyFinalShader = false;
+                            g_pHyprRenderer->setProjectionType(context, RPT_MONITOR);
+                            context.transformDamage        = false;
+                            context.applyFinalScreenShader = true;
+                            renderTexture(context, finalTexture, finalBox, {.finalMonitorCM = true});
+                            context.applyFinalScreenShader = false;
                         }
 
                         finalTexture = postProcessFBs[postProcessCount++]->getTexture();
-                        finalBox     = CBox{{}, m_renderData.pMonitor->m_transformedSize};
+                        finalBox     = CBox{{}, context.sceneMonitor->m_transformedSize};
                     } else {
                         Log::logger->log(Log::ERR, "Failed to acquire a work buffer for the final screen shader");
                         postProcessFBs[postProcessCount].reset();
@@ -887,45 +880,39 @@ void CHyprOpenGLImpl::end() {
                 }
             }
 
-            g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.outFB);
+            g_pHyprRenderer->bindFB(context, context.outFB);
             setViewport(0, 0, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y);
-            g_pHyprRenderer->setProjectionType(RPT_OUTPUT);
-            g_pHyprRenderer->m_renderData.transformDamage = true;
+            g_pHyprRenderer->setProjectionType(context, RPT_OUTPUT);
+            context.transformDamage = true;
 
             if (NEEDS_CM && !finalCMComplete)
-                renderTexture(finalTexture, finalBox, {.finalMonitorCM = true});
+                renderTexture(context, finalTexture, finalBox, {.finalMonitorCM = true});
             else
-                renderTexturePrimitive(finalTexture, finalBox);
+                renderTexturePrimitive(context, finalTexture, finalBox);
 
             for (size_t i = 0; i < postProcessCount; ++i)
                 postProcessFBs[i]->setImageDescription(savedDescriptions[i]);
 
             blend(true);
 
-            g_pHyprRenderer->setProjectionType(RPT_MONITOR);
-            g_pHyprRenderer->m_renderData.transformDamage = false;
+            g_pHyprRenderer->setProjectionType(context, RPT_MONITOR);
+            context.transformDamage = false;
         }
 
-        g_pHyprRenderer->m_renderData.useNearestNeighbor = false;
-        m_applyFinalShader                               = false;
+        context.useNearestNeighbor     = false;
+        context.applyFinalScreenShader = false;
     }
 
-    // reset our data
-    g_pHyprRenderer->m_renderData.mouseZoomFactor   = 1.f;
-    g_pHyprRenderer->m_renderData.mouseZoomUseMouse = true;
-    g_pHyprRenderer->m_renderData.blockScreenShader = false;
-    g_pHyprRenderer->m_renderData.currentFB.reset();
-    g_pHyprRenderer->m_renderData.mainFB.reset();
-    g_pHyprRenderer->m_renderData.outFB.reset();
+    context.currentFB.reset();
+    context.mainFB.reset();
+    context.outFB.reset();
     // invalidate our render FBs to signal to the driver we don't need them anymore
-    g_pHyprRenderer->m_renderData.pMonitor->resources()->forEachUnusedFB(
+    context.sceneMonitor->resources()->forEachUnusedFB(
         [](const auto& fb) {
             fb->bind();
             GLFB(fb)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT, GL_COLOR_ATTACHMENT0});
         },
         false);
-
-    m_renderData.pMonitor.reset();
 
     static const auto GLDEBUG = CConfigValue<Config::INTEGER>("debug:gl_debugging");
 
@@ -1093,17 +1080,16 @@ bool CHyprOpenGLImpl::blendEnabled() const {
     return m_blend;
 }
 
-void CHyprOpenGLImpl::scissor(const CBox& originalBox, bool transform) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to scissor without begin()!");
+void CHyprOpenGLImpl::scissor(const CRenderingContext& context, const CBox& originalBox, bool transform) {
+    RASSERT(context.sceneMonitor, "Tried to scissor without begin()!");
 
     // only call glScissor if the box has changed
     static CBox m_lastScissorBox = {};
 
     if (transform) {
         CBox       box = originalBox;
-        const auto TR  = Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform));
-        box.transform(TR, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
+        const auto TR  = Math::wlTransformToHyprutils(Math::invertTransform(context.sceneMonitor->m_transform));
+        box.transform(TR, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
 
         if (box != m_lastScissorBox) {
             GLCALL(glScissor(box.x, box.y, box.width, box.height));
@@ -1122,8 +1108,8 @@ void CHyprOpenGLImpl::scissor(const CBox& originalBox, bool transform) {
     setCapStatus(GL_SCISSOR_TEST, true);
 }
 
-void CHyprOpenGLImpl::scissor(const pixman_box32* pBox, bool transform) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to scissor without begin()!");
+void CHyprOpenGLImpl::scissor(const CRenderingContext& context, const pixman_box32* pBox, bool transform) {
+    RASSERT(context.sceneMonitor, "Tried to scissor without begin()!");
 
     if (!pBox) {
         setCapStatus(GL_SCISSOR_TEST, false);
@@ -1132,35 +1118,39 @@ void CHyprOpenGLImpl::scissor(const pixman_box32* pBox, bool transform) {
 
     CBox newBox = {pBox->x1, pBox->y1, pBox->x2 - pBox->x1, pBox->y2 - pBox->y1};
 
-    scissor(newBox, transform);
+    scissor(context, newBox, transform);
 }
 
-void CHyprOpenGLImpl::scissor(const int x, const int y, const int w, const int h, bool transform) {
+void CHyprOpenGLImpl::scissor(const CRenderingContext& context, const int x, const int y, const int w, const int h, bool transform) {
     CBox box = {x, y, w, h};
-    scissor(box, transform);
+    scissor(context, box, transform);
 }
 
-void CHyprOpenGLImpl::renderRect(const CBox& box, const CHyprColor& col, SRectRenderData data) {
+void CHyprOpenGLImpl::disableScissorState() {
+    setCapStatus(GL_SCISSOR_TEST, false);
+}
+
+void CHyprOpenGLImpl::renderRect(CRenderingContext& context, const CBox& box, const CHyprColor& col, SRectRenderData data) {
     if (!data.damage)
-        data.damage = &g_pHyprRenderer->m_renderData.damage;
+        data.damage = &context.damage;
 
     if (data.blur)
-        renderRectWithBlurInternal(box, col, data);
+        renderRectWithBlurInternal(context, box, col, data);
     else
-        renderRectWithDamageInternal(box, col, data);
+        renderRectWithDamageInternal(context, box, col, data);
 }
 
-void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
+void CHyprOpenGLImpl::renderRectWithBlurInternal(CRenderingContext& context, const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
     if (data.damage->empty())
         return;
 
-    CRegion damage{g_pHyprRenderer->m_renderData.damage};
+    CRegion damage{context.damage};
     damage.intersect(box);
 
     auto patternBox = data.blurPatternBox.value_or(box);
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(patternBox);
+    context.renderModif.applyToBox(patternBox);
     auto shapeBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(shapeBox);
+    context.renderModif.applyToBox(shapeBox);
     std::optional<SBlurShape> shape;
     if (std::abs(shapeBox.rot) < 0.0001F)
         shape = SBlurShape{
@@ -1169,16 +1159,15 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
             .roundingPower = data.roundingPower,
         };
     const bool usePrecomputedBlur = data.xray && !g_pHyprRenderer->blurProviderRequiresLiveBlur();
-    const auto blurredFB = usePrecomputedBlur ? g_pHyprRenderer->m_renderData.pMonitor->resources()->m_blurFB :
-                                                g_pHyprRenderer->blurMainFramebuffer(data.blurA, damage, {.patternBox = patternBox, .owner = data.blurOwner, .shape = shape});
+    const auto blurredFB          = usePrecomputedBlur ?
+        context.sceneMonitor->resources()->m_blurFB :
+        g_pHyprRenderer->blurMainFramebuffer(context, data.blurA, damage, {.patternBox = patternBox, .owner = data.blurOwner, .shape = shape});
     const auto blurredBG = blurredFB->getTexture();
+    const auto blurUV    = resolveBlurUV(box, blurredBG->m_size);
 
-    const auto SAVEDRENDERMODIF               = g_pHyprRenderer->m_renderData.renderModif;
-    g_pHyprRenderer->m_renderData.renderModif = {}; // fix shit
-
-    const auto blurUV = resolveBlurUV(box, blurredBG->m_size);
-
-    renderTexture(blurredBG, box,
+    CRenderingContext child{context, context.renderPass()};
+    child.renderModif = {};
+    renderTexture(child, blurredBG, box,
                   STextureRenderData{
                       .damage                      = &damage,
                       .a                           = data.blurA,
@@ -1190,29 +1179,27 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
                       .primarySurfaceUVTopLeft     = blurUV.pos(),
                       .primarySurfaceUVBottomRight = blurUV.pos() + blurUV.size(),
                   });
-    g_pHyprRenderer->m_renderData.renderModif = SAVEDRENDERMODIF;
 
-    renderRectWithDamageInternal(box, col, data);
+    renderRectWithDamageInternal(context, box, col, data);
 }
 
-void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void CHyprOpenGLImpl::renderRectWithDamageInternal(CRenderingContext& context, const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderRectWithDamage");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
-    auto        shader = useShader(getShaderVariant(SH_FRAG_QUAD, (data.round > 0 ? SH_FEAT_ROUNDING : 0) | globalFeatures()));
+    auto        shader = useShader(getShaderVariant(SH_FRAG_QUAD, (data.round > 0 ? SH_FEAT_ROUNDING : 0) | globalFeatures(context)));
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
 
     // premultiply the color as well as we don't work with straight alpha
     const auto premultiplied = CHyprColor(col.r * col.a, col.g * col.a, col.b * col.a, col.a);
-    const auto converted     = g_pHyprRenderer->getConvertedColor(premultiplied);
+    const auto converted     = g_pHyprRenderer->getConvertedColor(context, premultiplied);
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, converted.a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, premultiplied.r, premultiplied.g, premultiplied.b, premultiplied.a);
 
@@ -1227,49 +1214,48 @@ void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprC
 
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0) {
-        CRegion damageClip{g_pHyprRenderer->m_renderData.clipBox.x, g_pHyprRenderer->m_renderData.clipBox.y, g_pHyprRenderer->m_renderData.clipBox.width,
-                           g_pHyprRenderer->m_renderData.clipBox.height};
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        CRegion damageClip{context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
         damageClip.intersect(*data.damage);
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
     } else {
-        data.damage->forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        data.damage->forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
 
     glBindVertexArray(0);
-    scissor(nullptr);
+    scissor(context, nullptr);
 }
 
-void CHyprOpenGLImpl::renderTexture(SP<ITexture> tex, const CBox& box, STextureRenderData data) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTexture(CRenderingContext& context, SP<ITexture> tex, const CBox& box, STextureRenderData data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
 
     if (!data.damage) {
-        if (g_pHyprRenderer->m_renderData.damage.empty())
+        if (context.damage.empty())
             return;
 
-        data.damage = &g_pHyprRenderer->m_renderData.damage;
+        data.damage = &context.damage;
     }
 
     if (data.blur && !data.forceBlurBlend)
-        renderTextureWithBlurInternal(tex, box, data);
+        renderTextureWithBlurInternal(context, tex, box, data);
     else
-        renderTextureInternal(tex, box, data);
+        renderTextureInternal(context, tex, box, data);
 
-    scissor(nullptr);
+    scissor(context, nullptr);
 }
 
 static std::map<std::pair<uint32_t, uint32_t>, std::array<GLfloat, 9>> primariesConversionCache;
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
                                      const NColorManagement::PImageDescription targetImageDescription, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance,
                                      const SCMSettings& settings) {
     shader->setUniformFloat2(SHADER_SRC_TF_RANGE, settings.srcTFRange.min, settings.srcTFRange.max);
@@ -1314,29 +1300,26 @@ void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement:
     }
 }
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
                                      const NColorManagement::PImageDescription targetImageDescription, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance) {
-    const auto settings = g_pHyprRenderer->getCMSettings(imageDescription, targetImageDescription,
-                                                         g_pHyprRenderer->m_renderData.surface.valid() ? g_pHyprRenderer->m_renderData.surface.lock() : nullptr, modifySDR,
+    const auto settings = g_pHyprRenderer->getCMSettings(context, imageDescription, targetImageDescription, context.surface.valid() ? context.surface.lock() : nullptr, modifySDR,
                                                          sdrMinLuminance, sdrMaxLuminance);
-    passCMUniforms(shader, imageDescription, targetImageDescription, modifySDR, sdrMinLuminance, sdrMaxLuminance, settings);
+    passCMUniforms(context, shader, imageDescription, targetImageDescription, modifySDR, sdrMinLuminance, sdrMaxLuminance, settings);
 }
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const PImageDescription imageDescription) {
-    passCMUniforms(shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(), true, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance,
-                   g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance);
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const PImageDescription imageDescription) {
+    passCMUniforms(context, shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(context), true, context.sceneMonitor->m_sdrMinLuminance,
+                   context.sceneMonitor->m_sdrMaxLuminance);
 }
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const PImageDescription imageDescription, const SCMSettings& settings) {
-    passCMUniforms(shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(), true, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance,
-                   g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance, settings);
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const PImageDescription imageDescription, const SCMSettings& settings) {
+    passCMUniforms(context, shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(context), true, context.sceneMonitor->m_sdrMinLuminance,
+                   context.sceneMonitor->m_sdrMaxLuminance, settings);
 }
 
-WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
+WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal(CRenderingContext& context) {
     static const auto PDT            = CConfigValue<Config::INTEGER>("debug:damage_tracking");
     static const auto PCURSORTIMEOUT = CConfigValue<Config::FLOAT>("cursor:inactive_timeout");
-
-    auto&             m_renderData = g_pHyprRenderer->m_renderData;
 
     WP<CShader>       shader =
         g_pHyprRenderer->m_crashingInProgress ? getShaderVariant(SH_FRAG_GLITCH) : (m_finalScreenShader->program() ? m_finalScreenShader : getShaderVariant(SH_FRAG_PASSTHRURGBA));
@@ -1348,8 +1331,8 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
     else
         shader->setUniformFloat(SHADER_TIME, 0.f);
 
-    shader->setUniformInt(SHADER_WL_OUTPUT, m_renderData.pMonitor->m_id);
-    shader->setUniformFloat2(SHADER_FULL_SIZE, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
+    shader->setUniformInt(SHADER_WL_OUTPUT, context.sceneMonitor->m_id);
+    shader->setUniformFloat2(SHADER_FULL_SIZE, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
     shader->setUniformFloat(SHADER_POINTER_INACTIVE_TIMEOUT, *PCURSORTIMEOUT);
     shader->setUniformInt(SHADER_POINTER_HIDDEN, g_pHyprRenderer->m_cursorHiddenByCondition);
     shader->setUniformInt(SHADER_POINTER_KILLING, g_pInputManager->getClickMode() == CLICKMODE_KILL);
@@ -1358,7 +1341,7 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
     shader->setUniformFloat(SHADER_POINTER_SIZE, Pointer::Cursor::mgr()->getScaledSize());
 
     if (*PDT == 0) {
-        PHLMONITORREF pMonitor = m_renderData.pMonitor;
+        PHLMONITORREF pMonitor = context.sceneMonitor;
         Vector2D      p        = ((g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position) * pMonitor->m_scale);
         shader->setUniformFloat2(SHADER_POINTER, p.x / pMonitor->m_transformedSize.x, p.y / pMonitor->m_transformedSize.y);
 
@@ -1397,17 +1380,15 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
 
     if (g_pHyprRenderer->m_crashingInProgress) {
         shader->setUniformFloat(SHADER_DISTORT, g_pHyprRenderer->m_crashingDistort);
-        shader->setUniformFloat2(SHADER_FULL_SIZE, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
+        shader->setUniformFloat2(SHADER_FULL_SIZE, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
     }
 
     return shader;
 }
 
-WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox) {
+WP<CShader> CHyprOpenGLImpl::renderToFBInternal(CRenderingContext& context, SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox) {
     static const auto  PENABLECM = CConfigValue<Config::INTEGER>("render:cm_enabled");
     static auto        PBLEND    = CConfigValue<Config::INTEGER>("render:use_shader_blur_blend");
-
-    auto&              m_renderData = g_pHyprRenderer->m_renderData;
 
     float              alpha = std::clamp(data.a, 0.f, 1.f);
 
@@ -1419,15 +1400,15 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         case TEXTURE_RGBX: shaderFeatures &= ~SH_FEAT_RGBA; break;
 
         // TODO set correct features
-        case TEXTURE_EXTERNAL: shader = getShaderVariant(SH_FRAG_EXT, SH_FEAT_ROUNDING | SH_FEAT_DISCARD | SH_FEAT_TINT | globalFeatures()); break; // might be unused
+        case TEXTURE_EXTERNAL: shader = getShaderVariant(SH_FRAG_EXT, SH_FEAT_ROUNDING | SH_FEAT_DISCARD | SH_FEAT_TINT | globalFeatures(context)); break; // might be unused
         default: RASSERT(false, "tex->m_iTarget unsupported!");
     }
 
-    if (data.finalMonitorCM || (g_pHyprRenderer->m_renderData.currentWindow && g_pHyprRenderer->m_renderData.currentWindow->m_ruleApplicator->RGBX().valueOrDefault()))
+    if (data.finalMonitorCM || (context.currentWindow && context.currentWindow->m_ruleApplicator->RGBX().valueOrDefault()))
         shaderFeatures &= ~SH_FEAT_RGBA;
 
-    const auto surface                       = g_pHyprRenderer->m_renderData.surface;
-    const auto WORK_BUFFER_IMAGE_DESCRIPTION = g_pHyprRenderer->m_renderData.pMonitor->workBufferImageDescription();
+    const auto surface                       = context.surface;
+    const auto WORK_BUFFER_IMAGE_DESCRIPTION = context.sceneMonitor->workBufferImageDescription();
 
     // chosenSdrEotf contains the valid eotf for this display
 
@@ -1452,8 +1433,8 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
     }();
 
     const auto TARGET_IMAGE_DESCRIPTION = [&] {
-        if (g_pHyprRenderer->m_renderData.currentFB->imageDescription())
-            return g_pHyprRenderer->m_renderData.currentFB->imageDescription();
+        if (context.currentFB->imageDescription())
+            return context.currentFB->imageDescription();
 
         // if we are CM'ing back, use default sRGB
         if (data.cmBackToSRGB)
@@ -1461,7 +1442,7 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
 
         // for final CM, use the target description
         if (data.finalMonitorCM)
-            return g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription;
+            return context.sceneMonitor->m_imageDescription;
         // otherwise, use chosen, we're drawing into the work buffer
         // NOLINTNEXTLINE
         return WORK_BUFFER_IMAGE_DESCRIPTION;
@@ -1483,24 +1464,22 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         shaderFeatures |= SH_FEAT_DISCARD;
 
     const bool skipCM = !*PENABLECM || !m_cmSupported                   /* CM unsupported or disabled */
-        || g_pHyprRenderer->m_renderData.pMonitor->doesNoShaderCM()     /* no shader needed */
+        || context.sceneMonitor->doesNoShaderCM()                       /* no shader needed */
         || !SOURCE_IMAGE_DESCRIPTION->needsCM(TARGET_IMAGE_DESCRIPTION) /* Source and target have matching image descriptions */
         ;
 
-    if (g_pHyprRenderer->m_renderData.pMonitor->needsACopyFB())
+    if (context.sceneMonitor->needsACopyFB())
         Log::logger->log(Log::TRACE, "CM: render to FB skip={} {} -> {}", skipCM, SOURCE_IMAGE_DESCRIPTION->value(), TARGET_IMAGE_DESCRIPTION->value());
 
-    if (data.allowDim && g_pHyprRenderer->m_renderData.currentWindow &&
-        (g_pHyprRenderer->m_renderData.currentWindow->presentation().notRespondingTint() > 0 || g_pHyprRenderer->m_renderData.currentWindow->presentation().dimPercent() > 0))
+    if (data.allowDim && context.currentWindow && (context.currentWindow->presentation().notRespondingTint() > 0 || context.currentWindow->presentation().dimPercent() > 0))
         shaderFeatures |= SH_FEAT_TINT;
 
     if (data.round > 0)
         shaderFeatures |= SH_FEAT_ROUNDING;
 
     if (!skipCM) {
-        const auto settings =
-            g_pHyprRenderer->getCMSettings(SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, surface.valid() ? surface.lock() : nullptr, true,
-                                           g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance, true);
+        const auto settings = g_pHyprRenderer->getCMSettings(context, SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, surface.valid() ? surface.lock() : nullptr, true,
+                                                             context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance, true);
 
         shaderFeatures |= SH_FEAT_CM;
 
@@ -1518,14 +1497,14 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         }
 
         if (!shader)
-            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures(), settings.sourceTF, settings.targetTF);
+            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures(context), settings.sourceTF, settings.targetTF);
         shader = useShader(shader);
 
-        passCMUniforms(shader, SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, true, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance,
-                       g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance, settings);
+        passCMUniforms(context, shader, SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, true, context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance,
+                       settings);
     } else {
         if (!shader)
-            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures());
+            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures(context));
         shader = useShader(shader);
     }
 
@@ -1571,8 +1550,8 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         CBox motionPrev   = data.motionBlur.previous;
         CBox motionCurr   = data.motionBlur.current;
         CBox motionSource = data.motionBlur.source;
-        m_renderData.renderModif.applyToBox(motionPrev);
-        m_renderData.renderModif.applyToBox(motionCurr);
+        context.renderModif.applyToBox(motionPrev);
+        context.renderModif.applyToBox(motionCurr);
 
         shader->setUniformFloat4(SHADER_MOTION_PREV_BOX, motionPrev.x, motionPrev.y, motionPrev.w, motionPrev.h);
         shader->setUniformFloat4(SHADER_MOTION_CURR_BOX, motionCurr.x, motionCurr.y, motionCurr.w, motionCurr.h);
@@ -1582,14 +1561,14 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         shader->setUniformInt(SHADER_MOTION_SAMPLES, data.motionBlur.samples);
     }
 
-    if (data.allowDim && g_pHyprRenderer->m_renderData.currentWindow) {
-        if (g_pHyprRenderer->m_renderData.currentWindow->presentation().notRespondingTint() > 0) {
-            const auto DIM = g_pHyprRenderer->m_renderData.currentWindow->presentation().notRespondingTint();
+    if (data.allowDim && context.currentWindow) {
+        if (context.currentWindow->presentation().notRespondingTint() > 0) {
+            const auto DIM = context.currentWindow->presentation().notRespondingTint();
             shader->setUniformInt(SHADER_APPLY_TINT, 1);
             shader->setUniformFloat3(SHADER_TINT, 1.f - DIM, 1.f - DIM, 1.f - DIM);
-        } else if (g_pHyprRenderer->m_renderData.currentWindow->presentation().dimPercent() > 0) {
+        } else if (context.currentWindow->presentation().dimPercent() > 0) {
             shader->setUniformInt(SHADER_APPLY_TINT, 1);
-            const auto DIM = g_pHyprRenderer->m_renderData.currentWindow->presentation().dimPercent();
+            const auto DIM = context.currentWindow->presentation().dimPercent();
             shader->setUniformFloat3(SHADER_TINT, 1.f - DIM, 1.f - DIM, 1.f - DIM);
         } else
             shader->setUniformInt(SHADER_APPLY_TINT, 0);
@@ -1610,8 +1589,8 @@ static GLenum wrapModeToGl(const uint8_t wrapMode) {
     }
 }
 
-void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTextureInternal(CRenderingContext& context, SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
     RASSERT(tex, "Attempted to draw nullptr texture!");
     RASSERT(tex->ok(), "Attempted to draw invalid texture!");
 
@@ -1621,15 +1600,15 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
         return;
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     // get the needed transform for this texture
     // wl_surface::set_buffer_transform: "The compositor applies the inverse of this transformation whenever it uses the buffer contents."
     Hyprutils::Math::eTransform TRANSFORM = Math::invertTransform(tex->m_transform);
 
-    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
+    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox, TRANSFORM);
 
-    const bool                  useScreenShader = m_applyFinalShader;
+    const bool                  useScreenShader = context.applyFinalScreenShader;
 
     setActiveTexture(GL_TEXTURE0);
     tex->bind();
@@ -1637,7 +1616,7 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     tex->setTexParameter(GL_TEXTURE_WRAP_S, wrapModeToGl(data.wrapX));
     tex->setTexParameter(GL_TEXTURE_WRAP_T, wrapModeToGl(data.wrapY));
 
-    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+    if (context.useNearestNeighbor) {
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
@@ -1645,7 +1624,7 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
     }
 
-    auto shader = useScreenShader ? renderScreenShaderInternal() : renderToFBInternal(tex, data, tex->m_type, newBox);
+    auto shader = useScreenShader ? renderScreenShaderInternal(context) : renderToFBInternal(context, tex, data, tex->m_type, newBox);
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
@@ -1679,11 +1658,11 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     } else
         GLCALL(glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO)));
 
-    if (!g_pHyprRenderer->m_renderData.clipBox.empty() || !data.clipRegion.empty()) {
-        CRegion damageClip = g_pHyprRenderer->m_renderData.clipBox;
+    if (!context.clipBox.empty() || !data.clipRegion.empty()) {
+        CRegion damageClip = context.clipBox;
 
         if (!data.clipRegion.empty()) {
-            if (g_pHyprRenderer->m_renderData.clipBox.empty())
+            if (context.clipBox.empty())
                 damageClip = data.clipRegion;
             else
                 damageClip.intersect(data.clipRegion);
@@ -1692,14 +1671,14 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
         damageClip.intersect(*data.damage);
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
     } else {
-        data.damage->forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        data.damage->forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -1709,8 +1688,8 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture mesh without begin()!");
+void CHyprOpenGLImpl::renderTextureMesh(CRenderingContext& context, SP<ITexture> tex, const CBox& box, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture mesh without begin()!");
     RASSERT(tex, "Attempted to draw nullptr texture mesh!");
     RASSERT(tex->ok(), "Attempted to draw invalid texture mesh!");
 
@@ -1718,11 +1697,11 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
         return;
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     Hyprutils::Math::eTransform TRANSFORM = tex->m_transform;
 
-    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
+    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox, TRANSFORM);
 
     setActiveTexture(GL_TEXTURE0);
     tex->bind();
@@ -1730,7 +1709,7 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
     tex->setTexParameter(GL_TEXTURE_WRAP_S, wrapModeToGl(data.wrapX));
     tex->setTexParameter(GL_TEXTURE_WRAP_T, wrapModeToGl(data.wrapY));
 
-    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+    if (context.useNearestNeighbor) {
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
@@ -1738,7 +1717,7 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
     }
 
-    auto shader = renderToFBInternal(tex, data, tex->m_type, newBox);
+    auto shader = renderToFBInternal(context, tex, data, tex->m_type, newBox);
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
@@ -1748,25 +1727,25 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
     glBufferData(GL_ARRAY_BUFFER, sizeof(SMeshRenderVertex) * vertices.size(), nullptr, GL_DYNAMIC_DRAW);
     glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(SMeshRenderVertex) * vertices.size(), vertices.data());
 
-    if (!g_pHyprRenderer->m_renderData.clipBox.empty() || !data.clipRegion.empty()) {
-        CRegion damageClip = g_pHyprRenderer->m_renderData.clipBox;
+    if (!context.clipBox.empty() || !data.clipRegion.empty()) {
+        CRegion damageClip = context.clipBox;
 
         if (!data.clipRegion.empty()) {
-            if (g_pHyprRenderer->m_renderData.clipBox.empty())
+            if (context.clipBox.empty())
                 damageClip = data.clipRegion;
             else
                 damageClip.intersect(data.clipRegion);
         }
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this, &vertices](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context, &vertices](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLES, 0, sc<GLsizei>(vertices.size()));
             });
         }
     } else {
-        data.damage->forEachRect([this, &vertices](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        data.damage->forEachRect([this, &context, &vertices](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLES, 0, sc<GLsizei>(vertices.size()));
         });
     }
@@ -1776,27 +1755,27 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTexturePrimitive(SP<ITexture> tex, const CBox& box) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTexturePrimitive(CRenderingContext& context, SP<ITexture> tex, const CBox& box) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTexturePrimitive");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     // get transform
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     setActiveTexture(GL_TEXTURE0);
     tex->bind();
 
     // ensure the final blit uses the desired sampling filter
     // when cursor zoom is active we want nearest-neighbor (no anti-aliasing)
-    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+    if (context.useNearestNeighbor) {
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
@@ -1809,29 +1788,29 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<ITexture> tex, const CBox& box) 
     shader->setUniformInt(SHADER_TEX, 0);
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    g_pHyprRenderer->m_renderData.damage.forEachRect([this](const auto& RECT) {
-        scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+    context.damage.forEachRect([this, &context](const auto& RECT) {
+        scissor(context, &RECT, context.transformDamage);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     });
 
-    scissor(nullptr);
+    scissor(context, nullptr);
     glBindVertexArray(0);
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTextureMatte(SP<ITexture> tex, const CBox& box, SP<IFramebuffer> matte) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTextureMatte(CRenderingContext& context, SP<ITexture> tex, const CBox& box, SP<IFramebuffer> matte) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTextureMatte");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     // get transform
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
-    auto        shader = useShader(getShaderVariant(SH_FRAG_MATTE, globalFeatures()));
+    auto        shader = useShader(getShaderVariant(SH_FRAG_MATTE, globalFeatures(context)));
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
     shader->setUniformInt(SHADER_ALPHA_MATTE, 1);
@@ -1845,19 +1824,18 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<ITexture> tex, const CBox& box, SP<I
 
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    g_pHyprRenderer->m_renderData.damage.forEachRect([this](const auto& RECT) {
-        scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+    context.damage.forEachRect([this, &context](const auto& RECT) {
+        scissor(context, &RECT, context.transformDamage);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     });
 
-    scissor(nullptr);
+    scissor(context, nullptr);
     glBindVertexArray(0);
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to render texture with blur without begin()!");
+void CHyprOpenGLImpl::renderTextureWithBlurInternal(CRenderingContext& context, SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture with blur without begin()!");
 
     TRACY_GPU_ZONE("RenderTextureWithBlur");
 
@@ -1867,7 +1845,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
     if (!SHADERBLEND) {
 
         if (NEEDS_STENCIL) {
-            scissor(nullptr); // allow the entire window and stencil to render
+            scissor(context, nullptr); // allow the entire window and stencil to render
             glStencilMask(0xFF);
             glClearStencil(0);
             glClear(GL_STENCIL_BUFFER_BIT);
@@ -1879,9 +1857,9 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
 
             glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
-            renderTexture(tex, box,
+            renderTexture(context, tex, box,
                           STextureRenderData{
-                              .damage                      = &g_pHyprRenderer->m_renderData.damage,
+                              .damage                      = &context.damage,
                               .a                           = data.a,
                               .round                       = data.round,
                               .roundingPower               = data.roundingPower,
@@ -1893,8 +1871,8 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                               .discardOpacity              = data.discardOpacity,
                               .clipRegion                  = data.clipRegion,
                               .currentLS                   = data.currentLS,
-                              .primarySurfaceUVTopLeft     = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft,
-                              .primarySurfaceUVBottomRight = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight,
+                              .primarySurfaceUVTopLeft     = context.primarySurfaceUVTopLeft,
+                              .primarySurfaceUVBottomRight = context.primarySurfaceUVBottomRight,
                           }); // discard opaque and alpha < discardOpacity
 
             glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
@@ -1915,20 +1893,20 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
         if (PSURFACE && PSURFACE->m_hasBackgroundEffect && !PSURFACE->m_blurRegion.empty()) {
             CRegion protocolBlur = PSURFACE->m_blurRegion.copy();
             protocolBlur.intersect(CBox{0, 0, box.width, box.height});
-            protocolBlur.scale(m_renderData.pMonitor->m_scale);
+            protocolBlur.scale(context.sceneMonitor->m_scale);
             protocolBlur.translate(box.pos());
-            m_renderData.renderModif.applyToRegion(protocolBlur);
+            context.renderModif.applyToRegion(protocolBlur);
             if (blurClipRegion.empty())
                 blurClipRegion = protocolBlur;
             else
                 blurClipRegion.intersect(protocolBlur);
         }
 
-        bool renderModif = g_pHyprRenderer->m_renderData.renderModif.enabled;
+        bool renderModif = context.renderModif.enabled;
         if (!data.blockBlurOptimization)
-            g_pHyprRenderer->m_renderData.renderModif.enabled = false;
+            context.renderModif.enabled = false;
 
-        renderTextureInternal(data.blurredBG, box,
+        renderTextureInternal(context, data.blurredBG, box,
                               STextureRenderData{
                                   .damage         = data.damage,
                                   .a              = (*PBLURIGNOREOPACITY ? data.blurA : data.a * data.blurA) * data.overallA,
@@ -1944,18 +1922,18 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                                   .clipRegion     = blurClipRegion,
                                   .currentLS      = data.currentLS,
 
-                                  .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / m_renderData.pMonitor->m_transformedSize,
-                                  .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / m_renderData.pMonitor->m_transformedSize,
+                                  .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / context.sceneMonitor->m_transformedSize,
+                                  .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / context.sceneMonitor->m_transformedSize,
                               });
 
-        g_pHyprRenderer->m_renderData.renderModif.enabled = renderModif;
+        context.renderModif.enabled = renderModif;
 
         if (NEEDS_STENCIL)
             setCapStatus(GL_STENCIL_TEST, false);
     }
 
     // draw window
-    renderTextureInternal(tex, box,
+    renderTextureInternal(context, tex, box,
                           STextureRenderData{
                               .blur           = SHADERBLEND,
                               .blurredBG      = data.blurredBG,
@@ -1975,23 +1953,22 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                               .clipRegion     = data.clipRegion,
                               .currentLS      = data.currentLS,
 
-                              .primarySurfaceUVTopLeft     = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft,
-                              .primarySurfaceUVBottomRight = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight,
+                              .primarySurfaceUVTopLeft     = context.primarySurfaceUVTopLeft,
+                              .primarySurfaceUVBottomRight = context.primarySurfaceUVBottomRight,
                           });
 
-    GLFB(g_pHyprRenderer->m_renderData.currentFB)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT});
-    scissor(nullptr);
+    GLFB(context.currentFB)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT});
+    scissor(context, nullptr);
 }
 
-static SShaderVariant getDecoVariant() {
-    const bool IS_ICC   = g_pHyprRenderer->workBufferImageDescription()->value().icc.present;
-    const auto settings = g_pHyprRenderer->getCMSettings(g_pHyprRenderer->workBufferImageDescription(), getDefaultImageDescription(), nullptr, true,
-                                                         g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance);
-    const auto uniformSettings =
-        g_pHyprRenderer->getCMSettings(getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(), nullptr, true,
-                                       g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance);
+static SShaderVariant getDecoVariant(const CRenderingContext& context) {
+    const bool         IS_ICC          = g_pHyprRenderer->workBufferImageDescription(context)->value().icc.present;
+    const auto         settings        = g_pHyprRenderer->getCMSettings(context, g_pHyprRenderer->workBufferImageDescription(context), getDefaultImageDescription(), nullptr, true,
+                                                                        context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance);
+    const auto         uniformSettings = g_pHyprRenderer->getCMSettings(context, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(context), nullptr, true,
+                                                                        context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance);
 
-    ShaderFeatureFlags features = SH_FEAT_ROUNDING | SH_FEAT_CM | globalFeatures();
+    ShaderFeatureFlags features = SH_FEAT_ROUNDING | SH_FEAT_CM | globalFeatures(context);
     if (IS_ICC)
         features |= SH_FEAT_ICC;
     else {
@@ -2006,24 +1983,23 @@ static SShaderVariant getDecoVariant() {
     return {.features = features, .sourceTF = uniformSettings.sourceTF, .targetTF = uniformSettings.targetTF};
 }
 
-void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValueData& grad, SBorderRenderData data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void CHyprOpenGLImpl::renderBorder(CRenderingContext& context, const CBox& box, const Config::CGradientValueData& grad, SBorderRenderData data) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     CBox innerBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(innerBox);
+    context.renderModif.applyToBox(innerBox);
 
     if (data.borderSize < 1)
         return;
 
-    int scaledBorderSize = std::round(data.borderSize * m_renderData.pMonitor->m_scale);
-    scaledBorderSize     = std::round(scaledBorderSize * g_pHyprRenderer->m_renderData.renderModif.combinedScale());
+    int scaledBorderSize = std::round(data.borderSize * context.sceneMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * context.renderModif.combinedScale());
 
     // adjust box
     CBox newBox = innerBox;
@@ -2034,19 +2010,19 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     float       round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     const auto  BLEND = m_blend;
     blend(true);
 
     WP<CShader> shader;
 
-    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription(context)->needsCM(getDefaultImageDescription());
     if (!skipCM) {
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant()));
-        passCMUniforms(shader, getDefaultImageDescription());
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant(context)));
+        passCMUniforms(context, shader, getDefaultImageDescription());
     } else
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures()));
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures(context)));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniform4fv(SHADER_GRADIENT, grad.m_colorsOkLabA.size() / 4, grad.m_colorsOkLabA);
@@ -2070,15 +2046,15 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     // calculate the border's region, which we need to render over. No need to run the shader on
     // things outside there
-    CRegion borderRegion = g_pHyprRenderer->m_renderData.damage.copy().intersect(newBox);
+    CRegion borderRegion = context.damage.copy().intersect(newBox);
     borderRegion.subtract(innerBox.copy().expand(-scaledBorderSize - round));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0)
-        borderRegion.intersect(g_pHyprRenderer->m_renderData.clipBox);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0)
+        borderRegion.intersect(context.clipBox);
 
     if (!borderRegion.empty()) {
-        borderRegion.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        borderRegion.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -2088,24 +2064,24 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp, SBorderRenderData data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void CHyprOpenGLImpl::renderBorder(CRenderingContext& context, const CBox& box, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp,
+                                   SBorderRenderData data) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderBorder2");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     CBox innerBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(innerBox);
+    context.renderModif.applyToBox(innerBox);
 
     if (data.borderSize < 1)
         return;
 
-    int scaledBorderSize = std::round(data.borderSize * m_renderData.pMonitor->m_scale);
-    scaledBorderSize     = std::round(scaledBorderSize * g_pHyprRenderer->m_renderData.renderModif.combinedScale());
+    int scaledBorderSize = std::round(data.borderSize * context.sceneMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * context.renderModif.combinedScale());
 
     // adjust box
     CBox newBox = innerBox;
@@ -2116,18 +2092,18 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     float       round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     const auto  BLEND = m_blend;
     blend(true);
 
     WP<CShader> shader;
-    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription(context)->needsCM(getDefaultImageDescription());
     if (!skipCM) {
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant()));
-        passCMUniforms(shader, getDefaultImageDescription());
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant(context)));
+        passCMUniforms(context, shader, getDefaultImageDescription());
     } else
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures()));
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures(context)));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniform4fv(SHADER_GRADIENT, grad1.m_colorsOkLabA.size() / 4, grad1.m_colorsOkLabA);
@@ -2155,15 +2131,15 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     // calculate the border's region, which we need to render over. No need to run the shader on
     // things outside there
-    CRegion borderRegion = g_pHyprRenderer->m_renderData.damage.copy().intersect(newBox);
+    CRegion borderRegion = context.damage.copy().intersect(newBox);
     borderRegion.subtract(innerBox.copy().expand(-scaledBorderSize - round));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0)
-        borderRegion.intersect(g_pHyprRenderer->m_renderData.clipBox);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0)
+        borderRegion.intersect(context.clipBox);
 
     if (!borderRegion.empty()) {
-        borderRegion.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        borderRegion.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -2172,35 +2148,34 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
-    renderRoundedShadow(box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a);
+void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
+    renderRoundedShadow(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a);
 }
 
-void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
                                           const Config::CGradientValueData& grad2, float lerp, float a) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to render shadow without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render shadow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     TRACY_GPU_ZONE("RenderShadow");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     static auto PSHADOWPOWER = CConfigValue<Config::INTEGER>("decoration:shadow:render_power");
 
     const auto  SHADOWPOWER = std::clamp(sc<int>(*PSHADOWPOWER), 1, 4);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     blend(true);
 
-    const auto TF      = m_renderData.currentFB->imageDescription()->value().transferFunction;
+    const auto TF      = context.currentFB->imageDescription()->value().transferFunction;
     const bool needsCM = TF != CM_TRANSFER_FUNCTION_EXT_LINEAR;
-    auto       shader  = useShader(getShaderVariant(SH_FRAG_SHADOW, (needsCM ? SH_FEAT_CM : 0) | globalFeatures(), TF));
+    auto       shader  = useShader(getShaderVariant(SH_FRAG_SHADOW, (needsCM ? SH_FEAT_CM : 0) | globalFeatures(context), TF));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
 
@@ -2208,7 +2183,7 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
     if (!grad1.m_colors.empty())
         color = grad1.m_colors[0];
 
-    const auto converted = g_pHyprRenderer->getConvertedColor(color.stripA());
+    const auto converted = g_pHyprRenderer->getConvertedColor(context, color.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, color.a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, color.r, color.g, color.b, color.a);
 
@@ -2242,33 +2217,32 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
     CRegion drawRegion;
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0) {
-        drawRegion = {g_pHyprRenderer->m_renderData.clipBox.x, g_pHyprRenderer->m_renderData.clipBox.y, g_pHyprRenderer->m_renderData.clipBox.width,
-                      g_pHyprRenderer->m_renderData.clipBox.height};
-        drawRegion.intersect(g_pHyprRenderer->m_renderData.damage);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        drawRegion = {context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
+        drawRegion.intersect(context.damage);
     } else
-        drawRegion = g_pHyprRenderer->m_renderData.damage;
+        drawRegion = context.damage;
 
-    if (g_pHyprRenderer->m_renderData.currentWindow) {
-        const auto PWINDOW = g_pHyprRenderer->m_renderData.currentWindow.lock();
+    if (context.currentWindow) {
+        const auto PWINDOW = context.currentWindow.lock();
         if (PWINDOW) {
             if (const auto WINDOWBOX = PWINDOW->surfaceLogicalBox(); WINDOWBOX.has_value()) {
                 CBox       scaledWindowBox = WINDOWBOX.value();
 
                 const auto PWORKSPACE = PWINDOW->m_workspace;
                 if (PWORKSPACE && !(PWINDOW->m_state & WINDOW_STATE_PINNED))
-                    scaledWindowBox.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock()));
+                    scaledWindowBox.translate(g_pHyprRenderer->workspaceRenderOffset(context, PWORKSPACE, context.sceneMonitor.lock()));
 
-                scaledWindowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
-                scaledWindowBox.translate(-m_renderData.pMonitor->m_position);
-                scaledWindowBox.scale(m_renderData.pMonitor->m_scale).round();
-                m_renderData.renderModif.applyToBox(scaledWindowBox);
+                scaledWindowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(context, PWINDOW));
+                scaledWindowBox.translate(-context.sceneMonitor->m_position);
+                scaledWindowBox.scale(context.sceneMonitor->m_scale).round();
+                context.renderModif.applyToBox(scaledWindowBox);
 
                 const auto cutoutTopLeft     = scaledWindowBox.pos() - newBox.pos();
                 const auto cutoutBottomRight = cutoutTopLeft + scaledWindowBox.size();
 
-                float      cutoutRadius = std::max(0.F, sc<float>(PWINDOW->presentation().rounding() * m_renderData.pMonitor->m_scale));
-                cutoutRadius            = std::round(cutoutRadius * m_renderData.renderModif.combinedScale());
+                float      cutoutRadius = std::max(0.F, sc<float>(PWINDOW->presentation().rounding() * context.sceneMonitor->m_scale));
+                cutoutRadius            = std::round(cutoutRadius * context.renderModif.combinedScale());
 
                 shader->setUniformFloat2(SHADER_WINDOW_TOP_LEFT, sc<float>(cutoutTopLeft.x), sc<float>(cutoutTopLeft.y));
                 shader->setUniformFloat2(SHADER_WINDOW_BOTTOM_RIGHT, sc<float>(cutoutBottomRight.x), sc<float>(cutoutBottomRight.y));
@@ -2280,40 +2254,40 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
     }
 
     if (!drawRegion.empty())
-        drawRegion.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        drawRegion.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
 
     glBindVertexArray(0);
 }
 
-void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, int glowPower, float a) {
-    renderInnerGlow(box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, glowPower, a);
+void CHyprOpenGLImpl::renderInnerGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, int glowPower,
+                                      float a) {
+    renderInnerGlow(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, glowPower, a);
 }
-void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                      float lerp, int glowPower, float a) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to render inner glow without begin()!");
+void CHyprOpenGLImpl::renderInnerGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                      const Config::CGradientValueData& grad2, float lerp, int glowPower, float a) {
+    RASSERT(context.sceneMonitor, "Tried to render inner glow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render inner glow with width/height < 0!");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     TRACY_GPU_ZONE("RenderInnerGlow");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     static auto PGLOWPOWER = CConfigValue<Config::INTEGER>("decoration:glow:render_power");
 
     const auto  GLOWPOWER = std::clamp(sc<int>(*PGLOWPOWER), 1, 4);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     blend(true);
 
-    auto shader = useShader(getShaderVariant(SH_FRAG_INNER_GLOW, globalFeatures()));
+    auto shader = useShader(getShaderVariant(SH_FRAG_INNER_GLOW, globalFeatures(context)));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
 
@@ -2321,7 +2295,7 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
     if (!grad1.m_colors.empty())
         color = grad1.m_colors[0];
 
-    const auto converted = g_pHyprRenderer->getConvertedColor(color.stripA());
+    const auto converted = g_pHyprRenderer->getConvertedColor(context, color.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, color.a * a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, color.r, color.g, color.b, color.a * a);
 
@@ -2349,20 +2323,19 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
 
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0) {
-        CRegion damageClip{g_pHyprRenderer->m_renderData.clipBox.x, g_pHyprRenderer->m_renderData.clipBox.y, g_pHyprRenderer->m_renderData.clipBox.width,
-                           g_pHyprRenderer->m_renderData.clipBox.height};
-        damageClip.intersect(g_pHyprRenderer->m_renderData.damage);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        CRegion damageClip{context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
+        damageClip.intersect(context.damage);
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
     } else {
-        g_pHyprRenderer->m_renderData.damage.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        context.damage.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -2370,23 +2343,22 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
     glBindVertexArray(0);
 }
 
-bool CHyprOpenGLImpl::saveBufferForMirror(const CBox& box) {
-    const auto TEX = g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex ? g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex :
-                                                                                        g_pHyprRenderer->m_renderData.currentFB->getTexture();
+bool CHyprOpenGLImpl::saveBufferForMirror(CRenderingContext& context, const CBox& box) {
+    const auto TEX = context.sceneMonitor->resources()->m_mirrorTex ? context.sceneMonitor->resources()->m_mirrorTex : context.currentFB->getTexture();
     if (!TEX) {
         Log::logger->log(Log::ERR, "Invalid source texture for mirror");
         return false;
     }
-    auto fb    = g_pHyprRenderer->m_renderData.pMonitor->resources()->mirrorFB();
-    auto guard = g_pHyprRenderer->bindTempFB(fb);
+    auto fb    = context.sceneMonitor->resources()->mirrorFB();
+    auto guard = g_pHyprRenderer->bindTempFB(context, fb);
 
-    Log::logger->log(Log::TRACE, "CM: saveBufferForMirror {} -> {}", TEX->m_imageDescription->value(), g_pHyprRenderer->m_renderData.currentFB->imageDescription()->value());
+    Log::logger->log(Log::TRACE, "CM: saveBufferForMirror {} -> {}", TEX->m_imageDescription->value(), context.currentFB->imageDescription()->value());
 
     blend(false);
 
-    renderTexture(TEX, box,
+    renderTexture(context, TEX, box,
                   STextureRenderData{
-                      .damage        = &g_pHyprRenderer->m_renderData.finalDamage,
+                      .damage        = &context.finalDamage,
                       .a             = 1.F,
                       .round         = 0,
                       .discardActive = false,
@@ -2424,9 +2396,9 @@ void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITORREF pMonitor) {
         Log::logger->log(Log::DEBUG, "Monitor {} -> destroyed all render data", pMonitor->m_name);
 }
 
-void CHyprOpenGLImpl::renderOffToMain(SP<IFramebuffer> off) {
-    CBox monbox = {0, 0, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y};
-    renderTexturePrimitive(off->getTexture(), monbox);
+void CHyprOpenGLImpl::renderOffToMain(CRenderingContext& context, SP<IFramebuffer> off) {
+    CBox monbox = {0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y};
+    renderTexturePrimitive(context, off->getTexture(), monbox);
 }
 
 void CHyprOpenGLImpl::setViewport(GLint x, GLint y, GLsizei width, GLsizei height) {
@@ -2475,6 +2447,10 @@ void CHyprOpenGLImpl::bindFramebuffer(GLenum target, GLuint fb) {
         m_boundDrawFB = fb;
     if (READ)
         m_boundReadFB = fb;
+}
+
+GLuint CHyprOpenGLImpl::boundDrawFramebuffer() const {
+    return m_boundDrawFB;
 }
 
 void CHyprOpenGLImpl::onFramebufferDeleted(GLuint fb) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2156,11 +2156,21 @@ void CHyprOpenGLImpl::renderBorder(CRenderingContext& context, const CBox& box, 
 }
 
 void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
-    renderRoundedShadow(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a);
+    renderRoundedShadowInternal(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a, std::nullopt, 0);
+}
+
+void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a,
+                                          const CBox& cutoutBox, int cutoutRound) {
+    renderRoundedShadowInternal(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a, cutoutBox, cutoutRound);
 }
 
 void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
                                           const Config::CGradientValueData& grad2, float lerp, float a) {
+    renderRoundedShadowInternal(context, box, round, roundingPower, range, grad1, grad2, lerp, a, std::nullopt, 0);
+}
+
+void CHyprOpenGLImpl::renderRoundedShadowInternal(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                                  const Config::CGradientValueData& grad2, float lerp, float a, const std::optional<CBox>& cutoutBox, int cutoutRound) {
     RASSERT(context.sceneMonitor, "Tried to render shadow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
 
@@ -2230,7 +2240,20 @@ void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox
     } else
         drawRegion = context.damage;
 
-    if (context.currentWindow) {
+    if (cutoutBox) {
+        CBox transformedCutout = *cutoutBox;
+        context.renderModif.applyToBox(transformedCutout);
+
+        const auto cutoutTopLeft     = transformedCutout.pos() - newBox.pos();
+        const auto cutoutBottomRight = cutoutTopLeft + transformedCutout.size();
+        const auto cutoutRadius      = std::max(0.F, sc<float>(cutoutRound));
+
+        shader->setUniformFloat2(SHADER_WINDOW_TOP_LEFT, sc<float>(cutoutTopLeft.x), sc<float>(cutoutTopLeft.y));
+        shader->setUniformFloat2(SHADER_WINDOW_BOTTOM_RIGHT, sc<float>(cutoutBottomRight.x), sc<float>(cutoutBottomRight.y));
+        shader->setUniformFloat(SHADER_THICK, cutoutRadius);
+
+        drawRegion.subtract(transformedCutout.copy().expand(-sc<int>(std::round(cutoutRadius))));
+    } else if (context.currentWindow) {
         const auto PWINDOW = context.currentWindow.lock();
         if (PWINDOW) {
             if (const auto WINDOWBOX = PWINDOW->surfaceLogicalBox(); WINDOWBOX.has_value()) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2149,11 +2149,21 @@ void CHyprOpenGLImpl::renderBorder(CRenderingContext& context, const CBox& box, 
 }
 
 void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
-    renderRoundedShadow(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a);
+    renderRoundedShadowInternal(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a, std::nullopt, 0);
+}
+
+void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a,
+                                          const CBox& cutoutBox, int cutoutRound) {
+    renderRoundedShadowInternal(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a, cutoutBox, cutoutRound);
 }
 
 void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
                                           const Config::CGradientValueData& grad2, float lerp, float a) {
+    renderRoundedShadowInternal(context, box, round, roundingPower, range, grad1, grad2, lerp, a, std::nullopt, 0);
+}
+
+void CHyprOpenGLImpl::renderRoundedShadowInternal(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                                  const Config::CGradientValueData& grad2, float lerp, float a, const std::optional<CBox>& cutoutBox, int cutoutRound) {
     RASSERT(context.sceneMonitor, "Tried to render shadow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
 
@@ -2223,7 +2233,20 @@ void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox
     } else
         drawRegion = context.damage;
 
-    if (context.currentWindow) {
+    if (cutoutBox) {
+        CBox transformedCutout = *cutoutBox;
+        context.renderModif.applyToBox(transformedCutout);
+
+        const auto cutoutTopLeft     = transformedCutout.pos() - newBox.pos();
+        const auto cutoutBottomRight = cutoutTopLeft + transformedCutout.size();
+        const auto cutoutRadius      = std::max(0.F, sc<float>(cutoutRound));
+
+        shader->setUniformFloat2(SHADER_WINDOW_TOP_LEFT, sc<float>(cutoutTopLeft.x), sc<float>(cutoutTopLeft.y));
+        shader->setUniformFloat2(SHADER_WINDOW_BOTTOM_RIGHT, sc<float>(cutoutBottomRight.x), sc<float>(cutoutBottomRight.y));
+        shader->setUniformFloat(SHADER_THICK, cutoutRadius);
+
+        drawRegion.subtract(transformedCutout.copy().expand(-sc<int>(std::round(cutoutRadius))));
+    } else if (context.currentWindow) {
         const auto PWINDOW = context.currentWindow.lock();
         if (PWINDOW) {
             if (const auto WINDOWBOX = PWINDOW->surfaceLogicalBox(); WINDOWBOX.has_value()) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -35,6 +35,7 @@
 #include "../managers/screenshare/ScreenshareManager.hpp"
 #include "../notification/NotificationOverlay.hpp"
 #include "../state/MonitorState.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "errorOverlay/Overlay.hpp"
 #include "helpers/Color.hpp"
 #include "macros.hpp"
@@ -2264,9 +2265,9 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
                 const auto PWORKSPACE = PWINDOW->m_workspace;
                 if (PWORKSPACE && !(PWINDOW->m_state & WINDOW_STATE_PINNED))
-                    scaledWindowBox.translate(PWORKSPACE->m_renderOffset->value());
+                    scaledWindowBox.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock()));
 
-                scaledWindowBox.translate(PWINDOW->presentation().floatingOffset());
+                scaledWindowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
                 scaledWindowBox.translate(-m_renderData.pMonitor->m_position);
                 scaledWindowBox.scale(m_renderData.pMonitor->m_scale).round();
                 m_renderData.renderModif.applyToBox(scaledWindowBox);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1158,12 +1158,12 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(CRenderingContext& context, con
             .radius        = std::max(sc<float>(data.round), 0.F),
             .roundingPower = data.roundingPower,
         };
-    const bool usePrecomputedBlur = data.xray && !g_pHyprRenderer->blurProviderRequiresLiveBlur();
-    const auto blurredFB          = usePrecomputedBlur ?
+    const bool        usePrecomputedBlur = data.xray && !g_pHyprRenderer->blurProviderRequiresLiveBlur();
+    const auto        blurredFB          = usePrecomputedBlur ?
         context.sceneMonitor->resources()->m_blurFB :
         g_pHyprRenderer->blurMainFramebuffer(context, data.blurA, damage, {.patternBox = patternBox, .owner = data.blurOwner, .shape = shape});
-    const auto blurredBG = blurredFB->getTexture();
-    const auto blurUV    = resolveBlurUV(box, blurredBG->m_size);
+    const auto        blurredBG          = blurredFB->getTexture();
+    const auto        blurUV             = resolveBlurUV(box, blurredBG->m_size);
 
     CRenderingContext child{context, context.renderPass()};
     child.renderModif = {};

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -152,10 +152,8 @@ static int openRenderNode(int drmFd) {
     return renderFD;
 }
 
-static ShaderFeatureFlags globalFeatures() {
-    return g_pHyprRenderer->m_renderData.pMonitor && g_pHyprRenderer->m_renderData.pMonitor->needsUnmodifiedCopy() && g_pHyprRenderer->m_renderData.currentFB->getMirrorTexture() ?
-        SH_FEAT_MIRROR :
-        0;
+static ShaderFeatureFlags globalFeatures(const CRenderingContext& context) {
+    return context.sceneMonitor && context.sceneMonitor->needsUnmodifiedCopy() && context.currentFB->getMirrorTexture() ? SH_FEAT_MIRROR : 0;
 }
 
 void CHyprOpenGLImpl::initEGL(bool gbm) {
@@ -680,9 +678,7 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
     return image;
 }
 
-void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP<IRenderbuffer> rb, SP<IFramebuffer> fb) {
-    g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
-
+void CHyprOpenGLImpl::beginSimple(CRenderingContext& context, const CRegion& damage, SP<IRenderbuffer> rb, SP<IFramebuffer> fb) {
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
     if (RESETSTATUS != GL_NO_ERROR) {
         std::string errStr = "";
@@ -705,17 +701,17 @@ void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP
     if (!m_shadersInitialized)
         initShaders();
 
-    g_pHyprRenderer->m_renderData.transformDamage = false;
-    g_pHyprRenderer->m_renderData.damage.set(damage);
-    g_pHyprRenderer->m_renderData.finalDamage.set(damage);
+    context.transformDamage = false;
+    context.damage.set(damage);
+    context.finalDamage.set(damage);
 
-    m_fakeFrame = true;
+    context.fakeFrame = true;
 
-    g_pHyprRenderer->bindFB(FBO);
-    m_offloadedFramebuffer = false;
+    g_pHyprRenderer->bindFB(context, FBO);
+    context.offloadedFramebuffer = false;
 
-    g_pHyprRenderer->m_renderData.mainFB = g_pHyprRenderer->m_renderData.currentFB;
-    g_pHyprRenderer->m_renderData.outFB  = FBO;
+    context.mainFB = context.currentFB;
+    context.outFB  = FBO;
 }
 
 void CHyprOpenGLImpl::makeEGLCurrent() {
@@ -726,9 +722,7 @@ void CHyprOpenGLImpl::makeEGLCurrent() {
         eglMakeCurrent(g_pHyprOpenGL->m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, g_pHyprOpenGL->m_eglContext);
 }
 
-void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFramebuffer> fb, std::optional<CRegion> finalDamage) {
-    g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
-
+void CHyprOpenGLImpl::begin(CRenderingContext& context, const CRegion& damage_, SP<IFramebuffer> fb, std::optional<CRegion> finalDamage) {
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
     if (RESETSTATUS != GL_NO_ERROR) {
         std::string errStr = "";
@@ -744,16 +738,16 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFra
 
     TRACY_GPU_ZONE("RenderBegin");
 
-    setViewport(0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y);
+    setViewport(0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
 
     if (!m_shadersInitialized)
         initShaders();
 
-    g_pHyprRenderer->m_renderData.transformDamage = false;
-    g_pHyprRenderer->m_renderData.damage.set(damage_);
-    g_pHyprRenderer->m_renderData.finalDamage.set(finalDamage.value_or(damage_));
+    context.transformDamage = false;
+    context.damage.set(damage_);
+    context.finalDamage.set(finalDamage.value_or(damage_));
 
-    m_fakeFrame = !!fb;
+    context.fakeFrame = !!fb;
 
     if (g_pHyprRenderer->m_reloadScreenShader) {
         g_pHyprRenderer->m_reloadScreenShader = false;
@@ -761,100 +755,99 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFra
         applyScreenShader(*PSHADER);
     }
 
-    g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
-    m_offloadedFramebuffer = true;
-    if (!g_pHyprRenderer->m_renderData.damage.empty())
-        GLFB(g_pHyprRenderer->m_renderData.currentFB)->clearAfterInvalidation();
+    g_pHyprRenderer->bindFB(context, context.sceneMonitor->resources()->getUnusedWorkBuffer());
+    context.offloadedFramebuffer = true;
+    if (!context.damage.empty())
+        GLFB(context.currentFB)->clearAfterInvalidation();
 
-    g_pHyprRenderer->m_renderData.mainFB = g_pHyprRenderer->m_renderData.currentFB;
-    g_pHyprRenderer->m_renderData.outFB  = fb ? fb : dc<CHyprGLRenderer*>(g_pHyprRenderer.get())->m_currentRenderbuffer->getFB();
+    context.mainFB = context.currentFB;
+    context.outFB  = fb ? fb : context.renderbuffer->getFB();
 
-    if UNLIKELY (g_pHyprRenderer->m_renderData.pMonitor->needsUnmodifiedCopy() && !m_fakeFrame) {
-        if (!g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex)
-            g_pHyprRenderer->m_renderData.pMonitor->resources()->enableMirror();
-        g_pHyprRenderer->m_renderData.mainFB->enableMirror(g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex);
+    if UNLIKELY (context.sceneMonitor->needsUnmodifiedCopy() && !context.fakeFrame) {
+        if (!context.sceneMonitor->resources()->m_mirrorTex)
+            context.sceneMonitor->resources()->enableMirror();
+        context.mainFB->enableMirror(context.sceneMonitor->resources()->m_mirrorTex);
     } else {
-        if (g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex)
-            g_pHyprRenderer->m_renderData.pMonitor->resources()->disableMirror();
-        g_pHyprRenderer->m_renderData.mainFB->disableMirror();
+        if (context.sceneMonitor->resources()->m_mirrorTex)
+            context.sceneMonitor->resources()->disableMirror();
+        context.mainFB->disableMirror();
     }
 }
 
-void CHyprOpenGLImpl::end() {
+void CHyprOpenGLImpl::end(CRenderingContext& context) {
     static auto PZOOMDISABLEAA = CConfigValue<Config::INTEGER>("cursor:zoom_disable_aa");
-    auto&       m_renderData   = g_pHyprRenderer->m_renderData;
-    const auto  PMONITOR       = m_renderData.pMonitor;
+    const auto  PMONITOR       = context.sceneMonitor;
     TRACY_GPU_ZONE("RenderEnd");
 
-    g_pHyprRenderer->m_renderData.currentWindow.reset();
-    g_pHyprRenderer->m_renderData.surface.reset();
-    g_pHyprRenderer->m_renderData.clipBox = {};
+    context.currentWindow.reset();
+    context.surface.reset();
+    context.clipBox = {};
 
     // end the render, copy the data to the main framebuffer
-    if LIKELY (m_offloadedFramebuffer) {
-        g_pHyprRenderer->m_renderData.damage = g_pHyprRenderer->m_renderData.finalDamage;
-        if UNLIKELY (g_pHyprRenderer->m_renderMode != RENDER_MODE_NORMAL) {
-            const auto TARGET_SIZE = g_pHyprRenderer->m_renderData.outFB->m_size;
-            const auto TEXTURE     = g_pHyprRenderer->m_renderData.currentFB->getTexture();
+    if LIKELY (context.offloadedFramebuffer) {
+        context.damage = context.finalDamage;
+        if UNLIKELY (context.renderMode != RENDER_MODE_NORMAL) {
+            const auto TARGET_SIZE = context.outFB->m_size;
+            const auto TEXTURE     = context.currentFB->getTexture();
 
-            g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.outFB);
-            g_pHyprRenderer->m_renderData.fbSize = TARGET_SIZE;
-            g_pHyprRenderer->setProjectionType(RPT_EXPORT);
-            g_pHyprRenderer->m_renderData.transformDamage = false;
-            g_pHyprRenderer->m_renderData.damage          = CRegion{0, 0, TARGET_SIZE.x, TARGET_SIZE.y};
+            g_pHyprRenderer->bindFB(context, context.outFB);
+            context.fbSize = TARGET_SIZE;
+            g_pHyprRenderer->setProjectionType(context, RPT_EXPORT);
+            context.transformDamage = false;
+            context.damage          = CRegion{0, 0, TARGET_SIZE.x, TARGET_SIZE.y};
             setViewport(0, 0, TARGET_SIZE.x, TARGET_SIZE.y);
 
             blend(false);
-            renderTexturePrimitive(TEXTURE, CBox{{}, TARGET_SIZE});
+            renderTexturePrimitive(context, TEXTURE, CBox{{}, TARGET_SIZE});
             blend(true);
         } else {
-            CBox monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+            CBox monbox = {0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y};
 
-            if LIKELY (g_pHyprRenderer->m_renderData.mouseZoomFactor == 1.0f)
-                m_renderData.pMonitor->m_zoomController.m_resetCameraState = true;
-            m_renderData.pMonitor->m_zoomController.applyZoomTransform(monbox, m_renderData);
+            if LIKELY (context.mouseZoomFactor == 1.0f)
+                context.sceneMonitor->m_zoomController.m_resetCameraState = true;
+            context.sceneMonitor->m_zoomController.applyZoomTransform(monbox, context);
 
-            if UNLIKELY (g_pHyprRenderer->m_renderData.mouseZoomFactor != 1.F && g_pHyprRenderer->m_renderData.mouseZoomUseMouse && *PZOOMDISABLEAA)
-                g_pHyprRenderer->m_renderData.useNearestNeighbor = true;
+            if UNLIKELY (context.mouseZoomFactor != 1.F && context.mouseZoomUseMouse && *PZOOMDISABLEAA)
+                context.useNearestNeighbor = true;
 
             // copy the damaged areas into the mirror buffer
             // we can't use the offloadFB for mirroring / ss, as it contains artifacts from blurring
-            if UNLIKELY (g_pHyprRenderer->m_renderData.pMonitor->needsACopyFB() && !m_fakeFrame) {
-                if (saveBufferForMirror(monbox))
-                    g_pHyprRenderer->m_renderData.pMonitor->resources()->markMirrorFBUpdated();
+            if UNLIKELY (context.sceneMonitor->needsACopyFB() && !context.fakeFrame) {
+                if (saveBufferForMirror(context, monbox))
+                    context.sceneMonitor->resources()->markMirrorFBUpdated();
                 else
-                    g_pHyprRenderer->m_renderData.pMonitor->resources()->invalidateMirrorFB();
+                    context.sceneMonitor->resources()->invalidateMirrorFB();
             }
 
             blend(false);
 
-            const bool NEEDS_CM = g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription->value() != g_pHyprRenderer->m_renderData.mainFB->imageDescription()->value();
-            const bool WANTS_FINAL_SHADER = !g_pHyprRenderer->m_renderData.blockScreenShader && (m_finalScreenShader->program() >= 1 || g_pHyprRenderer->m_crashingInProgress);
+            const bool                      NEEDS_CM           = context.sceneMonitor->m_imageDescription->value() != context.mainFB->imageDescription()->value();
+            const bool                      WANTS_FINAL_SHADER = !context.blockScreenShader && (m_finalScreenShader->program() >= 1 || g_pHyprRenderer->m_crashingInProgress);
 
-            auto       finalTexture = g_pHyprRenderer->m_renderData.currentFB->getTexture();
-            CBox       finalBox     = monbox;
-            std::array<SP<IFramebuffer>, 2>                    postProcessFBs;
+            auto                            finalTexture = context.currentFB->getTexture();
+            CBox                            finalBox     = monbox;
+            std::array<SP<IFramebuffer>, 2> postProcessFBs;
             std::array<NColorManagement::PImageDescription, 2> savedDescriptions;
             size_t                                             postProcessCount = 0;
             bool                                               finalCMComplete  = false;
 
             if (WANTS_FINAL_SHADER) {
                 if (NEEDS_CM) {
-                    postProcessFBs[postProcessCount] = g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+                    postProcessFBs[postProcessCount] = context.sceneMonitor->resources()->getUnusedWorkBuffer();
                     if (postProcessFBs[postProcessCount]) {
                         savedDescriptions[postProcessCount] = postProcessFBs[postProcessCount]->imageDescription();
-                        postProcessFBs[postProcessCount]->setImageDescription(g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription);
+                        postProcessFBs[postProcessCount]->setImageDescription(context.sceneMonitor->m_imageDescription);
 
                         {
-                            auto guard = g_pHyprRenderer->bindTempFB(postProcessFBs[postProcessCount]);
+                            auto guard = g_pHyprRenderer->bindTempFB(context, postProcessFBs[postProcessCount]);
                             GLFB(postProcessFBs[postProcessCount])->clearAfterInvalidation();
-                            g_pHyprRenderer->setProjectionType(RPT_MONITOR);
-                            g_pHyprRenderer->m_renderData.transformDamage = false;
-                            renderTexture(finalTexture, finalBox, {.finalMonitorCM = true});
+                            g_pHyprRenderer->setProjectionType(context, RPT_MONITOR);
+                            context.transformDamage = false;
+                            renderTexture(context, finalTexture, finalBox, {.finalMonitorCM = true});
                         }
 
                         finalTexture    = postProcessFBs[postProcessCount++]->getTexture();
-                        finalBox        = CBox{{}, m_renderData.pMonitor->m_transformedSize};
+                        finalBox        = CBox{{}, context.sceneMonitor->m_transformedSize};
                         finalCMComplete = true;
                     } else {
                         Log::logger->log(Log::ERR, "Failed to acquire a work buffer for final color management");
@@ -863,23 +856,23 @@ void CHyprOpenGLImpl::end() {
                 }
 
                 if (!NEEDS_CM || finalCMComplete) {
-                    postProcessFBs[postProcessCount] = g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+                    postProcessFBs[postProcessCount] = context.sceneMonitor->resources()->getUnusedWorkBuffer();
                     if (postProcessFBs[postProcessCount]) {
                         savedDescriptions[postProcessCount] = postProcessFBs[postProcessCount]->imageDescription();
-                        postProcessFBs[postProcessCount]->setImageDescription(g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription);
+                        postProcessFBs[postProcessCount]->setImageDescription(context.sceneMonitor->m_imageDescription);
 
                         {
-                            auto guard = g_pHyprRenderer->bindTempFB(postProcessFBs[postProcessCount]);
+                            auto guard = g_pHyprRenderer->bindTempFB(context, postProcessFBs[postProcessCount]);
                             GLFB(postProcessFBs[postProcessCount])->clearAfterInvalidation();
-                            g_pHyprRenderer->setProjectionType(RPT_MONITOR);
-                            g_pHyprRenderer->m_renderData.transformDamage = false;
-                            m_applyFinalShader                            = true;
-                            renderTexture(finalTexture, finalBox, {.finalMonitorCM = true});
-                            m_applyFinalShader = false;
+                            g_pHyprRenderer->setProjectionType(context, RPT_MONITOR);
+                            context.transformDamage        = false;
+                            context.applyFinalScreenShader = true;
+                            renderTexture(context, finalTexture, finalBox, {.finalMonitorCM = true});
+                            context.applyFinalScreenShader = false;
                         }
 
                         finalTexture = postProcessFBs[postProcessCount++]->getTexture();
-                        finalBox     = CBox{{}, m_renderData.pMonitor->m_transformedSize};
+                        finalBox     = CBox{{}, context.sceneMonitor->m_transformedSize};
                     } else {
                         Log::logger->log(Log::ERR, "Failed to acquire a work buffer for the final screen shader");
                         postProcessFBs[postProcessCount].reset();
@@ -887,45 +880,39 @@ void CHyprOpenGLImpl::end() {
                 }
             }
 
-            g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.outFB);
+            g_pHyprRenderer->bindFB(context, context.outFB);
             setViewport(0, 0, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y);
-            g_pHyprRenderer->setProjectionType(RPT_OUTPUT);
-            g_pHyprRenderer->m_renderData.transformDamage = true;
+            g_pHyprRenderer->setProjectionType(context, RPT_OUTPUT);
+            context.transformDamage = true;
 
             if (NEEDS_CM && !finalCMComplete)
-                renderTexture(finalTexture, finalBox, {.finalMonitorCM = true});
+                renderTexture(context, finalTexture, finalBox, {.finalMonitorCM = true});
             else
-                renderTexturePrimitive(finalTexture, finalBox);
+                renderTexturePrimitive(context, finalTexture, finalBox);
 
             for (size_t i = 0; i < postProcessCount; ++i)
                 postProcessFBs[i]->setImageDescription(savedDescriptions[i]);
 
             blend(true);
 
-            g_pHyprRenderer->setProjectionType(RPT_MONITOR);
-            g_pHyprRenderer->m_renderData.transformDamage = false;
+            g_pHyprRenderer->setProjectionType(context, RPT_MONITOR);
+            context.transformDamage = false;
         }
 
-        g_pHyprRenderer->m_renderData.useNearestNeighbor = false;
-        m_applyFinalShader                               = false;
+        context.useNearestNeighbor     = false;
+        context.applyFinalScreenShader = false;
     }
 
-    // reset our data
-    g_pHyprRenderer->m_renderData.mouseZoomFactor   = 1.f;
-    g_pHyprRenderer->m_renderData.mouseZoomUseMouse = true;
-    g_pHyprRenderer->m_renderData.blockScreenShader = false;
-    g_pHyprRenderer->m_renderData.currentFB.reset();
-    g_pHyprRenderer->m_renderData.mainFB.reset();
-    g_pHyprRenderer->m_renderData.outFB.reset();
+    context.currentFB.reset();
+    context.mainFB.reset();
+    context.outFB.reset();
     // invalidate our render FBs to signal to the driver we don't need them anymore
-    g_pHyprRenderer->m_renderData.pMonitor->resources()->forEachUnusedFB(
+    context.sceneMonitor->resources()->forEachUnusedFB(
         [](const auto& fb) {
             fb->bind();
             GLFB(fb)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT, GL_COLOR_ATTACHMENT0});
         },
         false);
-
-    m_renderData.pMonitor.reset();
 
     static const auto GLDEBUG = CConfigValue<Config::INTEGER>("debug:gl_debugging");
 
@@ -1093,17 +1080,16 @@ bool CHyprOpenGLImpl::blendEnabled() const {
     return m_blend;
 }
 
-void CHyprOpenGLImpl::scissor(const CBox& originalBox, bool transform) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to scissor without begin()!");
+void CHyprOpenGLImpl::scissor(const CRenderingContext& context, const CBox& originalBox, bool transform) {
+    RASSERT(context.sceneMonitor, "Tried to scissor without begin()!");
 
     // only call glScissor if the box has changed
     static CBox m_lastScissorBox = {};
 
     if (transform) {
         CBox       box = originalBox;
-        const auto TR  = Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform));
-        box.transform(TR, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
+        const auto TR  = Math::wlTransformToHyprutils(Math::invertTransform(context.sceneMonitor->m_transform));
+        box.transform(TR, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
 
         if (box != m_lastScissorBox) {
             GLCALL(glScissor(box.x, box.y, box.width, box.height));
@@ -1122,8 +1108,8 @@ void CHyprOpenGLImpl::scissor(const CBox& originalBox, bool transform) {
     setCapStatus(GL_SCISSOR_TEST, true);
 }
 
-void CHyprOpenGLImpl::scissor(const pixman_box32* pBox, bool transform) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to scissor without begin()!");
+void CHyprOpenGLImpl::scissor(const CRenderingContext& context, const pixman_box32* pBox, bool transform) {
+    RASSERT(context.sceneMonitor, "Tried to scissor without begin()!");
 
     if (!pBox) {
         setCapStatus(GL_SCISSOR_TEST, false);
@@ -1132,35 +1118,39 @@ void CHyprOpenGLImpl::scissor(const pixman_box32* pBox, bool transform) {
 
     CBox newBox = {pBox->x1, pBox->y1, pBox->x2 - pBox->x1, pBox->y2 - pBox->y1};
 
-    scissor(newBox, transform);
+    scissor(context, newBox, transform);
 }
 
-void CHyprOpenGLImpl::scissor(const int x, const int y, const int w, const int h, bool transform) {
+void CHyprOpenGLImpl::scissor(const CRenderingContext& context, const int x, const int y, const int w, const int h, bool transform) {
     CBox box = {x, y, w, h};
-    scissor(box, transform);
+    scissor(context, box, transform);
 }
 
-void CHyprOpenGLImpl::renderRect(const CBox& box, const CHyprColor& col, SRectRenderData data) {
+void CHyprOpenGLImpl::disableScissorState() {
+    setCapStatus(GL_SCISSOR_TEST, false);
+}
+
+void CHyprOpenGLImpl::renderRect(CRenderingContext& context, const CBox& box, const CHyprColor& col, SRectRenderData data) {
     if (!data.damage)
-        data.damage = &g_pHyprRenderer->m_renderData.damage;
+        data.damage = &context.damage;
 
     if (data.blur)
-        renderRectWithBlurInternal(box, col, data);
+        renderRectWithBlurInternal(context, box, col, data);
     else
-        renderRectWithDamageInternal(box, col, data);
+        renderRectWithDamageInternal(context, box, col, data);
 }
 
-void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
+void CHyprOpenGLImpl::renderRectWithBlurInternal(CRenderingContext& context, const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
     if (data.damage->empty())
         return;
 
-    CRegion damage{g_pHyprRenderer->m_renderData.damage};
+    CRegion damage{context.damage};
     damage.intersect(box);
 
     auto patternBox = data.blurPatternBox.value_or(box);
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(patternBox);
+    context.renderModif.applyToBox(patternBox);
     auto shapeBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(shapeBox);
+    context.renderModif.applyToBox(shapeBox);
     std::optional<SBlurShape> shape;
     if (std::abs(shapeBox.rot) < 0.0001F)
         shape = SBlurShape{
@@ -1169,25 +1159,23 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
             .roundingPower = data.roundingPower,
         };
     const bool usePrecomputedBlur = data.xray && !g_pHyprRenderer->blurProviderRequiresLiveBlur();
-    const auto blurredFB = usePrecomputedBlur ? g_pHyprRenderer->m_renderData.pMonitor->resources()->m_blurFB :
-                                                g_pHyprRenderer->blurMainFramebuffer(data.blurA, damage, {.patternBox = patternBox, .owner = data.blurOwner, .shape = shape});
-    const auto blurredBG = blurredFB->getTexture();
+    const auto blurredFB          = usePrecomputedBlur ?
+        context.sceneMonitor->resources()->m_blurFB :
+        g_pHyprRenderer->blurMainFramebuffer(context, data.blurA, damage, {.patternBox = patternBox, .owner = data.blurOwner, .shape = shape});
+    const auto blurredBG          = blurredFB->getTexture();
 
-    const auto SAVEDRENDERMODIF               = g_pHyprRenderer->m_renderData.renderModif;
-    g_pHyprRenderer->m_renderData.renderModif = {}; // fix shit
+    CBox       transformedBox = box;
+    transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(context.sceneMonitor->m_transform)), context.sceneMonitor->m_transformedSize.x,
+                             context.sceneMonitor->m_transformedSize.y);
 
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+    CBox              monitorSpaceBox = {transformedBox.pos().x / context.sceneMonitor->m_pixelSize.x * context.sceneMonitor->m_transformedSize.x,
+                                         transformedBox.pos().y / context.sceneMonitor->m_pixelSize.y * context.sceneMonitor->m_transformedSize.y,
+                                         transformedBox.width / context.sceneMonitor->m_pixelSize.x * context.sceneMonitor->m_transformedSize.x,
+                                         transformedBox.height / context.sceneMonitor->m_pixelSize.y * context.sceneMonitor->m_transformedSize.y};
 
-    CBox  transformedBox = box;
-    transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
-                             m_renderData.pMonitor->m_transformedSize.y);
-
-    CBox monitorSpaceBox = {transformedBox.pos().x / m_renderData.pMonitor->m_pixelSize.x * m_renderData.pMonitor->m_transformedSize.x,
-                            transformedBox.pos().y / m_renderData.pMonitor->m_pixelSize.y * m_renderData.pMonitor->m_transformedSize.y,
-                            transformedBox.width / m_renderData.pMonitor->m_pixelSize.x * m_renderData.pMonitor->m_transformedSize.x,
-                            transformedBox.height / m_renderData.pMonitor->m_pixelSize.y * m_renderData.pMonitor->m_transformedSize.y};
-
-    renderTexture(blurredBG, box,
+    CRenderingContext child{context, context.renderPass()};
+    child.renderModif = {};
+    renderTexture(child, blurredBG, box,
                   STextureRenderData{
                       .damage                      = &damage,
                       .a                           = data.blurA,
@@ -1196,32 +1184,30 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
                       .allowCustomUV               = true,
                       .allowDim                    = false,
                       .noAA                        = false,
-                      .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / m_renderData.pMonitor->m_transformedSize,
-                      .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / m_renderData.pMonitor->m_transformedSize,
+                      .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / context.sceneMonitor->m_transformedSize,
+                      .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / context.sceneMonitor->m_transformedSize,
                   });
-    g_pHyprRenderer->m_renderData.renderModif = SAVEDRENDERMODIF;
 
-    renderRectWithDamageInternal(box, col, data);
+    renderRectWithDamageInternal(context, box, col, data);
 }
 
-void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void CHyprOpenGLImpl::renderRectWithDamageInternal(CRenderingContext& context, const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderRectWithDamage");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
-    auto        shader = useShader(getShaderVariant(SH_FRAG_QUAD, (data.round > 0 ? SH_FEAT_ROUNDING : 0) | globalFeatures()));
+    auto        shader = useShader(getShaderVariant(SH_FRAG_QUAD, (data.round > 0 ? SH_FEAT_ROUNDING : 0) | globalFeatures(context)));
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
 
     // premultiply the color as well as we don't work with straight alpha
     const auto premultiplied = CHyprColor(col.r * col.a, col.g * col.a, col.b * col.a, col.a);
-    const auto converted     = g_pHyprRenderer->getConvertedColor(premultiplied);
+    const auto converted     = g_pHyprRenderer->getConvertedColor(context, premultiplied);
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, converted.a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, premultiplied.r, premultiplied.g, premultiplied.b, premultiplied.a);
 
@@ -1236,49 +1222,48 @@ void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprC
 
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0) {
-        CRegion damageClip{g_pHyprRenderer->m_renderData.clipBox.x, g_pHyprRenderer->m_renderData.clipBox.y, g_pHyprRenderer->m_renderData.clipBox.width,
-                           g_pHyprRenderer->m_renderData.clipBox.height};
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        CRegion damageClip{context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
         damageClip.intersect(*data.damage);
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
     } else {
-        data.damage->forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        data.damage->forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
 
     glBindVertexArray(0);
-    scissor(nullptr);
+    scissor(context, nullptr);
 }
 
-void CHyprOpenGLImpl::renderTexture(SP<ITexture> tex, const CBox& box, STextureRenderData data) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTexture(CRenderingContext& context, SP<ITexture> tex, const CBox& box, STextureRenderData data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
 
     if (!data.damage) {
-        if (g_pHyprRenderer->m_renderData.damage.empty())
+        if (context.damage.empty())
             return;
 
-        data.damage = &g_pHyprRenderer->m_renderData.damage;
+        data.damage = &context.damage;
     }
 
     if (data.blur && !data.forceBlurBlend)
-        renderTextureWithBlurInternal(tex, box, data);
+        renderTextureWithBlurInternal(context, tex, box, data);
     else
-        renderTextureInternal(tex, box, data);
+        renderTextureInternal(context, tex, box, data);
 
-    scissor(nullptr);
+    scissor(context, nullptr);
 }
 
 static std::map<std::pair<uint32_t, uint32_t>, std::array<GLfloat, 9>> primariesConversionCache;
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
                                      const NColorManagement::PImageDescription targetImageDescription, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance,
                                      const SCMSettings& settings) {
     shader->setUniformFloat2(SHADER_SRC_TF_RANGE, settings.srcTFRange.min, settings.srcTFRange.max);
@@ -1323,29 +1308,26 @@ void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement:
     }
 }
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
                                      const NColorManagement::PImageDescription targetImageDescription, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance) {
-    const auto settings = g_pHyprRenderer->getCMSettings(imageDescription, targetImageDescription,
-                                                         g_pHyprRenderer->m_renderData.surface.valid() ? g_pHyprRenderer->m_renderData.surface.lock() : nullptr, modifySDR,
+    const auto settings = g_pHyprRenderer->getCMSettings(context, imageDescription, targetImageDescription, context.surface.valid() ? context.surface.lock() : nullptr, modifySDR,
                                                          sdrMinLuminance, sdrMaxLuminance);
-    passCMUniforms(shader, imageDescription, targetImageDescription, modifySDR, sdrMinLuminance, sdrMaxLuminance, settings);
+    passCMUniforms(context, shader, imageDescription, targetImageDescription, modifySDR, sdrMinLuminance, sdrMaxLuminance, settings);
 }
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const PImageDescription imageDescription) {
-    passCMUniforms(shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(), true, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance,
-                   g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance);
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const PImageDescription imageDescription) {
+    passCMUniforms(context, shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(context), true, context.sceneMonitor->m_sdrMinLuminance,
+                   context.sceneMonitor->m_sdrMaxLuminance);
 }
 
-void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const PImageDescription imageDescription, const SCMSettings& settings) {
-    passCMUniforms(shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(), true, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance,
-                   g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance, settings);
+void CHyprOpenGLImpl::passCMUniforms(CRenderingContext& context, WP<CShader> shader, const PImageDescription imageDescription, const SCMSettings& settings) {
+    passCMUniforms(context, shader, imageDescription, g_pHyprRenderer->workBufferImageDescription(context), true, context.sceneMonitor->m_sdrMinLuminance,
+                   context.sceneMonitor->m_sdrMaxLuminance, settings);
 }
 
-WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
+WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal(CRenderingContext& context) {
     static const auto PDT            = CConfigValue<Config::INTEGER>("debug:damage_tracking");
     static const auto PCURSORTIMEOUT = CConfigValue<Config::FLOAT>("cursor:inactive_timeout");
-
-    auto&             m_renderData = g_pHyprRenderer->m_renderData;
 
     WP<CShader>       shader =
         g_pHyprRenderer->m_crashingInProgress ? getShaderVariant(SH_FRAG_GLITCH) : (m_finalScreenShader->program() ? m_finalScreenShader : getShaderVariant(SH_FRAG_PASSTHRURGBA));
@@ -1357,8 +1339,8 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
     else
         shader->setUniformFloat(SHADER_TIME, 0.f);
 
-    shader->setUniformInt(SHADER_WL_OUTPUT, m_renderData.pMonitor->m_id);
-    shader->setUniformFloat2(SHADER_FULL_SIZE, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
+    shader->setUniformInt(SHADER_WL_OUTPUT, context.sceneMonitor->m_id);
+    shader->setUniformFloat2(SHADER_FULL_SIZE, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
     shader->setUniformFloat(SHADER_POINTER_INACTIVE_TIMEOUT, *PCURSORTIMEOUT);
     shader->setUniformInt(SHADER_POINTER_HIDDEN, g_pHyprRenderer->m_cursorHiddenByCondition);
     shader->setUniformInt(SHADER_POINTER_KILLING, g_pInputManager->getClickMode() == CLICKMODE_KILL);
@@ -1367,7 +1349,7 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
     shader->setUniformFloat(SHADER_POINTER_SIZE, Pointer::Cursor::mgr()->getScaledSize());
 
     if (*PDT == 0) {
-        PHLMONITORREF pMonitor = m_renderData.pMonitor;
+        PHLMONITORREF pMonitor = context.sceneMonitor;
         Vector2D      p        = ((g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position) * pMonitor->m_scale);
         shader->setUniformFloat2(SHADER_POINTER, p.x / pMonitor->m_transformedSize.x, p.y / pMonitor->m_transformedSize.y);
 
@@ -1406,17 +1388,15 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal() {
 
     if (g_pHyprRenderer->m_crashingInProgress) {
         shader->setUniformFloat(SHADER_DISTORT, g_pHyprRenderer->m_crashingDistort);
-        shader->setUniformFloat2(SHADER_FULL_SIZE, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
+        shader->setUniformFloat2(SHADER_FULL_SIZE, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y);
     }
 
     return shader;
 }
 
-WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox) {
+WP<CShader> CHyprOpenGLImpl::renderToFBInternal(CRenderingContext& context, SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox) {
     static const auto  PENABLECM = CConfigValue<Config::INTEGER>("render:cm_enabled");
     static auto        PBLEND    = CConfigValue<Config::INTEGER>("render:use_shader_blur_blend");
-
-    auto&              m_renderData = g_pHyprRenderer->m_renderData;
 
     float              alpha = std::clamp(data.a, 0.f, 1.f);
 
@@ -1428,15 +1408,15 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         case TEXTURE_RGBX: shaderFeatures &= ~SH_FEAT_RGBA; break;
 
         // TODO set correct features
-        case TEXTURE_EXTERNAL: shader = getShaderVariant(SH_FRAG_EXT, SH_FEAT_ROUNDING | SH_FEAT_DISCARD | SH_FEAT_TINT | globalFeatures()); break; // might be unused
+        case TEXTURE_EXTERNAL: shader = getShaderVariant(SH_FRAG_EXT, SH_FEAT_ROUNDING | SH_FEAT_DISCARD | SH_FEAT_TINT | globalFeatures(context)); break; // might be unused
         default: RASSERT(false, "tex->m_iTarget unsupported!");
     }
 
-    if (data.finalMonitorCM || (g_pHyprRenderer->m_renderData.currentWindow && g_pHyprRenderer->m_renderData.currentWindow->m_ruleApplicator->RGBX().valueOrDefault()))
+    if (data.finalMonitorCM || (context.currentWindow && context.currentWindow->m_ruleApplicator->RGBX().valueOrDefault()))
         shaderFeatures &= ~SH_FEAT_RGBA;
 
-    const auto surface                       = g_pHyprRenderer->m_renderData.surface;
-    const auto WORK_BUFFER_IMAGE_DESCRIPTION = g_pHyprRenderer->m_renderData.pMonitor->workBufferImageDescription();
+    const auto surface                       = context.surface;
+    const auto WORK_BUFFER_IMAGE_DESCRIPTION = context.sceneMonitor->workBufferImageDescription();
 
     // chosenSdrEotf contains the valid eotf for this display
 
@@ -1461,8 +1441,8 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
     }();
 
     const auto TARGET_IMAGE_DESCRIPTION = [&] {
-        if (g_pHyprRenderer->m_renderData.currentFB->imageDescription())
-            return g_pHyprRenderer->m_renderData.currentFB->imageDescription();
+        if (context.currentFB->imageDescription())
+            return context.currentFB->imageDescription();
 
         // if we are CM'ing back, use default sRGB
         if (data.cmBackToSRGB)
@@ -1470,7 +1450,7 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
 
         // for final CM, use the target description
         if (data.finalMonitorCM)
-            return g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription;
+            return context.sceneMonitor->m_imageDescription;
         // otherwise, use chosen, we're drawing into the work buffer
         // NOLINTNEXTLINE
         return WORK_BUFFER_IMAGE_DESCRIPTION;
@@ -1492,24 +1472,22 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         shaderFeatures |= SH_FEAT_DISCARD;
 
     const bool skipCM = !*PENABLECM || !m_cmSupported                   /* CM unsupported or disabled */
-        || g_pHyprRenderer->m_renderData.pMonitor->doesNoShaderCM()     /* no shader needed */
+        || context.sceneMonitor->doesNoShaderCM()                       /* no shader needed */
         || !SOURCE_IMAGE_DESCRIPTION->needsCM(TARGET_IMAGE_DESCRIPTION) /* Source and target have matching image descriptions */
         ;
 
-    if (g_pHyprRenderer->m_renderData.pMonitor->needsACopyFB())
+    if (context.sceneMonitor->needsACopyFB())
         Log::logger->log(Log::TRACE, "CM: render to FB skip={} {} -> {}", skipCM, SOURCE_IMAGE_DESCRIPTION->value(), TARGET_IMAGE_DESCRIPTION->value());
 
-    if (data.allowDim && g_pHyprRenderer->m_renderData.currentWindow &&
-        (g_pHyprRenderer->m_renderData.currentWindow->presentation().notRespondingTint() > 0 || g_pHyprRenderer->m_renderData.currentWindow->presentation().dimPercent() > 0))
+    if (data.allowDim && context.currentWindow && (context.currentWindow->presentation().notRespondingTint() > 0 || context.currentWindow->presentation().dimPercent() > 0))
         shaderFeatures |= SH_FEAT_TINT;
 
     if (data.round > 0)
         shaderFeatures |= SH_FEAT_ROUNDING;
 
     if (!skipCM) {
-        const auto settings =
-            g_pHyprRenderer->getCMSettings(SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, surface.valid() ? surface.lock() : nullptr, true,
-                                           g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance, true);
+        const auto settings = g_pHyprRenderer->getCMSettings(context, SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, surface.valid() ? surface.lock() : nullptr, true,
+                                                             context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance, true);
 
         shaderFeatures |= SH_FEAT_CM;
 
@@ -1527,14 +1505,14 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         }
 
         if (!shader)
-            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures(), settings.sourceTF, settings.targetTF);
+            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures(context), settings.sourceTF, settings.targetTF);
         shader = useShader(shader);
 
-        passCMUniforms(shader, SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, true, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance,
-                       g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance, settings);
+        passCMUniforms(context, shader, SOURCE_IMAGE_DESCRIPTION, TARGET_IMAGE_DESCRIPTION, true, context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance,
+                       settings);
     } else {
         if (!shader)
-            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures());
+            shader = getShaderVariant(SH_FRAG_SURFACE, shaderFeatures | globalFeatures(context));
         shader = useShader(shader);
     }
 
@@ -1580,8 +1558,8 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         CBox motionPrev   = data.motionBlur.previous;
         CBox motionCurr   = data.motionBlur.current;
         CBox motionSource = data.motionBlur.source;
-        m_renderData.renderModif.applyToBox(motionPrev);
-        m_renderData.renderModif.applyToBox(motionCurr);
+        context.renderModif.applyToBox(motionPrev);
+        context.renderModif.applyToBox(motionCurr);
 
         shader->setUniformFloat4(SHADER_MOTION_PREV_BOX, motionPrev.x, motionPrev.y, motionPrev.w, motionPrev.h);
         shader->setUniformFloat4(SHADER_MOTION_CURR_BOX, motionCurr.x, motionCurr.y, motionCurr.w, motionCurr.h);
@@ -1591,14 +1569,14 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
         shader->setUniformInt(SHADER_MOTION_SAMPLES, data.motionBlur.samples);
     }
 
-    if (data.allowDim && g_pHyprRenderer->m_renderData.currentWindow) {
-        if (g_pHyprRenderer->m_renderData.currentWindow->presentation().notRespondingTint() > 0) {
-            const auto DIM = g_pHyprRenderer->m_renderData.currentWindow->presentation().notRespondingTint();
+    if (data.allowDim && context.currentWindow) {
+        if (context.currentWindow->presentation().notRespondingTint() > 0) {
+            const auto DIM = context.currentWindow->presentation().notRespondingTint();
             shader->setUniformInt(SHADER_APPLY_TINT, 1);
             shader->setUniformFloat3(SHADER_TINT, 1.f - DIM, 1.f - DIM, 1.f - DIM);
-        } else if (g_pHyprRenderer->m_renderData.currentWindow->presentation().dimPercent() > 0) {
+        } else if (context.currentWindow->presentation().dimPercent() > 0) {
             shader->setUniformInt(SHADER_APPLY_TINT, 1);
-            const auto DIM = g_pHyprRenderer->m_renderData.currentWindow->presentation().dimPercent();
+            const auto DIM = context.currentWindow->presentation().dimPercent();
             shader->setUniformFloat3(SHADER_TINT, 1.f - DIM, 1.f - DIM, 1.f - DIM);
         } else
             shader->setUniformInt(SHADER_APPLY_TINT, 0);
@@ -1619,8 +1597,8 @@ static GLenum wrapModeToGl(const uint8_t wrapMode) {
     }
 }
 
-void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTextureInternal(CRenderingContext& context, SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
     RASSERT(tex, "Attempted to draw nullptr texture!");
     RASSERT(tex->ok(), "Attempted to draw invalid texture!");
 
@@ -1630,15 +1608,15 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
         return;
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     // get the needed transform for this texture
     // wl_surface::set_buffer_transform: "The compositor applies the inverse of this transformation whenever it uses the buffer contents."
     Hyprutils::Math::eTransform TRANSFORM = Math::invertTransform(tex->m_transform);
 
-    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
+    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox, TRANSFORM);
 
-    const bool                  useScreenShader = m_applyFinalShader;
+    const bool                  useScreenShader = context.applyFinalScreenShader;
 
     setActiveTexture(GL_TEXTURE0);
     tex->bind();
@@ -1646,7 +1624,7 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     tex->setTexParameter(GL_TEXTURE_WRAP_S, wrapModeToGl(data.wrapX));
     tex->setTexParameter(GL_TEXTURE_WRAP_T, wrapModeToGl(data.wrapY));
 
-    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+    if (context.useNearestNeighbor) {
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
@@ -1654,7 +1632,7 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
     }
 
-    auto shader = useScreenShader ? renderScreenShaderInternal() : renderToFBInternal(tex, data, tex->m_type, newBox);
+    auto shader = useScreenShader ? renderScreenShaderInternal(context) : renderToFBInternal(context, tex, data, tex->m_type, newBox);
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
@@ -1688,11 +1666,11 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     } else
         GLCALL(glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO)));
 
-    if (!g_pHyprRenderer->m_renderData.clipBox.empty() || !data.clipRegion.empty()) {
-        CRegion damageClip = g_pHyprRenderer->m_renderData.clipBox;
+    if (!context.clipBox.empty() || !data.clipRegion.empty()) {
+        CRegion damageClip = context.clipBox;
 
         if (!data.clipRegion.empty()) {
-            if (g_pHyprRenderer->m_renderData.clipBox.empty())
+            if (context.clipBox.empty())
                 damageClip = data.clipRegion;
             else
                 damageClip.intersect(data.clipRegion);
@@ -1701,14 +1679,14 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
         damageClip.intersect(*data.damage);
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
     } else {
-        data.damage->forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        data.damage->forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -1718,8 +1696,8 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture mesh without begin()!");
+void CHyprOpenGLImpl::renderTextureMesh(CRenderingContext& context, SP<ITexture> tex, const CBox& box, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture mesh without begin()!");
     RASSERT(tex, "Attempted to draw nullptr texture mesh!");
     RASSERT(tex->ok(), "Attempted to draw invalid texture mesh!");
 
@@ -1727,11 +1705,11 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
         return;
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     Hyprutils::Math::eTransform TRANSFORM = tex->m_transform;
 
-    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
+    const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox, TRANSFORM);
 
     setActiveTexture(GL_TEXTURE0);
     tex->bind();
@@ -1739,7 +1717,7 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
     tex->setTexParameter(GL_TEXTURE_WRAP_S, wrapModeToGl(data.wrapX));
     tex->setTexParameter(GL_TEXTURE_WRAP_T, wrapModeToGl(data.wrapY));
 
-    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+    if (context.useNearestNeighbor) {
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
@@ -1747,7 +1725,7 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
     }
 
-    auto shader = renderToFBInternal(tex, data, tex->m_type, newBox);
+    auto shader = renderToFBInternal(context, tex, data, tex->m_type, newBox);
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
@@ -1757,25 +1735,25 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
     glBufferData(GL_ARRAY_BUFFER, sizeof(SMeshRenderVertex) * vertices.size(), nullptr, GL_DYNAMIC_DRAW);
     glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(SMeshRenderVertex) * vertices.size(), vertices.data());
 
-    if (!g_pHyprRenderer->m_renderData.clipBox.empty() || !data.clipRegion.empty()) {
-        CRegion damageClip = g_pHyprRenderer->m_renderData.clipBox;
+    if (!context.clipBox.empty() || !data.clipRegion.empty()) {
+        CRegion damageClip = context.clipBox;
 
         if (!data.clipRegion.empty()) {
-            if (g_pHyprRenderer->m_renderData.clipBox.empty())
+            if (context.clipBox.empty())
                 damageClip = data.clipRegion;
             else
                 damageClip.intersect(data.clipRegion);
         }
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this, &vertices](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context, &vertices](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLES, 0, sc<GLsizei>(vertices.size()));
             });
         }
     } else {
-        data.damage->forEachRect([this, &vertices](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        data.damage->forEachRect([this, &context, &vertices](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLES, 0, sc<GLsizei>(vertices.size()));
         });
     }
@@ -1785,27 +1763,27 @@ void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTexturePrimitive(SP<ITexture> tex, const CBox& box) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTexturePrimitive(CRenderingContext& context, SP<ITexture> tex, const CBox& box) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTexturePrimitive");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     // get transform
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     setActiveTexture(GL_TEXTURE0);
     tex->bind();
 
     // ensure the final blit uses the desired sampling filter
     // when cursor zoom is active we want nearest-neighbor (no anti-aliasing)
-    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+    if (context.useNearestNeighbor) {
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
@@ -1818,29 +1796,29 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<ITexture> tex, const CBox& box) 
     shader->setUniformInt(SHADER_TEX, 0);
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    g_pHyprRenderer->m_renderData.damage.forEachRect([this](const auto& RECT) {
-        scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+    context.damage.forEachRect([this, &context](const auto& RECT) {
+        scissor(context, &RECT, context.transformDamage);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     });
 
-    scissor(nullptr);
+    scissor(context, nullptr);
     glBindVertexArray(0);
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTextureMatte(SP<ITexture> tex, const CBox& box, SP<IFramebuffer> matte) {
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
+void CHyprOpenGLImpl::renderTextureMatte(CRenderingContext& context, SP<ITexture> tex, const CBox& box, SP<IFramebuffer> matte) {
+    RASSERT(context.sceneMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTextureMatte");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     // get transform
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
-    auto        shader = useShader(getShaderVariant(SH_FRAG_MATTE, globalFeatures()));
+    auto        shader = useShader(getShaderVariant(SH_FRAG_MATTE, globalFeatures(context)));
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);
     shader->setUniformInt(SHADER_ALPHA_MATTE, 1);
@@ -1854,19 +1832,18 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<ITexture> tex, const CBox& box, SP<I
 
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    g_pHyprRenderer->m_renderData.damage.forEachRect([this](const auto& RECT) {
-        scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+    context.damage.forEachRect([this, &context](const auto& RECT) {
+        scissor(context, &RECT, context.transformDamage);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     });
 
-    scissor(nullptr);
+    scissor(context, nullptr);
     glBindVertexArray(0);
     tex->unbind();
 }
 
-void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to render texture with blur without begin()!");
+void CHyprOpenGLImpl::renderTextureWithBlurInternal(CRenderingContext& context, SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
+    RASSERT(context.sceneMonitor, "Tried to render texture with blur without begin()!");
 
     TRACY_GPU_ZONE("RenderTextureWithBlur");
 
@@ -1876,7 +1853,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
     if (!SHADERBLEND) {
 
         if (NEEDS_STENCIL) {
-            scissor(nullptr); // allow the entire window and stencil to render
+            scissor(context, nullptr); // allow the entire window and stencil to render
             glStencilMask(0xFF);
             glClearStencil(0);
             glClear(GL_STENCIL_BUFFER_BIT);
@@ -1888,9 +1865,9 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
 
             glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
 
-            renderTexture(tex, box,
+            renderTexture(context, tex, box,
                           STextureRenderData{
-                              .damage                      = &g_pHyprRenderer->m_renderData.damage,
+                              .damage                      = &context.damage,
                               .a                           = data.a,
                               .round                       = data.round,
                               .roundingPower               = data.roundingPower,
@@ -1902,8 +1879,8 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                               .discardOpacity              = data.discardOpacity,
                               .clipRegion                  = data.clipRegion,
                               .currentLS                   = data.currentLS,
-                              .primarySurfaceUVTopLeft     = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft,
-                              .primarySurfaceUVBottomRight = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight,
+                              .primarySurfaceUVTopLeft     = context.primarySurfaceUVTopLeft,
+                              .primarySurfaceUVBottomRight = context.primarySurfaceUVBottomRight,
                           }); // discard opaque and alpha < discardOpacity
 
             glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
@@ -1924,7 +1901,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
         if (PSURFACE && PSURFACE->m_hasBackgroundEffect && !PSURFACE->m_blurRegion.empty()) {
             CRegion protocolBlur = PSURFACE->m_blurRegion.copy();
             protocolBlur.intersect(CBox{0, 0, box.width, box.height});
-            protocolBlur.scale(m_renderData.pMonitor->m_scale);
+            protocolBlur.scale(context.sceneMonitor->m_scale);
             protocolBlur.translate(box.pos());
             if (blurClipRegion.empty())
                 blurClipRegion = protocolBlur;
@@ -1932,11 +1909,11 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                 blurClipRegion.intersect(protocolBlur);
         }
 
-        bool renderModif = g_pHyprRenderer->m_renderData.renderModif.enabled;
+        bool renderModif = context.renderModif.enabled;
         if (!data.blockBlurOptimization)
-            g_pHyprRenderer->m_renderData.renderModif.enabled = false;
+            context.renderModif.enabled = false;
 
-        renderTextureInternal(data.blurredBG, box,
+        renderTextureInternal(context, data.blurredBG, box,
                               STextureRenderData{
                                   .damage         = data.damage,
                                   .a              = (*PBLURIGNOREOPACITY ? data.blurA : data.a * data.blurA) * data.overallA,
@@ -1952,18 +1929,18 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                                   .clipRegion     = blurClipRegion,
                                   .currentLS      = data.currentLS,
 
-                                  .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / m_renderData.pMonitor->m_transformedSize,
-                                  .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / m_renderData.pMonitor->m_transformedSize,
+                                  .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / context.sceneMonitor->m_transformedSize,
+                                  .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / context.sceneMonitor->m_transformedSize,
                               });
 
-        g_pHyprRenderer->m_renderData.renderModif.enabled = renderModif;
+        context.renderModif.enabled = renderModif;
 
         if (NEEDS_STENCIL)
             setCapStatus(GL_STENCIL_TEST, false);
     }
 
     // draw window
-    renderTextureInternal(tex, box,
+    renderTextureInternal(context, tex, box,
                           STextureRenderData{
                               .blur           = SHADERBLEND,
                               .blurredBG      = data.blurredBG,
@@ -1983,23 +1960,22 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
                               .clipRegion     = data.clipRegion,
                               .currentLS      = data.currentLS,
 
-                              .primarySurfaceUVTopLeft     = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft,
-                              .primarySurfaceUVBottomRight = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight,
+                              .primarySurfaceUVTopLeft     = context.primarySurfaceUVTopLeft,
+                              .primarySurfaceUVBottomRight = context.primarySurfaceUVBottomRight,
                           });
 
-    GLFB(g_pHyprRenderer->m_renderData.currentFB)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT});
-    scissor(nullptr);
+    GLFB(context.currentFB)->invalidate({GL_DEPTH_STENCIL_ATTACHMENT});
+    scissor(context, nullptr);
 }
 
-static SShaderVariant getDecoVariant() {
-    const bool IS_ICC   = g_pHyprRenderer->workBufferImageDescription()->value().icc.present;
-    const auto settings = g_pHyprRenderer->getCMSettings(g_pHyprRenderer->workBufferImageDescription(), getDefaultImageDescription(), nullptr, true,
-                                                         g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance);
-    const auto uniformSettings =
-        g_pHyprRenderer->getCMSettings(getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(), nullptr, true,
-                                       g_pHyprRenderer->m_renderData.pMonitor->m_sdrMinLuminance, g_pHyprRenderer->m_renderData.pMonitor->m_sdrMaxLuminance);
+static SShaderVariant getDecoVariant(const CRenderingContext& context) {
+    const bool         IS_ICC          = g_pHyprRenderer->workBufferImageDescription(context)->value().icc.present;
+    const auto         settings        = g_pHyprRenderer->getCMSettings(context, g_pHyprRenderer->workBufferImageDescription(context), getDefaultImageDescription(), nullptr, true,
+                                                                        context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance);
+    const auto         uniformSettings = g_pHyprRenderer->getCMSettings(context, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(context), nullptr, true,
+                                                                        context.sceneMonitor->m_sdrMinLuminance, context.sceneMonitor->m_sdrMaxLuminance);
 
-    ShaderFeatureFlags features = SH_FEAT_ROUNDING | SH_FEAT_CM | globalFeatures();
+    ShaderFeatureFlags features = SH_FEAT_ROUNDING | SH_FEAT_CM | globalFeatures(context);
     if (IS_ICC)
         features |= SH_FEAT_ICC;
     else {
@@ -2014,24 +1990,23 @@ static SShaderVariant getDecoVariant() {
     return {.features = features, .sourceTF = uniformSettings.sourceTF, .targetTF = uniformSettings.targetTF};
 }
 
-void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValueData& grad, SBorderRenderData data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void CHyprOpenGLImpl::renderBorder(CRenderingContext& context, const CBox& box, const Config::CGradientValueData& grad, SBorderRenderData data) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     CBox innerBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(innerBox);
+    context.renderModif.applyToBox(innerBox);
 
     if (data.borderSize < 1)
         return;
 
-    int scaledBorderSize = std::round(data.borderSize * m_renderData.pMonitor->m_scale);
-    scaledBorderSize     = std::round(scaledBorderSize * g_pHyprRenderer->m_renderData.renderModif.combinedScale());
+    int scaledBorderSize = std::round(data.borderSize * context.sceneMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * context.renderModif.combinedScale());
 
     // adjust box
     CBox newBox = innerBox;
@@ -2042,19 +2017,19 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     float       round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     const auto  BLEND = m_blend;
     blend(true);
 
     WP<CShader> shader;
 
-    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription(context)->needsCM(getDefaultImageDescription());
     if (!skipCM) {
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant()));
-        passCMUniforms(shader, getDefaultImageDescription());
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant(context)));
+        passCMUniforms(context, shader, getDefaultImageDescription());
     } else
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures()));
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures(context)));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniform4fv(SHADER_GRADIENT, grad.m_colorsOkLabA.size() / 4, grad.m_colorsOkLabA);
@@ -2078,15 +2053,15 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     // calculate the border's region, which we need to render over. No need to run the shader on
     // things outside there
-    CRegion borderRegion = g_pHyprRenderer->m_renderData.damage.copy().intersect(newBox);
+    CRegion borderRegion = context.damage.copy().intersect(newBox);
     borderRegion.subtract(innerBox.copy().expand(-scaledBorderSize - round));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0)
-        borderRegion.intersect(g_pHyprRenderer->m_renderData.clipBox);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0)
+        borderRegion.intersect(context.clipBox);
 
     if (!borderRegion.empty()) {
-        borderRegion.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        borderRegion.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -2096,24 +2071,24 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp, SBorderRenderData data) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
+void CHyprOpenGLImpl::renderBorder(CRenderingContext& context, const CBox& box, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp,
+                                   SBorderRenderData data) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderBorder2");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     CBox innerBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(innerBox);
+    context.renderModif.applyToBox(innerBox);
 
     if (data.borderSize < 1)
         return;
 
-    int scaledBorderSize = std::round(data.borderSize * m_renderData.pMonitor->m_scale);
-    scaledBorderSize     = std::round(scaledBorderSize * g_pHyprRenderer->m_renderData.renderModif.combinedScale());
+    int scaledBorderSize = std::round(data.borderSize * context.sceneMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * context.renderModif.combinedScale());
 
     // adjust box
     CBox newBox = innerBox;
@@ -2124,18 +2099,18 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     float       round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     const auto  BLEND = m_blend;
     blend(true);
 
     WP<CShader> shader;
-    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+    const bool  skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription(context)->needsCM(getDefaultImageDescription());
     if (!skipCM) {
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant()));
-        passCMUniforms(shader, getDefaultImageDescription());
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, getDecoVariant(context)));
+        passCMUniforms(context, shader, getDefaultImageDescription());
     } else
-        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures()));
+        shader = useShader(getShaderVariant(SH_FRAG_BORDER1, SH_FEAT_ROUNDING | globalFeatures(context)));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniform4fv(SHADER_GRADIENT, grad1.m_colorsOkLabA.size() / 4, grad1.m_colorsOkLabA);
@@ -2163,15 +2138,15 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
 
     // calculate the border's region, which we need to render over. No need to run the shader on
     // things outside there
-    CRegion borderRegion = g_pHyprRenderer->m_renderData.damage.copy().intersect(newBox);
+    CRegion borderRegion = context.damage.copy().intersect(newBox);
     borderRegion.subtract(innerBox.copy().expand(-scaledBorderSize - round));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0)
-        borderRegion.intersect(g_pHyprRenderer->m_renderData.clipBox);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0)
+        borderRegion.intersect(context.clipBox);
 
     if (!borderRegion.empty()) {
-        borderRegion.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        borderRegion.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -2180,35 +2155,34 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
-    renderRoundedShadow(box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a);
+void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
+    renderRoundedShadow(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, a);
 }
 
-void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+void CHyprOpenGLImpl::renderRoundedShadow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
                                           const Config::CGradientValueData& grad2, float lerp, float a) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to render shadow without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render shadow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     TRACY_GPU_ZONE("RenderShadow");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     static auto PSHADOWPOWER = CConfigValue<Config::INTEGER>("decoration:shadow:render_power");
 
     const auto  SHADOWPOWER = std::clamp(sc<int>(*PSHADOWPOWER), 1, 4);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     blend(true);
 
-    const auto TF      = m_renderData.currentFB->imageDescription()->value().transferFunction;
+    const auto TF      = context.currentFB->imageDescription()->value().transferFunction;
     const bool needsCM = TF != CM_TRANSFER_FUNCTION_EXT_LINEAR;
-    auto       shader  = useShader(getShaderVariant(SH_FRAG_SHADOW, (needsCM ? SH_FEAT_CM : 0) | globalFeatures(), TF));
+    auto       shader  = useShader(getShaderVariant(SH_FRAG_SHADOW, (needsCM ? SH_FEAT_CM : 0) | globalFeatures(context), TF));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
 
@@ -2216,7 +2190,7 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
     if (!grad1.m_colors.empty())
         color = grad1.m_colors[0];
 
-    const auto converted = g_pHyprRenderer->getConvertedColor(color.stripA());
+    const auto converted = g_pHyprRenderer->getConvertedColor(context, color.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, color.a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, color.r, color.g, color.b, color.a);
 
@@ -2250,33 +2224,32 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
     CRegion drawRegion;
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0) {
-        drawRegion = {g_pHyprRenderer->m_renderData.clipBox.x, g_pHyprRenderer->m_renderData.clipBox.y, g_pHyprRenderer->m_renderData.clipBox.width,
-                      g_pHyprRenderer->m_renderData.clipBox.height};
-        drawRegion.intersect(g_pHyprRenderer->m_renderData.damage);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        drawRegion = {context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
+        drawRegion.intersect(context.damage);
     } else
-        drawRegion = g_pHyprRenderer->m_renderData.damage;
+        drawRegion = context.damage;
 
-    if (g_pHyprRenderer->m_renderData.currentWindow) {
-        const auto PWINDOW = g_pHyprRenderer->m_renderData.currentWindow.lock();
+    if (context.currentWindow) {
+        const auto PWINDOW = context.currentWindow.lock();
         if (PWINDOW) {
             if (const auto WINDOWBOX = PWINDOW->surfaceLogicalBox(); WINDOWBOX.has_value()) {
                 CBox       scaledWindowBox = WINDOWBOX.value();
 
                 const auto PWORKSPACE = PWINDOW->m_workspace;
                 if (PWORKSPACE && !(PWINDOW->m_state & WINDOW_STATE_PINNED))
-                    scaledWindowBox.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock()));
+                    scaledWindowBox.translate(g_pHyprRenderer->workspaceRenderOffset(context, PWORKSPACE, context.sceneMonitor.lock()));
 
-                scaledWindowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
-                scaledWindowBox.translate(-m_renderData.pMonitor->m_position);
-                scaledWindowBox.scale(m_renderData.pMonitor->m_scale).round();
-                m_renderData.renderModif.applyToBox(scaledWindowBox);
+                scaledWindowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(context, PWINDOW));
+                scaledWindowBox.translate(-context.sceneMonitor->m_position);
+                scaledWindowBox.scale(context.sceneMonitor->m_scale).round();
+                context.renderModif.applyToBox(scaledWindowBox);
 
                 const auto cutoutTopLeft     = scaledWindowBox.pos() - newBox.pos();
                 const auto cutoutBottomRight = cutoutTopLeft + scaledWindowBox.size();
 
-                float      cutoutRadius = std::max(0.F, sc<float>(PWINDOW->presentation().rounding() * m_renderData.pMonitor->m_scale));
-                cutoutRadius            = std::round(cutoutRadius * m_renderData.renderModif.combinedScale());
+                float      cutoutRadius = std::max(0.F, sc<float>(PWINDOW->presentation().rounding() * context.sceneMonitor->m_scale));
+                cutoutRadius            = std::round(cutoutRadius * context.renderModif.combinedScale());
 
                 shader->setUniformFloat2(SHADER_WINDOW_TOP_LEFT, sc<float>(cutoutTopLeft.x), sc<float>(cutoutTopLeft.y));
                 shader->setUniformFloat2(SHADER_WINDOW_BOTTOM_RIGHT, sc<float>(cutoutBottomRight.x), sc<float>(cutoutBottomRight.y));
@@ -2288,40 +2261,40 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
     }
 
     if (!drawRegion.empty())
-        drawRegion.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        drawRegion.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
 
     glBindVertexArray(0);
 }
 
-void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, int glowPower, float a) {
-    renderInnerGlow(box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, glowPower, a);
+void CHyprOpenGLImpl::renderInnerGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, int glowPower,
+                                      float a) {
+    renderInnerGlow(context, box, round, roundingPower, range, grad, Config::CGradientValueData{}, 0.f, glowPower, a);
 }
-void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                      float lerp, int glowPower, float a) {
-    auto& m_renderData = g_pHyprRenderer->m_renderData;
-    RASSERT(m_renderData.pMonitor, "Tried to render inner glow without begin()!");
+void CHyprOpenGLImpl::renderInnerGlow(CRenderingContext& context, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                      const Config::CGradientValueData& grad2, float lerp, int glowPower, float a) {
+    RASSERT(context.sceneMonitor, "Tried to render inner glow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render inner glow with width/height < 0!");
 
-    if (g_pHyprRenderer->m_renderData.damage.empty())
+    if (context.damage.empty())
         return;
 
     TRACY_GPU_ZONE("RenderInnerGlow");
 
     CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    context.renderModif.applyToBox(newBox);
 
     static auto PGLOWPOWER = CConfigValue<Config::INTEGER>("decoration:glow:render_power");
 
     const auto  GLOWPOWER = std::clamp(sc<int>(*PGLOWPOWER), 1, 4);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(context, newBox);
 
     blend(true);
 
-    auto shader = useShader(getShaderVariant(SH_FRAG_INNER_GLOW, globalFeatures()));
+    auto shader = useShader(getShaderVariant(SH_FRAG_INNER_GLOW, globalFeatures(context)));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
 
@@ -2329,7 +2302,7 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
     if (!grad1.m_colors.empty())
         color = grad1.m_colors[0];
 
-    const auto converted = g_pHyprRenderer->getConvertedColor(color.stripA());
+    const auto converted = g_pHyprRenderer->getConvertedColor(context, color.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, color.a * a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, color.r, color.g, color.b, color.a * a);
 
@@ -2357,20 +2330,19 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
 
     glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
-    if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0) {
-        CRegion damageClip{g_pHyprRenderer->m_renderData.clipBox.x, g_pHyprRenderer->m_renderData.clipBox.y, g_pHyprRenderer->m_renderData.clipBox.width,
-                           g_pHyprRenderer->m_renderData.clipBox.height};
-        damageClip.intersect(g_pHyprRenderer->m_renderData.damage);
+    if (context.clipBox.width != 0 && context.clipBox.height != 0) {
+        CRegion damageClip{context.clipBox.x, context.clipBox.y, context.clipBox.width, context.clipBox.height};
+        damageClip.intersect(context.damage);
 
         if (!damageClip.empty()) {
-            damageClip.forEachRect([this](const auto& RECT) {
-                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            damageClip.forEachRect([this, &context](const auto& RECT) {
+                scissor(context, &RECT, context.transformDamage);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
     } else {
-        g_pHyprRenderer->m_renderData.damage.forEachRect([this](const auto& RECT) {
-            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+        context.damage.forEachRect([this, &context](const auto& RECT) {
+            scissor(context, &RECT, context.transformDamage);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         });
     }
@@ -2378,23 +2350,22 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
     glBindVertexArray(0);
 }
 
-bool CHyprOpenGLImpl::saveBufferForMirror(const CBox& box) {
-    const auto TEX = g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex ? g_pHyprRenderer->m_renderData.pMonitor->resources()->m_mirrorTex :
-                                                                                        g_pHyprRenderer->m_renderData.currentFB->getTexture();
+bool CHyprOpenGLImpl::saveBufferForMirror(CRenderingContext& context, const CBox& box) {
+    const auto TEX = context.sceneMonitor->resources()->m_mirrorTex ? context.sceneMonitor->resources()->m_mirrorTex : context.currentFB->getTexture();
     if (!TEX) {
         Log::logger->log(Log::ERR, "Invalid source texture for mirror");
         return false;
     }
-    auto fb    = g_pHyprRenderer->m_renderData.pMonitor->resources()->mirrorFB();
-    auto guard = g_pHyprRenderer->bindTempFB(fb);
+    auto fb    = context.sceneMonitor->resources()->mirrorFB();
+    auto guard = g_pHyprRenderer->bindTempFB(context, fb);
 
-    Log::logger->log(Log::TRACE, "CM: saveBufferForMirror {} -> {}", TEX->m_imageDescription->value(), g_pHyprRenderer->m_renderData.currentFB->imageDescription()->value());
+    Log::logger->log(Log::TRACE, "CM: saveBufferForMirror {} -> {}", TEX->m_imageDescription->value(), context.currentFB->imageDescription()->value());
 
     blend(false);
 
-    renderTexture(TEX, box,
+    renderTexture(context, TEX, box,
                   STextureRenderData{
-                      .damage        = &g_pHyprRenderer->m_renderData.finalDamage,
+                      .damage        = &context.finalDamage,
                       .a             = 1.F,
                       .round         = 0,
                       .discardActive = false,
@@ -2432,9 +2403,9 @@ void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITORREF pMonitor) {
         Log::logger->log(Log::DEBUG, "Monitor {} -> destroyed all render data", pMonitor->m_name);
 }
 
-void CHyprOpenGLImpl::renderOffToMain(SP<IFramebuffer> off) {
-    CBox monbox = {0, 0, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y};
-    renderTexturePrimitive(off->getTexture(), monbox);
+void CHyprOpenGLImpl::renderOffToMain(CRenderingContext& context, SP<IFramebuffer> off) {
+    CBox monbox = {0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y};
+    renderTexturePrimitive(context, off->getTexture(), monbox);
 }
 
 void CHyprOpenGLImpl::setViewport(GLint x, GLint y, GLsizei width, GLsizei height) {
@@ -2483,6 +2454,10 @@ void CHyprOpenGLImpl::bindFramebuffer(GLenum target, GLuint fb) {
         m_boundDrawFB = fb;
     if (READ)
         m_boundReadFB = fb;
+}
+
+GLuint CHyprOpenGLImpl::boundDrawFramebuffer() const {
+    return m_boundDrawFB;
 }
 
 void CHyprOpenGLImpl::onFramebufferDeleted(GLuint fb) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -440,7 +440,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_drmFD(g_pCompositor->m_drmRenderNode.fd >
         if (e.state != WL_POINTER_BUTTON_STATE_PRESSED)
             return;
 
-        addLastPressToHistory(g_pInputManager->getMouseCoordsInternal(), g_pInputManager->getClickMode() == CLICKMODE_KILL, false);
+        addLastPressToHistory(Pointer::mgr()->untransformedPosition(), g_pInputManager->getClickMode() == CLICKMODE_KILL, false);
     });
 
     static auto P3 = Event::bus()->m_events.input.touch.down.listen([](ITouch::SDownEvent e, Event::SCallbackInfo&) {
@@ -1350,7 +1350,7 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal(CRenderingContext& conte
 
     if (*PDT == 0) {
         PHLMONITORREF pMonitor = context.sceneMonitor;
-        Vector2D      p        = ((g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position) * pMonitor->m_scale);
+        Vector2D      p        = ((Pointer::mgr()->untransformedPosition() - pMonitor->m_position) * pMonitor->m_scale);
         shader->setUniformFloat2(SHADER_POINTER, p.x / pMonitor->m_transformedSize.x, p.y / pMonitor->m_transformedSize.y);
 
         std::vector<float> pressedPos = m_pressedHistoryPositions | std::views::transform([&](const Vector2D& vec) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -35,6 +35,7 @@
 #include "../managers/screenshare/ScreenshareManager.hpp"
 #include "../notification/NotificationOverlay.hpp"
 #include "../state/MonitorState.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "errorOverlay/Overlay.hpp"
 #include "helpers/Color.hpp"
 #include "macros.hpp"
@@ -2256,9 +2257,9 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
                 const auto PWORKSPACE = PWINDOW->m_workspace;
                 if (PWORKSPACE && !(PWINDOW->m_state & WINDOW_STATE_PINNED))
-                    scaledWindowBox.translate(PWORKSPACE->m_renderOffset->value());
+                    scaledWindowBox.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE, g_pHyprRenderer->renderData().pMonitor.lock()));
 
-                scaledWindowBox.translate(PWINDOW->presentation().floatingOffset());
+                scaledWindowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
                 scaledWindowBox.translate(-m_renderData.pMonitor->m_position);
                 scaledWindowBox.scale(m_renderData.pMonitor->m_scale).round();
                 m_renderData.renderModif.applyToBox(scaledWindowBox);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -440,7 +440,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_drmFD(g_pCompositor->m_drmRenderNode.fd >
         if (e.state != WL_POINTER_BUTTON_STATE_PRESSED)
             return;
 
-        addLastPressToHistory(g_pInputManager->getMouseCoordsInternal(), g_pInputManager->getClickMode() == CLICKMODE_KILL, false);
+        addLastPressToHistory(Pointer::mgr()->untransformedPosition(), g_pInputManager->getClickMode() == CLICKMODE_KILL, false);
     });
 
     static auto P3 = Event::bus()->m_events.input.touch.down.listen([](ITouch::SDownEvent e, Event::SCallbackInfo&) {
@@ -1342,7 +1342,7 @@ WP<CShader> CHyprOpenGLImpl::renderScreenShaderInternal(CRenderingContext& conte
 
     if (*PDT == 0) {
         PHLMONITORREF pMonitor = context.sceneMonitor;
-        Vector2D      p        = ((g_pInputManager->getMouseCoordsInternal() - pMonitor->m_position) * pMonitor->m_scale);
+        Vector2D      p        = ((Pointer::mgr()->untransformedPosition() - pMonitor->m_position) * pMonitor->m_scale);
         shader->setUniformFloat2(SHADER_POINTER, p.x / pMonitor->m_transformedSize.x, p.y / pMonitor->m_transformedSize.y);
 
         std::vector<float> pressedPos = m_pressedHistoryPositions | std::views::transform([&](const Vector2D& vec) {

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -95,43 +95,6 @@ namespace Render::GL {
         std::array<std::map<Render::SShaderVariant, SP<CShader>>, Render::SH_FRAG_LAST> fragVariants;
     };
 
-    struct SCurrentRenderData {
-        PHLMONITORREF            pMonitor;
-        Mat3x3                   projection;
-        Mat3x3                   savedProjection;
-        Mat3x3                   monitorProjection;
-
-        SP<IFramebuffer>         currentFB = nullptr; // current rendering to
-        SP<IFramebuffer>         mainFB    = nullptr; // main to render to
-        SP<IFramebuffer>         outFB     = nullptr; // out to render to (if offloaded, etc)
-
-        CRegion                  damage;
-        CRegion                  finalDamage; // damage used for final off -> main
-
-        Render::SRenderModifData renderModif;
-        float                    mouseZoomFactor            = 1.f;
-        bool                     mouseZoomUseMouse          = true; // true by default
-        bool                     useNearestNeighbor         = false;
-        bool                     blockScreenShader          = false;
-        bool                     simplePass                 = false;
-        bool                     transformDamage            = true;
-        bool                     noSimplify                 = false;
-        bool                     renderingTransformedSource = false;
-
-        Vector2D                 primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-        Vector2D                 primarySurfaceUVBottomRight = Vector2D(-1, -1);
-
-        CBox                     clipBox = {}; // scaled coordinates
-        CRegion                  clipRegion;
-
-        uint32_t                 discardMode    = DISCARD_OPAQUE;
-        float                    discardOpacity = 0.f;
-
-        PHLLSREF                 currentLS;
-        PHLWINDOWREF             currentWindow;
-        WP<CWLSurfaceResource>   surface;
-    };
-
     class CEGLSync : public ISyncFDManager {
       public:
         static UP<CEGLSync> create();
@@ -203,48 +166,50 @@ namespace Render::GL {
             int   outerRound    = -1; /* use round */
         };
 
-        void makeEGLCurrent();
-        void begin(PHLMONITOR, const CRegion& damage, SP<IFramebuffer> fb = nullptr, std::optional<CRegion> finalDamage = {});
-        void beginSimple(PHLMONITOR, const CRegion& damage, SP<IRenderbuffer> rb = nullptr, SP<IFramebuffer> fb = nullptr);
-        void end();
+        void   makeEGLCurrent();
+        void   begin(CRenderingContext&, const CRegion& damage, SP<IFramebuffer> fb = nullptr, std::optional<CRegion> finalDamage = {});
+        void   beginSimple(CRenderingContext&, const CRegion& damage, SP<IRenderbuffer> rb = nullptr, SP<IFramebuffer> fb = nullptr);
+        void   end(CRenderingContext&);
 
-        void renderRect(const CBox&, const CHyprColor&, SRectRenderData data);
-        void renderTexture(SP<ITexture>, const CBox&, STextureRenderData data);
-        void renderTextureMesh(SP<ITexture>, const CBox&, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data);
-        void renderRoundedShadow(const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a = 1.0);
-        void renderRoundedShadow(const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                 float lerp, float a = 1.0);
-        void renderInnerGlow(const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, int glowPower, float a = 1.0);
-        void renderInnerGlow(const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp,
-                             int glowPower, float a = 1.0);
-        void renderBorder(const CBox&, const Config::CGradientValueData&, SBorderRenderData data);
-        void renderBorder(const CBox&, const Config::CGradientValueData&, const Config::CGradientValueData&, float lerp, SBorderRenderData data);
-        void renderTextureMatte(SP<ITexture> tex, const CBox& pBox, SP<IFramebuffer> matte);
-        void renderTexturePrimitive(SP<ITexture> tex, const CBox& box);
+        void   renderRect(CRenderingContext&, const CBox&, const CHyprColor&, SRectRenderData data);
+        void   renderTexture(CRenderingContext&, SP<ITexture>, const CBox&, STextureRenderData data);
+        void   renderTextureMesh(CRenderingContext&, SP<ITexture>, const CBox&, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data);
+        void   renderRoundedShadow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a = 1.0);
+        void   renderRoundedShadow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                   const Config::CGradientValueData& grad2, float lerp, float a = 1.0);
+        void   renderInnerGlow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, int glowPower, float a = 1.0);
+        void   renderInnerGlow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                               const Config::CGradientValueData& grad2, float lerp, int glowPower, float a = 1.0);
+        void   renderBorder(CRenderingContext&, const CBox&, const Config::CGradientValueData&, SBorderRenderData data);
+        void   renderBorder(CRenderingContext&, const CBox&, const Config::CGradientValueData&, const Config::CGradientValueData&, float lerp, SBorderRenderData data);
+        void   renderTextureMatte(CRenderingContext&, SP<ITexture> tex, const CBox& pBox, SP<IFramebuffer> matte);
+        void   renderTexturePrimitive(CRenderingContext&, SP<ITexture> tex, const CBox& box);
 
-        void setViewport(GLint x, GLint y, GLsizei width, GLsizei height);
-        void setCapStatus(int cap, bool status);
-        void setActiveTexture(GLenum texture);
-        void blendFunc(GLenum sfactor, GLenum dfactor);
-        void bindArrayBuffer(GLuint buffer);
-        void bindFramebuffer(GLenum target, GLuint fb);
+        void   setViewport(GLint x, GLint y, GLsizei width, GLsizei height);
+        void   setCapStatus(int cap, bool status);
+        void   setActiveTexture(GLenum texture);
+        void   blendFunc(GLenum sfactor, GLenum dfactor);
+        void   bindArrayBuffer(GLuint buffer);
+        void   bindFramebuffer(GLenum target, GLuint fb);
+        GLuint boundDrawFramebuffer() const;
         // GL implicitly rebinds 0 on every target the deleted fb was bound to, keep the shadow in sync
         void                                      onFramebufferDeleted(GLuint fb);
 
         void                                      blend(bool enabled);
         bool                                      blendEnabled() const;
 
-        void                                      scissor(const CBox&, bool transform = true);
-        void                                      scissor(const pixman_box32*, bool transform = true);
-        void                                      scissor(const int x, const int y, const int w, const int h, bool transform = true);
+        void                                      scissor(const CRenderingContext&, const CBox&, bool transform = true);
+        void                                      scissor(const CRenderingContext&, const pixman_box32*, bool transform = true);
+        void                                      scissor(const CRenderingContext&, const int x, const int y, const int w, const int h, bool transform = true);
+        void                                      disableScissorState();
 
         void                                      destroyMonitorResources(PHLMONITORREF);
 
-        bool                                      saveBufferForMirror(const CBox&);
+        bool                                      saveBufferForMirror(CRenderingContext&, const CBox&);
 
         void                                      applyScreenShader(const std::string& path);
 
-        void                                      renderOffToMain(SP<IFramebuffer> off);
+        void                                      renderOffToMain(CRenderingContext&, SP<IFramebuffer> off);
 
         std::vector<SDRMFormat>                   getDRMFormats();
         std::vector<uint64_t>                     getDRMFormatModifiers(DRMFormat format);
@@ -342,11 +307,8 @@ namespace Render::GL {
         int                     m_drmFD = -1;
         std::string             m_extensions;
 
-        bool                    m_fakeFrame            = false;
-        bool                    m_applyFinalShader     = false;
-        bool                    m_blend                = false;
-        bool                    m_offloadedFramebuffer = false;
-        bool                    m_cmSupported          = true;
+        bool                    m_blend       = false;
+        bool                    m_cmSupported = true;
 
         SP<CShader>             m_finalScreenShader;
         GLuint                  m_currentProgram;
@@ -364,19 +326,19 @@ namespace Render::GL {
         //
         std::optional<std::vector<uint64_t>> getModsForFormat(EGLint format);
 
-        void        passCMUniforms(WP<CShader>, const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
-                                   bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance, const SCMSettings& settings);
-        void        passCMUniforms(WP<CShader>, const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
-                                   bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1);
-        void        passCMUniforms(WP<CShader>, const NColorManagement::PImageDescription imageDescription);
-        void        passCMUniforms(WP<CShader>, const NColorManagement::PImageDescription imageDescription, const SCMSettings& settings);
-        void        renderRectInternal(const CBox&, const CHyprColor&, const SRectRenderData& data);
-        void        renderRectWithBlurInternal(const CBox&, const CHyprColor&, const SRectRenderData& data);
-        void        renderRectWithDamageInternal(const CBox&, const CHyprColor&, const SRectRenderData& data);
-        WP<CShader> renderScreenShaderInternal();
-        WP<CShader> renderToFBInternal(SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox);
-        void        renderTextureInternal(SP<ITexture>, const CBox&, const STextureRenderData& data);
-        void        renderTextureWithBlurInternal(SP<ITexture>, const CBox&, const STextureRenderData& data);
+        void passCMUniforms(CRenderingContext&, WP<CShader>, const NColorManagement::PImageDescription imageDescription,
+                            const NColorManagement::PImageDescription targetImageDescription, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance,
+                            const SCMSettings& settings);
+        void passCMUniforms(CRenderingContext&, WP<CShader>, const NColorManagement::PImageDescription imageDescription,
+                            const NColorManagement::PImageDescription targetImageDescription, bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1);
+        void passCMUniforms(CRenderingContext&, WP<CShader>, const NColorManagement::PImageDescription imageDescription);
+        void passCMUniforms(CRenderingContext&, WP<CShader>, const NColorManagement::PImageDescription imageDescription, const SCMSettings& settings);
+        void renderRectWithBlurInternal(CRenderingContext&, const CBox&, const CHyprColor&, const SRectRenderData& data);
+        void renderRectWithDamageInternal(CRenderingContext&, const CBox&, const CHyprColor&, const SRectRenderData& data);
+        WP<CShader> renderScreenShaderInternal(CRenderingContext&);
+        WP<CShader> renderToFBInternal(CRenderingContext&, SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox);
+        void        renderTextureInternal(CRenderingContext&, SP<ITexture>, const CBox&, const STextureRenderData& data);
+        void        renderTextureWithBlurInternal(CRenderingContext&, SP<ITexture>, const CBox&, const STextureRenderData& data);
 
         friend class IHyprRenderer;
         friend class CHyprGLRenderer;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -175,6 +175,8 @@ namespace Render::GL {
         void   renderTexture(CRenderingContext&, SP<ITexture>, const CBox&, STextureRenderData data);
         void   renderTextureMesh(CRenderingContext&, SP<ITexture>, const CBox&, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data);
         void   renderRoundedShadow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a = 1.0);
+        void   renderRoundedShadow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a,
+                                   const CBox& cutoutBox, int cutoutRound);
         void   renderRoundedShadow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
                                    const Config::CGradientValueData& grad2, float lerp, float a = 1.0);
         void   renderInnerGlow(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, int glowPower, float a = 1.0);
@@ -335,6 +337,8 @@ namespace Render::GL {
         void passCMUniforms(CRenderingContext&, WP<CShader>, const NColorManagement::PImageDescription imageDescription, const SCMSettings& settings);
         void renderRectWithBlurInternal(CRenderingContext&, const CBox&, const CHyprColor&, const SRectRenderData& data);
         void renderRectWithDamageInternal(CRenderingContext&, const CBox&, const CHyprColor&, const SRectRenderData& data);
+        void renderRoundedShadowInternal(CRenderingContext&, const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                         const Config::CGradientValueData& grad2, float lerp, float a, const std::optional<CBox>& cutoutBox, int cutoutRound);
         WP<CShader> renderScreenShaderInternal(CRenderingContext&);
         WP<CShader> renderToFBInternal(CRenderingContext&, SP<ITexture> tex, const STextureRenderData& data, eTextureType texType, const CBox& newBox);
         void        renderTextureInternal(CRenderingContext&, SP<ITexture>, const CBox&, const STextureRenderData& data);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -32,6 +32,7 @@
 #include "../errorOverlay/Overlay.hpp"
 #include "../debug/Overlay.hpp"
 #include "../notification/NotificationOverlay.hpp"
+#include "../overview/Overview.hpp"
 #include "../layout/LayoutManager.hpp"
 #include "../layout/space/Space.hpp"
 #include "../i18n/Engine.hpp"
@@ -149,7 +150,7 @@ IHyprRenderer::IHyprRenderer() {
 
     // cursor hiding stuff
 
-    static auto P = Event::bus()->m_events.input.keyboard.key.listen([&](IKeyboard::SKeyEvent e, Event::SCallbackInfo&) {
+    static auto P = Event::bus()->m_events.input.keyboard.key.listen([&](IKeyboard::SKeyEvent e, SP<IKeyboard>, Event::SCallbackInfo&) {
         if (m_cursorHiddenConditions.hiddenOnKeyboard)
             return;
 
@@ -240,8 +241,17 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->m_workspace)
         return false;
 
-    if (m_isolatedWorkspace)
-        return !(pWindow->m_state & WINDOW_STATE_PINNED) && pWindow->m_workspace == m_isolatedWorkspace;
+    if (m_isolatedWorkspace) {
+        if (pWindow->m_state & WINDOW_STATE_PINNED)
+            return m_isolatedWorkspaceFullScene;
+
+        if (pWindow->m_workspace == m_isolatedWorkspace)
+            return true;
+
+        const auto WORKSPACE_MONITOR = pWindow->m_workspace->m_monitor.lock();
+        return m_isolatedWorkspaceFullScene && pWindow->onSpecialWorkspace() && WORKSPACE_MONITOR &&
+            (WORKSPACE_MONITOR->m_activeSpecialWorkspace == pWindow->m_workspace || WORKSPACE_MONITOR->m_workspaceTransition->participates(pWindow->m_workspace));
+    }
 
     if (pWindow->m_state & WINDOW_STATE_PINNED)
         return true;
@@ -404,7 +414,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
@@ -426,7 +436,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
@@ -483,7 +493,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
@@ -535,7 +545,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     lastWindow.reset();
 
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
@@ -577,7 +587,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         // render the bad boy
         renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
@@ -846,7 +856,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             pWindow->popupHead()->breadthfirst(
                 [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (!popup->mapped() || !popup->resource() || (!m_isolatedWorkspace && (!popup->acceptsInput() || !popup->alphaNonZero())))
+                    if (!popup->mapped() || !popup->resource() || ((!m_isolatedWorkspace || m_isolatedWorkspaceFullScene) && (!popup->acceptsInput() || !popup->alphaNonZero())))
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();
@@ -1195,7 +1205,8 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         }
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
+        if (!m_isolatedWorkspace)
+            Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
@@ -1223,7 +1234,8 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         }
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
+        if (!m_isolatedWorkspace)
+            Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
@@ -1295,7 +1307,8 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
 
-    Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOWS);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOWS);
 
     // Render surfaces above windows for monitor
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
@@ -1592,7 +1605,7 @@ bool IHyprRenderer::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindo
     static auto PBLURNEWOPTIMIZE = CConfigValue<Config::INTEGER>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Config::INTEGER>("decoration:blur:xray");
 
-    if (!getBlurTexture(m_renderData.pMonitor))
+    if (m_isolatedWorkspaceFullScene || !getBlurTexture(m_renderData.pMonitor))
         return false;
 
     if (blurProviderRequiresLiveBlur())
@@ -2636,6 +2649,14 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
 }
 
 bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(workspace, framebuffer, Time::steadyNow(), sendFeedback, false);
+}
+
+bool IHyprRenderer::renderWorkspaceSceneToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(workspace, framebuffer, time, sendFeedback, true);
+}
+
+bool IHyprRenderer::renderWorkspaceToBufferInternal(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != MONITOR)
         return false;
@@ -2646,16 +2667,18 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
         framebuffer->setImageDescription(MONITOR->workBufferImageDescription());
 
     CRenderPass pass;
-    const auto  OLDRENDERDATA        = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
-    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER  = MONITOR->m_blurFBShouldRender;
-    auto* const OLDPASS              = m_currentPass;
+    const auto  OLDRENDERDATA                 = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
+    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
+    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER           = MONITOR->m_blurFBShouldRender;
+    auto* const OLDPASS                       = m_currentPass;
 
     CScopeGuard restore([&] {
         m_currentPass                 = OLDPASS;
         m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
         m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
         m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
         MONITOR->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
@@ -2666,8 +2689,9 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
     CRegion     damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
     m_currentPass                 = &pass;
     m_isolatedWorkspace           = workspace;
+    m_isolatedWorkspaceFullScene  = fullScene;
     m_bBlockSurfaceFeedback       = !sendFeedback;
-    m_bRenderingSnapshot          = true;
+    m_bRenderingSnapshot          = !fullScene;
     MONITOR->m_blurFBShouldRender = false;
     m_renderData.pMonitor         = MONITOR;
     m_renderData.mainFB           = framebuffer;
@@ -2688,10 +2712,15 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
     setProjectionType(RPT_EXPORT);
 
     addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
-    if (Fullscreen::controller()->hasFullscreen(workspace))
-        renderWorkspaceWindowsFullscreen(MONITOR, workspace, Time::steadyNow());
+    if (fullScene) {
+        renderAllClientsForWorkspace(MONITOR, workspace, time);
+        const CBox renderBox = {{}, MONITOR->m_transformedSize};
+        renderLockscreen(MONITOR, time, renderBox);
+        renderIME(MONITOR, time, renderBox);
+    } else if (Fullscreen::controller()->hasFullscreen(workspace))
+        renderWorkspaceWindowsFullscreen(MONITOR, workspace, time);
     else
-        renderWorkspaceWindows(MONITOR, workspace, Time::steadyNow());
+        renderWorkspaceWindows(MONITOR, workspace, time);
 
     m_currentPass = OLDPASS;
     pass.render(damage);
@@ -2709,16 +2738,18 @@ bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> f
         framebuffer->setImageDescription(monitor->workBufferImageDescription());
 
     CRenderPass pass;
-    const auto  OLDRENDERDATA        = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
-    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER  = monitor->m_blurFBShouldRender;
-    auto* const OLDPASS              = m_currentPass;
+    const auto  OLDRENDERDATA                 = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
+    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
+    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER           = monitor->m_blurFBShouldRender;
+    auto* const OLDPASS                       = m_currentPass;
 
     CScopeGuard restore([&] {
         m_currentPass                 = OLDPASS;
         m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
         m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
         m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
         monitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
@@ -2729,10 +2760,11 @@ bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> f
     CRegion     damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
     m_currentPass = &pass;
     m_isolatedWorkspace.reset();
-    m_bBlockSurfaceFeedback = !sendFeedback;
-    m_bRenderingSnapshot    = false;
-    m_renderData.pMonitor   = monitor;
-    m_renderData.mainFB     = framebuffer;
+    m_isolatedWorkspaceFullScene = false;
+    m_bBlockSurfaceFeedback      = !sendFeedback;
+    m_bRenderingSnapshot         = false;
+    m_renderData.pMonitor        = monitor;
+    m_renderData.mainFB          = framebuffer;
     m_renderData.outFB.reset();
     m_renderData.fbSize                     = monitor->m_transformedSize;
     m_renderData.damage                     = damage;
@@ -3019,8 +3051,9 @@ void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
     windowBox.translate(pWindow->presentation().floatingOffset());
     windowBox = pWindow->effects().transformBoxForDamage(windowBox);
 
+    const bool OVERVIEW_SELECTED = Overview::overview()->shouldRenderWorkspace(PWINDOWWORKSPACE);
     for (auto const& m : State::monitorState()->monitors()) {
-        if (forceFull || shouldRenderWindow(pWindow, m)) { // only damage if window is rendered on monitor
+        if (forceFull || shouldRenderWindow(pWindow, m) || (OVERVIEW_SELECTED && m == PWORKSPACEMONITOR)) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->m_position.x, windowBox.y - m->m_position.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->m_scale).round();
             m->addDamage(fixedDamageBox);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1198,12 +1198,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHL
     if UNLIKELY (!pWorkspace) {
         // allow rendering without a workspace. In this case, just render layers.
 
-        renderBackground(context, pMonitor);
-
-        for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(context, ls.lock(), pMonitor, time);
-        }
-        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderMonitorBackground(context, pMonitor, time);
 
         if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
@@ -1227,12 +1222,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHL
     }
 
     if LIKELY (!*PXPMODE) {
-        renderBackground(context, pMonitor);
-
-        for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(context, ls.lock(), pMonitor, time);
-        }
-        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderMonitorBackground(context, pMonitor, time);
 
         if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
@@ -1329,6 +1319,18 @@ void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHL
     renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_POPUP);
 
     renderDragIcon(context, pMonitor, time);
+}
+
+void IHyprRenderer::renderMonitorBackground(CRenderingContext& context, PHLMONITOR monitor, const Time::steady_tp& time) {
+    if (!monitor)
+        return;
+
+    renderBackground(context, monitor);
+
+    for (const auto& layer : monitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
+        renderLayer(context, layer.lock(), monitor, time);
+    }
+    renderFadeouts(context, monitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 }
 
 void IHyprRenderer::renderIME(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -40,6 +40,7 @@
 #include "../helpers/CursorShapes.hpp"
 #include "../helpers/MainLoopExecutor.hpp"
 #include "../output/Monitor.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "../state/MonitorState.hpp"
 #include "../state/WorkspaceState.hpp"
 #include "macros.hpp"
@@ -238,6 +239,9 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->m_workspace)
         return false;
 
+    if (m_isolatedWorkspace)
+        return !(pWindow->m_state & WINDOW_STATE_PINNED) && pWindow->m_workspace == m_isolatedWorkspace;
+
     if (pWindow->m_state & WINDOW_STATE_PINNED)
         return true;
 
@@ -248,7 +252,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
 
     const auto PWINDOWWORKSPACE = pWindow->m_workspace;
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_monitor == pMonitor) {
-        if (PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() || PWINDOWWORKSPACE->m_alpha->isBeingAnimated() || PWINDOWWORKSPACE->m_forceRendering)
+        if (pMonitor->m_workspaceTransition->participates(PWINDOWWORKSPACE))
             return true;
 
         // if hidden behind fullscreen
@@ -256,7 +260,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
             pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) == 0)
             return false;
 
-        if (!PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOWWORKSPACE->m_alpha->isBeingAnimated() && !PWINDOWWORKSPACE->isVisible())
+        if (!pMonitor->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE) && !PWINDOWWORKSPACE->isVisible())
             return false;
     }
 
@@ -278,13 +282,14 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
         return false;
 
     if (pWindow->positionAnimation()->isBeingAnimated()) {
-        if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated())
+        const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
+        if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
             return false;
         // render window if window and monitor intersect
         // (when moving out of or through a monitor)
         CBox windowBox = pWindow->getFullWindowBoundingBox();
-        if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated())
-            windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
+        if (PWINDOWWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
+            windowBox.translate(PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWINDOWWORKSPACE));
         windowBox.translate(pWindow->presentation().floatingOffset());
 
         const CBox monitorBox = {pMonitor->m_position, pMonitor->m_size};
@@ -305,14 +310,16 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (!pWindow->m_workspace)
         return false;
 
-    if ((pWindow->m_state & WINDOW_STATE_PINNED) || PWORKSPACE->m_forceRendering)
+    const auto PWORKSPACEMONITOR = PWORKSPACE->m_monitor.lock();
+
+    if ((pWindow->m_state & WINDOW_STATE_PINNED) || (PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->forceRendering(PWORKSPACE)))
         return true;
 
     if (PWORKSPACE && PWORKSPACE->isVisible())
         return true;
 
     for (auto const& m : State::monitorState()->monitors()) {
-        if (PWORKSPACE && PWORKSPACE->m_monitor == m && (PWORKSPACE->m_renderOffset->isBeingAnimated() || PWORKSPACE->m_alpha->isBeingAnimated()))
+        if (PWORKSPACE && PWORKSPACE->m_monitor == m && m->m_workspaceTransition->isAnimating(PWORKSPACE))
             return true;
 
         if (m->m_activeSpecialWorkspace && pWindow->onSpecialWorkspace())
@@ -320,6 +327,38 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     }
 
     return false;
+}
+
+float IHyprRenderer::workspaceRenderAlpha(PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+        return 1.F;
+
+    const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
+    return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->alphaValue(workspace) : 1.F;
+}
+
+Vector2D IHyprRenderer::workspaceRenderOffset(PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+        return {};
+
+    const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
+    return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->offsetValue(workspace) : Vector2D{};
+}
+
+bool IHyprRenderer::workspaceRenderIsAnimating(PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+        return false;
+
+    const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
+    return WORKSPACEMONITOR && WORKSPACEMONITOR->m_workspaceTransition->isAnimating(workspace);
+}
+
+Vector2D IHyprRenderer::windowRenderFloatingOffset(PHLWINDOW window) const {
+    return window && !(m_isolatedWorkspace && window->m_workspace == m_isolatedWorkspace) ? window->presentation().floatingOffset() : Vector2D{};
+}
+
+bool IHyprRenderer::renderingWorkspaceToBuffer() const {
+    return !!m_isolatedWorkspace;
 }
 
 bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
@@ -335,7 +374,8 @@ bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
 void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW pWorkspaceWindow = nullptr;
 
-    Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     // pre-filter renderable windows once for the tiled + floating passes
     std::vector<PHLWINDOW> windows;
@@ -363,7 +403,8 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
     for (auto const& w : windows) {
@@ -379,16 +420,21 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (w->isFadingOutUnderFullscreen())
             continue; // render these over fullscreen so the fade-out is visible
 
+        if (m_isolatedWorkspace && w->shouldRenderOverFullscreen())
+            continue;
+
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
     for (auto const& w : Desktop::windowState()->windows()) {
         const auto PWORKSPACE = w->m_workspace;
 
         if (w->m_workspace != pWorkspace || !Fullscreen::controller()->isFullscreen(w)) {
-            if (!(PWORKSPACE && (PWORKSPACE->m_renderOffset->isBeingAnimated() || PWORKSPACE->m_alpha->isBeingAnimated() || PWORKSPACE->m_forceRendering)))
+            const auto PWORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+            if (!(PWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->participates(PWORKSPACE)))
                 continue;
 
             if (w->m_monitor != pMonitor)
@@ -421,6 +467,9 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (shouldSkipWindow)
             continue;
 
+        if (!shouldRenderWindow(w, pMonitor))
+            continue;
+
         const bool mismatchedSpecialWorkspace = w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace();
 
         if (mismatchedSpecialWorkspace)
@@ -433,13 +482,15 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
 void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW lastWindow;
 
-    Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     std::vector<PHLWINDOWREF> windows;
     windows.reserve(Desktop::windowState()->windows().size());
@@ -483,7 +534,8 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     lastWindow.reset();
 
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
     for (auto& w : windows) {
@@ -524,7 +576,8 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         // render the bad boy
         renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
 void IHyprRenderer::bindOffMain() {
@@ -562,10 +615,11 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     TRACY_GPU_ZONE("RenderWindow");
 
-    const auto PWORKSPACE = pWindow->m_workspace;
-    const auto REALPOS =
-        pWindow->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + ((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
-    static auto                      PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
+    const auto  PWORKSPACE      = pWindow->m_workspace;
+    const auto  WORKSPACEOFFSET = workspaceRenderOffset(PWORKSPACE, pMonitor);
+    const auto  WINDOWOFFSET    = windowRenderFloatingOffset(pWindow);
+    const auto  REALPOS         = pWindow->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + ((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET);
+    static auto PDIMAROUND      = CConfigValue<Config::FLOAT>("decoration:dim_around");
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time};
     const auto                       REALSIZE   = pWindow->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
@@ -592,7 +646,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.surface   = pWindow->wlSurface()->resource();
     renderdata.dontRound = Fullscreen::controller()->getFullscreenModes(pWindow).internal == Fullscreen::FSMODE_FULLSCREEN;
     renderdata.fadeAlpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) *
-        pWindow->presentation().alphaValue(WINDOW_ALPHA_LAYOUT) * ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
+        pWindow->presentation().alphaValue(WINDOW_ALPHA_LAYOUT) *
+        ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : workspaceRenderAlpha(PWORKSPACE, pMonitor)) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) : 1.F) *
         pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_FROM_WORKSPACE);
     renderdata.alpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_ACTIVE);
@@ -617,7 +672,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     // for plugins
     m_renderData.currentWindow = pWindow;
 
-    Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
 
     const auto fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
 
@@ -629,15 +685,12 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         addPassElement(makeUnique<CRectPassElement>(data));
     }
 
-    renderdata.pos += pWindow->presentation().floatingOffset();
+    renderdata.pos += WINDOWOFFSET;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && PWORKSPACE->m_renderOffset->isBeingAnimated() &&
+    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(PWORKSPACE, pMonitor) &&
         !(pWindow->m_state & WINDOW_STATE_PINNED)) {
-        CRegion rg         = pWindow->getFullWindowBoundingBox()
-                                 .translate(-pMonitor->m_position + PWORKSPACE->m_renderOffset->value() + pWindow->presentation().floatingOffset())
-                                 .scale(pMonitor->m_scale)
-                                 .round();
+        CRegion rg = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
         renderdata.clipBox = rg.getExtents();
     }
 
@@ -730,9 +783,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             passRedirect.reset();
 
             CBox currentBox = pWindow->getFullWindowBoundingBox();
-            currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : PWORKSPACE->m_renderOffset->value()) + pWindow->presentation().floatingOffset() -
-                                 pMonitor->m_position);
-            CBox            transformedBox = pWindow->effects().transformedExtents(currentBox);
+            currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET) + WINDOWOFFSET - pMonitor->m_position);
+            CBox transformedBox = pWindow->effects().transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
             if (!standalone && !m_bRenderingSnapshot) {
@@ -788,17 +840,18 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             if (pWindow->m_ruleApplicator->nearestNeighbor().valueOrDefault())
                 renderdata.useNearestNeighbor = true;
 
-            renderdata.surfaceCounter = 0;
+            renderdata.surfaceCounter  = 0;
+            const auto PARENTFADEALPHA = renderdata.fadeAlpha;
 
             pWindow->popupHead()->breadthfirst(
-                [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
+                [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
                     if (!popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();
                     const Vector2D oldPos = renderdata.pos;
                     renderdata.pos += pos;
-                    renderdata.fadeAlpha = popup->alpha()[POPUP_ALPHA_FADE]->value();
+                    renderdata.fadeAlpha = PARENTFADEALPHA * popup->alpha()[POPUP_ALPHA_FADE]->value();
 
                     popup->wlSurface()->resource()->breadthfirst(
                         [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
@@ -812,7 +865,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                             renderdata.texture     = s->m_current.texture;
                             renderdata.surface     = s;
                             renderdata.mainSurface = false;
-                            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
                             renderdata.surfaceCounter++;
                         },
                         data);
@@ -821,7 +874,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 },
                 &renderdata);
 
-            renderdata.alpha = 1.F;
+            renderdata.fadeAlpha = PARENTFADEALPHA;
+            renderdata.alpha     = 1.F;
         }
 
         if (decorate) {
@@ -834,7 +888,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         }
     }
 
-    Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOW);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOW);
 
     m_renderData.currentWindow.reset();
 }
@@ -1203,15 +1258,25 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         m_renderPass.add(makeUnique<CRectPassElement>(data));
     }
 
-    // special
-    for (auto const& ws : State::workspaceState()->workspaces()) {
-        if (ws->m_alpha->value() <= 0.F || !ws->m_isSpecialWorkspace)
+    std::vector<PHLWORKSPACE> specialWorkspaces;
+    for (const auto& monitor : State::monitorState()->monitors()) {
+        for (const auto& workspace : monitor->m_workspaceTransition->participants(true)) {
+            if (!std::ranges::contains(specialWorkspaces, workspace))
+                specialWorkspaces.emplace_back(workspace);
+        }
+
+        if (monitor->m_activeSpecialWorkspace && !std::ranges::contains(specialWorkspaces, monitor->m_activeSpecialWorkspace))
+            specialWorkspaces.emplace_back(monitor->m_activeSpecialWorkspace);
+    }
+
+    for (const auto& workspace : specialWorkspaces) {
+        if (workspaceRenderAlpha(workspace, pMonitor) <= 0.F)
             continue;
 
-        if (Fullscreen::controller()->hasFullscreen(ws.lock()))
-            renderWorkspaceWindowsFullscreen(pMonitor, ws.lock(), time);
+        if (Fullscreen::controller()->hasFullscreen(workspace))
+            renderWorkspaceWindowsFullscreen(pMonitor, workspace, time);
         else
-            renderWorkspaceWindows(pMonitor, ws.lock(), time);
+            renderWorkspaceWindows(pMonitor, workspace, time);
     }
 
     // pinned always above
@@ -2557,6 +2622,70 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
     renderAllClientsForWorkspace(pMonitor, pWorkspace, now, translate, scale);
 }
 
+bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
+    const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != MONITOR)
+        return false;
+    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+        return false;
+
+    if (!framebuffer->imageDescription())
+        framebuffer->setImageDescription(MONITOR->workBufferImageDescription());
+
+    CRenderPass pass;
+    const auto  OLDRENDERDATA        = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
+    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER  = MONITOR->m_blurFBShouldRender;
+    auto* const OLDPASS              = m_currentPass;
+
+    CScopeGuard restore([&] {
+        m_currentPass                 = OLDPASS;
+        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
+        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
+        MONITOR->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
+        m_renderData                  = OLDRENDERDATA;
+    });
+    auto        framebufferGuard = bindTempFB(framebuffer);
+
+    CRegion     damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
+    m_currentPass                 = &pass;
+    m_isolatedWorkspace           = workspace;
+    m_bBlockSurfaceFeedback       = !sendFeedback;
+    m_bRenderingSnapshot          = true;
+    MONITOR->m_blurFBShouldRender = false;
+    m_renderData.pMonitor         = MONITOR;
+    m_renderData.mainFB           = framebuffer;
+    m_renderData.outFB.reset();
+    m_renderData.fbSize                     = MONITOR->m_transformedSize;
+    m_renderData.damage                     = damage;
+    m_renderData.finalDamage                = damage;
+    m_renderData.renderModif                = {};
+    m_renderData.mouseZoomFactor            = 1.F;
+    m_renderData.mouseZoomUseMouse          = false;
+    m_renderData.transformDamage            = false;
+    m_renderData.noSimplify                 = false;
+    m_renderData.renderingTransformedSource = false;
+    m_renderData.blockScreenShader          = true;
+    m_renderData.currentWindow.reset();
+    m_renderData.surface.reset();
+    m_renderData.clipBox = {};
+    setProjectionType(RPT_EXPORT);
+
+    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    if (Fullscreen::controller()->hasFullscreen(workspace))
+        renderWorkspaceWindowsFullscreen(MONITOR, workspace, Time::steadyNow());
+    else
+        renderWorkspaceWindows(MONITOR, workspace, Time::steadyNow());
+
+    m_currentPass = OLDPASS;
+    pass.render(damage);
+
+    return true;
+}
+
 void IHyprRenderer::sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now) {
     for (const auto& view : Desktop::View::getViewsForWorkspace(pWorkspace)) {
         if (!view->mapped() || !view->acceptsInput() || !view->resource())
@@ -2810,10 +2939,11 @@ void IHyprRenderer::damageSurface(SP<CWLSurfaceResource> pSurface, double x, dou
 }
 
 void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
-    CBox       windowBox        = pWindow->getFullWindowBoundingBox();
-    const auto PWINDOWWORKSPACE = pWindow->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !(pWindow->m_state & WINDOW_STATE_PINNED))
-        windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
+    CBox       windowBox         = pWindow->getFullWindowBoundingBox();
+    const auto PWINDOWWORKSPACE  = pWindow->m_workspace;
+    const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
+    if (PWINDOWWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE) && !(pWindow->m_state & WINDOW_STATE_PINNED))
+        windowBox.translate(PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWINDOWWORKSPACE));
     windowBox.translate(pWindow->presentation().floatingOffset());
     windowBox = pWindow->effects().transformBoxForDamage(windowBox);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2238,7 +2238,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     }
 
     context.mouseZoomFactor = 1.f;
-    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->position()).run())
+    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run())
         context.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
 
     if (pMonitor->m_zoomAnimProgress->value() != 1) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2257,7 +2257,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     }
 
     context.mouseZoomFactor = 1.f;
-    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->position()).run())
+    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run())
         context.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
 
     if (pMonitor->m_zoomAnimProgress->value() != 1) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -32,6 +32,7 @@
 #include "../errorOverlay/Overlay.hpp"
 #include "../debug/Overlay.hpp"
 #include "../notification/NotificationOverlay.hpp"
+#include "../overview/Overview.hpp"
 #include "../layout/LayoutManager.hpp"
 #include "../layout/space/Space.hpp"
 #include "../i18n/Engine.hpp"
@@ -148,7 +149,7 @@ IHyprRenderer::IHyprRenderer() {
 
     // cursor hiding stuff
 
-    static auto P = Event::bus()->m_events.input.keyboard.key.listen([&](IKeyboard::SKeyEvent e, Event::SCallbackInfo&) {
+    static auto P = Event::bus()->m_events.input.keyboard.key.listen([&](IKeyboard::SKeyEvent e, SP<IKeyboard>, Event::SCallbackInfo&) {
         if (m_cursorHiddenConditions.hiddenOnKeyboard)
             return;
 
@@ -239,8 +240,17 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->m_workspace)
         return false;
 
-    if (m_isolatedWorkspace)
-        return !(pWindow->m_state & WINDOW_STATE_PINNED) && pWindow->m_workspace == m_isolatedWorkspace;
+    if (m_isolatedWorkspace) {
+        if (pWindow->m_state & WINDOW_STATE_PINNED)
+            return m_isolatedWorkspaceFullScene;
+
+        if (pWindow->m_workspace == m_isolatedWorkspace)
+            return true;
+
+        const auto WORKSPACE_MONITOR = pWindow->m_workspace->m_monitor.lock();
+        return m_isolatedWorkspaceFullScene && pWindow->onSpecialWorkspace() && WORKSPACE_MONITOR &&
+            (WORKSPACE_MONITOR->m_activeSpecialWorkspace == pWindow->m_workspace || WORKSPACE_MONITOR->m_workspaceTransition->participates(pWindow->m_workspace));
+    }
 
     if (pWindow->m_state & WINDOW_STATE_PINNED)
         return true;
@@ -403,7 +413,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
@@ -425,7 +435,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
@@ -482,7 +492,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
@@ -534,7 +544,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     lastWindow.reset();
 
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
@@ -576,7 +586,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         // render the bad boy
         renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace)
+    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
@@ -845,7 +855,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             pWindow->popupHead()->breadthfirst(
                 [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (!popup->mapped() || !popup->resource() || (!m_isolatedWorkspace && (!popup->acceptsInput() || !popup->alphaNonZero())))
+                    if (!popup->mapped() || !popup->resource() || ((!m_isolatedWorkspace || m_isolatedWorkspaceFullScene) && (!popup->acceptsInput() || !popup->alphaNonZero())))
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();
@@ -1194,7 +1204,8 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         }
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
+        if (!m_isolatedWorkspace)
+            Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
@@ -1222,7 +1233,8 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         }
         renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
+        if (!m_isolatedWorkspace)
+            Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
@@ -1294,7 +1306,8 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
 
-    Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOWS);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOWS);
 
     // Render surfaces above windows for monitor
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
@@ -1591,7 +1604,7 @@ bool IHyprRenderer::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindo
     static auto PBLURNEWOPTIMIZE = CConfigValue<Config::INTEGER>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Config::INTEGER>("decoration:blur:xray");
 
-    if (!getBlurTexture(m_renderData.pMonitor))
+    if (m_isolatedWorkspaceFullScene || !getBlurTexture(m_renderData.pMonitor))
         return false;
 
     if (blurProviderRequiresLiveBlur())
@@ -2623,6 +2636,14 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
 }
 
 bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(workspace, framebuffer, Time::steadyNow(), sendFeedback, false);
+}
+
+bool IHyprRenderer::renderWorkspaceSceneToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(workspace, framebuffer, time, sendFeedback, true);
+}
+
+bool IHyprRenderer::renderWorkspaceToBufferInternal(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != MONITOR)
         return false;
@@ -2633,16 +2654,18 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
         framebuffer->setImageDescription(MONITOR->workBufferImageDescription());
 
     CRenderPass pass;
-    const auto  OLDRENDERDATA        = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
-    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER  = MONITOR->m_blurFBShouldRender;
-    auto* const OLDPASS              = m_currentPass;
+    const auto  OLDRENDERDATA                 = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
+    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
+    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER           = MONITOR->m_blurFBShouldRender;
+    auto* const OLDPASS                       = m_currentPass;
 
     CScopeGuard restore([&] {
         m_currentPass                 = OLDPASS;
         m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
         m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
         m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
         MONITOR->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
@@ -2653,8 +2676,9 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
     CRegion     damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
     m_currentPass                 = &pass;
     m_isolatedWorkspace           = workspace;
+    m_isolatedWorkspaceFullScene  = fullScene;
     m_bBlockSurfaceFeedback       = !sendFeedback;
-    m_bRenderingSnapshot          = true;
+    m_bRenderingSnapshot          = !fullScene;
     MONITOR->m_blurFBShouldRender = false;
     m_renderData.pMonitor         = MONITOR;
     m_renderData.mainFB           = framebuffer;
@@ -2675,10 +2699,15 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
     setProjectionType(RPT_EXPORT);
 
     addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
-    if (Fullscreen::controller()->hasFullscreen(workspace))
-        renderWorkspaceWindowsFullscreen(MONITOR, workspace, Time::steadyNow());
+    if (fullScene) {
+        renderAllClientsForWorkspace(MONITOR, workspace, time);
+        const CBox renderBox = {{}, MONITOR->m_transformedSize};
+        renderLockscreen(MONITOR, time, renderBox);
+        renderIME(MONITOR, time, renderBox);
+    } else if (Fullscreen::controller()->hasFullscreen(workspace))
+        renderWorkspaceWindowsFullscreen(MONITOR, workspace, time);
     else
-        renderWorkspaceWindows(MONITOR, workspace, Time::steadyNow());
+        renderWorkspaceWindows(MONITOR, workspace, time);
 
     m_currentPass = OLDPASS;
     pass.render(damage);
@@ -2696,16 +2725,18 @@ bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> f
         framebuffer->setImageDescription(monitor->workBufferImageDescription());
 
     CRenderPass pass;
-    const auto  OLDRENDERDATA        = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
-    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER  = monitor->m_blurFBShouldRender;
-    auto* const OLDPASS              = m_currentPass;
+    const auto  OLDRENDERDATA                 = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
+    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
+    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER           = monitor->m_blurFBShouldRender;
+    auto* const OLDPASS                       = m_currentPass;
 
     CScopeGuard restore([&] {
         m_currentPass                 = OLDPASS;
         m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
         m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
         m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
         monitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
@@ -2716,10 +2747,11 @@ bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> f
     CRegion     damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
     m_currentPass = &pass;
     m_isolatedWorkspace.reset();
-    m_bBlockSurfaceFeedback = !sendFeedback;
-    m_bRenderingSnapshot    = false;
-    m_renderData.pMonitor   = monitor;
-    m_renderData.mainFB     = framebuffer;
+    m_isolatedWorkspaceFullScene = false;
+    m_bBlockSurfaceFeedback      = !sendFeedback;
+    m_bRenderingSnapshot         = false;
+    m_renderData.pMonitor        = monitor;
+    m_renderData.mainFB          = framebuffer;
     m_renderData.outFB.reset();
     m_renderData.fbSize                     = monitor->m_transformedSize;
     m_renderData.damage                     = damage;
@@ -3006,8 +3038,9 @@ void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
     windowBox.translate(pWindow->presentation().floatingOffset());
     windowBox = pWindow->effects().transformBoxForDamage(windowBox);
 
+    const bool OVERVIEW_SELECTED = Overview::overview()->shouldRenderWorkspace(PWINDOWWORKSPACE);
     for (auto const& m : State::monitorState()->monitors()) {
-        if (forceFull || shouldRenderWindow(pWindow, m)) { // only damage if window is rendered on monitor
+        if (forceFull || shouldRenderWindow(pWindow, m) || (OVERVIEW_SELECTED && m == PWORKSPACEMONITOR)) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->m_position.x, windowBox.y - m->m_position.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->m_scale).round();
             m->addDamage(fixedDamageBox);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -50,6 +50,7 @@
 #include "pass/RendererHintsPassElement.hpp"
 #include "pass/SurfacePassElement.hpp"
 #include "pass/BackdropScopePassElement.hpp"
+#include "scene/Scene.hpp"
 #include "../debug/log/Logger.hpp"
 #include "../protocols/ColorManagement.hpp"
 #include "../protocols/types/ContentType.hpp"
@@ -2226,48 +2227,35 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     Event::bus()->m_events.render.stage.emit(RENDER_BEGIN);
 
-    bool renderCursor = true;
+    bool renderCursor = !pMonitor->isMirror();
 
     if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
-        if (pMonitor->isMirror()) {
-            blend(false);
-            renderMirrored();
-            blend(true);
-            Event::bus()->m_events.render.stage.emit(RENDER_POST_MIRROR);
-            renderCursor = false;
-        } else {
-            CBox renderBox = {0, 0, sc<int>(pMonitor->m_transformedSize.x), sc<int>(pMonitor->m_transformedSize.y)};
-            renderWorkspace(pMonitor, pMonitor->m_activeWorkspace, NOW, renderBox);
-            renderLockscreen(pMonitor, NOW, renderBox);
+        pMonitor->resources()->m_sceneStack.current()->draw(NOW);
 
-            // render IME even above the lockscreen - allow the user to use it to potentially input stuff on it.
-            renderIME(pMonitor, NOW, renderBox);
+        if (pMonitor == Desktop::focusState()->monitor()) {
+            Notification::overlay()->draw(pMonitor);
+            ErrorOverlay::overlay()->draw();
+        }
 
-            if (pMonitor == Desktop::focusState()->monitor()) {
-                Notification::overlay()->draw(pMonitor);
-                ErrorOverlay::overlay()->draw();
-            }
+        // for drawing the debug overlay
+        if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
+            renderStartOverlay = std::chrono::high_resolution_clock::now();
+            Debug::overlay()->draw();
+            endRenderOverlay = std::chrono::high_resolution_clock::now();
+        }
 
-            // for drawing the debug overlay
-            if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
-                renderStartOverlay = std::chrono::high_resolution_clock::now();
-                Debug::overlay()->draw();
-                endRenderOverlay = std::chrono::high_resolution_clock::now();
-            }
-
-            if (*PDAMAGEBLINK && damageBlinkCleanup == 0) {
-                CRectPassElement::SRectData data;
-                data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
-                data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-                m_renderPass.add(makeUnique<CRectPassElement>(data));
-                damageBlinkCleanup = 1;
-            } else if (*PDAMAGEBLINK) {
-                damageBlinkCleanup++;
-                if (damageBlinkCleanup > 3)
-                    damageBlinkCleanup = 0;
-            }
+        if (*PDAMAGEBLINK && damageBlinkCleanup == 0) {
+            CRectPassElement::SRectData data;
+            data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
+            data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
+            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            damageBlinkCleanup = 1;
+        } else if (*PDAMAGEBLINK) {
+            damageBlinkCleanup++;
+            if (damageBlinkCleanup > 3)
+                damageBlinkCleanup = 0;
         }
     } else if (!pMonitor->isMirror()) {
         if (pMonitor->m_activeWorkspace)

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1006,7 +1006,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pLayer->alpha()[LS_ALPHA_FADE]->value());
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     TRACY_GPU_ZONE("RenderLayer");
@@ -1043,7 +1043,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = s->m_current.texture;
                 renderdata.surface     = s;
                 renderdata.mainSurface = s == pLayer->wlSurface()->resource();
-                m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -1078,7 +1078,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = SURF->m_current.texture;
                 renderdata.surface     = SURF;
                 renderdata.mainSurface = false;
-                m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -1119,7 +1119,7 @@ void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, con
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == SURF;
-            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
@@ -1149,7 +1149,7 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == pSurface->surface->surface();
-            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
@@ -1176,11 +1176,11 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
     CScopeGuard x([&RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
@@ -1232,7 +1232,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
 
     // pre window pass
     if (preBlurQueued(pMonitor))
-        m_renderPass.add(makeUnique<CPreBlurElement>());
+        addPassElement(makeUnique<CPreBlurElement>());
 
     if UNLIKELY /* subjective? */ (Fullscreen::controller()->hasFullscreen(pWorkspace))
         renderWorkspaceWindowsFullscreen(pMonitor, pWorkspace, time);
@@ -1245,7 +1245,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
         data.color = CHyprColor(0, 0, 0, pMonitor->m_specialDim->value());
 
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     if UNLIKELY (pMonitor->m_specialBlur->value() != 0.F) {
@@ -1255,7 +1255,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.blur  = true;
         data.blurA = pMonitor->m_specialBlur->value();
 
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     std::vector<PHLWORKSPACE> specialWorkspaces;
@@ -1336,11 +1336,11 @@ void IHyprRenderer::renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, c
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
     CScopeGuard x([&RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
@@ -1436,7 +1436,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
     static auto PNOSPLASH        = CConfigValue<Config::INTEGER>("misc:disable_splash_rendering");
 
     if (*PRENDERTEX /* inverted cfg flag */ || pMonitor->m_backgroundOpacity->isBeingAnimated())
-        m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+        addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
     if (!*PRENDERTEX) {
         static auto PBACKGROUNDCOLOR = CConfigValue<Config::INTEGER>("misc:background_color");
@@ -1445,7 +1445,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             pMonitor->m_background = getBackground(pMonitor);
 
         if (!pMonitor->m_background)
-            m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+            addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
         else {
             CTexPassElement::SRenderData data;
             const double                 MONRATIO = m_renderData.pMonitor->m_transformedSize.x / m_renderData.pMonitor->m_transformedSize.y;
@@ -1462,12 +1462,12 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             }
 
             if (MONRATIO != WPRATIO)
-                m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+                addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
             data.box = {origin, pMonitor->m_background->m_size * scale};
             data.a   = m_renderData.pMonitor->m_backgroundOpacity->value();
             data.tex = pMonitor->m_background;
-            m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 
@@ -1481,7 +1481,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             CTexPassElement::SRenderData data;
             data.box = {{(monitorSize.x - pMonitor->m_splash->m_size.x) / 2.0, monitorSize.y * 0.98 - pMonitor->m_splash->m_size.y}, pMonitor->m_splash->m_size};
             data.tex = pMonitor->m_splash;
-            m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 }
@@ -1777,7 +1777,7 @@ void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
     data.color = CHyprColor(0, 0, 0, 1.f);
     data.box   = CBox{{}, pMonitor->m_transformedSize};
 
-    m_renderPass.add(makeUnique<CRectPassElement>(data));
+    addPassElement(makeUnique<CRectPassElement>(data));
 }
 
 void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
@@ -1797,7 +1797,7 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
     data.box = monbox;
     data.a   = 1;
 
-    m_renderPass.add(makeUnique<CTexPassElement>(data));
+    addPassElement(makeUnique<CTexPassElement>(data));
 
     if (!ANY_PRESENT && m_lockTtyTextTexture) {
         // also render text for the tty number
@@ -1805,7 +1805,7 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
         data.tex    = m_lockTtyTextTexture;
         data.box    = texbox;
 
-        m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 
@@ -2117,13 +2117,13 @@ void IHyprRenderer::renderMirrored() {
 
     const auto MIRROR_TEX = mirrored->resources()->getMirrorTexture();
 
-    m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
 
     CTexPassElement::SRenderData data;
     data.tex = MIRROR_TEX;
     data.box = monbox;
 
-    m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+    addPassElement(makeUnique<CTexPassElement>(std::move(data)));
 }
 
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
@@ -2256,7 +2256,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     // if we have no tracking or full tracking, invalidate the entire monitor
     if (*PDAMAGETRACKINGMODE == DAMAGE_TRACKING_NONE || *PDAMAGETRACKINGMODE == DAMAGE_TRACKING_MONITOR || pMonitor->m_forceFullFrames > 0 || damageBlinkCleanup > 0 ||
-        ZOOM_DAMAGE_ENTIRE)
+        ZOOM_DAMAGE_ENTIRE || pMonitor->resources()->m_sceneStack.hasOverride())
         damage = {0, 0, sc<int>(pMonitor->m_transformedSize.x) * 10, sc<int>(pMonitor->m_transformedSize.y) * 10};
 
     finalDamage = damage;
@@ -2274,7 +2274,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     bool renderCursor = !pMonitor->isMirror();
 
-    if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
+    if (pMonitor->m_solitaryClient && !pMonitor->resources()->m_sceneStack.hasOverride() && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
         pMonitor->resources()->m_sceneStack.current()->draw(NOW);
@@ -2295,7 +2295,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             CRectPassElement::SRectData data;
             data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
             data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            addPassElement(makeUnique<CRectPassElement>(data));
             damageBlinkCleanup = 1;
         } else if (*PDAMAGEBLINK) {
             damageBlinkCleanup++;
@@ -2321,7 +2321,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = Colors::BLACK.modifyA(pMonitor->m_dpmsBlackOpacity->value());
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     Event::bus()->m_events.render.stage.emit(RENDER_LAST_MOMENT);
@@ -2679,6 +2679,65 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
         renderWorkspaceWindowsFullscreen(MONITOR, workspace, Time::steadyNow());
     else
         renderWorkspaceWindows(MONITOR, workspace, Time::steadyNow());
+
+    m_currentPass = OLDPASS;
+    pass.render(damage);
+
+    return true;
+}
+
+bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    if (!monitor || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != monitor->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != monitor)
+        return false;
+    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+        return false;
+
+    if (!framebuffer->imageDescription())
+        framebuffer->setImageDescription(monitor->workBufferImageDescription());
+
+    CRenderPass pass;
+    const auto  OLDRENDERDATA        = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
+    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER  = monitor->m_blurFBShouldRender;
+    auto* const OLDPASS              = m_currentPass;
+
+    CScopeGuard restore([&] {
+        m_currentPass                 = OLDPASS;
+        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
+        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
+        monitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
+        m_renderData                  = OLDRENDERDATA;
+    });
+    auto        framebufferGuard = bindTempFB(framebuffer);
+
+    CRegion     damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
+    m_currentPass = &pass;
+    m_isolatedWorkspace.reset();
+    m_bBlockSurfaceFeedback = !sendFeedback;
+    m_bRenderingSnapshot    = false;
+    m_renderData.pMonitor   = monitor;
+    m_renderData.mainFB     = framebuffer;
+    m_renderData.outFB.reset();
+    m_renderData.fbSize                     = monitor->m_transformedSize;
+    m_renderData.damage                     = damage;
+    m_renderData.finalDamage                = damage;
+    m_renderData.renderModif                = {};
+    m_renderData.mouseZoomFactor            = 1.F;
+    m_renderData.mouseZoomUseMouse          = false;
+    m_renderData.transformDamage            = false;
+    m_renderData.noSimplify                 = false;
+    m_renderData.renderingTransformedSource = false;
+    m_renderData.blockScreenShader          = true;
+    m_renderData.currentWindow.reset();
+    m_renderData.surface.reset();
+    m_renderData.clipBox = {};
+    setProjectionType(RPT_EXPORT);
+
+    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    CMonitorScene{monitor}.draw(time);
 
     m_currentPass = OLDPASS;
     pass.render(damage);
@@ -3395,7 +3454,7 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = false;
-            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         nullptr);
@@ -3435,7 +3494,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             CRectPassElement::SRectData data;
             data.box   = {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y};
             data.color = CHyprColor(0, 0, 0, EFFECTS.dimAroundAlpha);
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            addPassElement(makeUnique<CRectPassElement>(data));
         }
 
         if (EFFECTS.preBlur) {
@@ -3447,7 +3506,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             data.round         = EFFECTS.preBlur->round;
             data.roundingPower = EFFECTS.preBlur->roundingPower;
             data.xray          = EFFECTS.preBlur->xray;
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            addPassElement(makeUnique<CRectPassElement>(data));
         }
 
         CTexPassElement::SRenderData data;
@@ -3462,7 +3521,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
         data.ignoreAlpha           = EFFECTS.textureBlur.ignoreAlpha;
         data.blockBlurOptimization = EFFECTS.textureBlur.blockBlurOptimization;
 
-        m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2633,7 +2633,7 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
                                                     bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     auto&      parent  = context;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB || parent.sceneMonitor != MONITOR)
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB)
         return false;
     if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -691,7 +691,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     // if window is floating and we have a slide animation, clip it to its full bb
     if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(PWORKSPACE, pMonitor) &&
         !(pWindow->m_state & WINDOW_STATE_PINNED)) {
-        CRegion rg = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
+        CRegion rg         = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
         renderdata.clipBox = rg.getExtents();
     }
 
@@ -785,7 +785,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             CBox currentBox = pWindow->getFullWindowBoundingBox();
             currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET) + WINDOWOFFSET - pMonitor->m_position);
-            CBox transformedBox = pWindow->effects().transformedExtents(currentBox);
+            CBox            transformedBox = pWindow->effects().transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
             if (!standalone && !m_bRenderingSnapshot) {
@@ -846,7 +846,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             pWindow->popupHead()->breadthfirst(
                 [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (!popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
+                    if (!popup->mapped() || !popup->resource() || (!m_isolatedWorkspace && (!popup->acceptsInput() || !popup->alphaNonZero())))
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -233,39 +233,22 @@ WP<Render::GL::CHyprOpenGLImpl> IHyprRenderer::glBackend() {
     return Render::GL::g_pHyprOpenGL;
 }
 
-bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
-    if (!pWindow->presentation().visibleOnMonitor(pMonitor))
+static bool shouldRenderWindowOnMonitor(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
+    if (!pWindow->presentation().visibleOnMonitor(pMonitor) || !pWindow->m_workspace)
         return false;
-
-    if (!pWindow->m_workspace)
-        return false;
-
-    if (m_isolatedWorkspace) {
-        if (pWindow->m_state & WINDOW_STATE_PINNED)
-            return m_isolatedWorkspaceFullScene;
-
-        if (pWindow->m_workspace == m_isolatedWorkspace)
-            return true;
-
-        const auto WORKSPACE_MONITOR = pWindow->m_workspace->m_monitor.lock();
-        return m_isolatedWorkspaceFullScene && pWindow->onSpecialWorkspace() && WORKSPACE_MONITOR &&
-            (WORKSPACE_MONITOR->m_activeSpecialWorkspace == pWindow->m_workspace || WORKSPACE_MONITOR->m_workspaceTransition->participates(pWindow->m_workspace));
-    }
 
     if (pWindow->m_state & WINDOW_STATE_PINNED)
         return true;
 
-    // if the window is being moved to a workspace that is not invisible, and the alpha is > 0.F, render it.
     if (pWindow->presentation().movingFromMonitor() && pWindow->presentation().alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE)->isBeingAnimated() &&
-        pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) > 0.F && pWindow->m_workspace && !pWindow->m_workspace->isVisible())
+        pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) > 0.F && !pWindow->m_workspace->isVisible())
         return true;
 
     const auto PWINDOWWORKSPACE = pWindow->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_monitor == pMonitor) {
+    if (PWINDOWWORKSPACE->m_monitor == pMonitor) {
         if (pMonitor->m_workspaceTransition->participates(PWINDOWWORKSPACE))
             return true;
 
-        // if hidden behind fullscreen
         if (Fullscreen::controller()->hasFullscreen(PWINDOWWORKSPACE) && !pWindow->isAllowedOverFullscreen() &&
             pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) == 0)
             return false;
@@ -277,28 +260,25 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (pWindow->m_monitor == pMonitor)
         return true;
 
-    if ((!pWindow->m_workspace || !pWindow->m_workspace->isVisible()) && pWindow->m_monitor != pMonitor)
+    if (!pWindow->m_workspace->isVisible() && pWindow->m_monitor != pMonitor)
         return false;
 
-    // if not, check if it maybe is active on a different monitor.
-    if (pWindow->m_workspace && pWindow->m_workspace->isVisible() && pWindow->isFloating() /* tiled windows can't be multi-ws */)
-        return !Fullscreen::controller()->isFullscreen(pWindow); // Do not draw fullscreen windows on other monitors
+    if (pWindow->m_workspace->isVisible() && pWindow->isFloating())
+        return !Fullscreen::controller()->isFullscreen(pWindow);
 
     if (pMonitor->m_activeSpecialWorkspace == pWindow->m_workspace)
         return true;
 
-    // if window is tiled and it's flying in, don't render on other mons (for slide)
     if (!pWindow->isFloating() && pWindow->positionAnimation()->isBeingAnimated() && pWindow->presentation().animatingIn() && pWindow->m_monitor != pMonitor)
         return false;
 
     if (pWindow->positionAnimation()->isBeingAnimated()) {
-        const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
-        if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
+        const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE->m_monitor.lock();
+        if (!PWINDOWWORKSPACE->m_isSpecialWorkspace && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
             return false;
-        // render window if window and monitor intersect
-        // (when moving out of or through a monitor)
+
         CBox windowBox = pWindow->getFullWindowBoundingBox();
-        if (PWINDOWWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
+        if (PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
             windowBox.translate(PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWINDOWWORKSPACE));
         windowBox.translate(pWindow->presentation().floatingOffset());
 
@@ -308,6 +288,32 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     }
 
     return false;
+}
+
+bool IHyprRenderer::shouldRenderWindow(const CRenderingContext& context, PHLWINDOW pWindow, PHLMONITOR pMonitor) {
+    if (!pWindow->presentation().visibleOnMonitor(pMonitor))
+        return false;
+
+    if (!pWindow->m_workspace)
+        return false;
+
+    if (context.isolatedWorkspace) {
+        if (pWindow->m_state & WINDOW_STATE_PINNED)
+            return context.isolatedWorkspaceFullScene;
+
+        if (pWindow->m_workspace == context.isolatedWorkspace)
+            return true;
+
+        const auto WORKSPACE_MONITOR = pWindow->m_workspace->m_monitor.lock();
+        return context.isolatedWorkspaceFullScene && pWindow->onSpecialWorkspace() && WORKSPACE_MONITOR &&
+            (WORKSPACE_MONITOR->m_activeSpecialWorkspace == pWindow->m_workspace || WORKSPACE_MONITOR->m_workspaceTransition->participates(pWindow->m_workspace));
+    }
+
+    return shouldRenderWindowOnMonitor(pWindow, pMonitor);
+}
+
+bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
+    return shouldRenderWindowOnMonitor(pWindow, pMonitor);
 }
 
 bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
@@ -339,36 +345,36 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     return false;
 }
 
-float IHyprRenderer::workspaceRenderAlpha(PHLWORKSPACE workspace, PHLMONITOR) const {
-    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+float IHyprRenderer::workspaceRenderAlpha(const CRenderingContext& context, PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (context.isolatedWorkspace && workspace == context.isolatedWorkspace))
         return 1.F;
 
     const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
     return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->alphaValue(workspace) : 1.F;
 }
 
-Vector2D IHyprRenderer::workspaceRenderOffset(PHLWORKSPACE workspace, PHLMONITOR) const {
-    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+Vector2D IHyprRenderer::workspaceRenderOffset(const CRenderingContext& context, PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (context.isolatedWorkspace && workspace == context.isolatedWorkspace))
         return {};
 
     const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
     return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->offsetValue(workspace) : Vector2D{};
 }
 
-bool IHyprRenderer::workspaceRenderIsAnimating(PHLWORKSPACE workspace, PHLMONITOR) const {
-    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+bool IHyprRenderer::workspaceRenderIsAnimating(const CRenderingContext& context, PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (context.isolatedWorkspace && workspace == context.isolatedWorkspace))
         return false;
 
     const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
     return WORKSPACEMONITOR && WORKSPACEMONITOR->m_workspaceTransition->isAnimating(workspace);
 }
 
-Vector2D IHyprRenderer::windowRenderFloatingOffset(PHLWINDOW window) const {
-    return window && !(m_isolatedWorkspace && window->m_workspace == m_isolatedWorkspace) ? window->presentation().floatingOffset() : Vector2D{};
+Vector2D IHyprRenderer::windowRenderFloatingOffset(const CRenderingContext& context, PHLWINDOW window) const {
+    return window && !(context.isolatedWorkspace && window->m_workspace == context.isolatedWorkspace) ? window->presentation().floatingOffset() : Vector2D{};
 }
 
-bool IHyprRenderer::renderingWorkspaceToBuffer() const {
-    return !!m_isolatedWorkspace;
+bool IHyprRenderer::renderingWorkspaceToBuffer(const CRenderingContext& context) const {
+    return !!context.isolatedWorkspace;
 }
 
 bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
@@ -381,17 +387,17 @@ bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
     return true;
 }
 
-void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
+void IHyprRenderer::renderWorkspaceWindowsFullscreen(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW pWorkspaceWindow = nullptr;
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     // pre-filter renderable windows once for the tiled + floating passes
     std::vector<PHLWINDOW> windows;
     windows.reserve(Desktop::windowState()->windows().size());
     for (auto const& w : Desktop::windowState()->windows()) {
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         if (w->presentation().alphaValue(WINDOW_ALPHA_FADE) * w->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) == 0.f)
@@ -411,10 +417,10 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
     for (auto const& w : windows) {
@@ -430,13 +436,13 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (w->isFadingOutUnderFullscreen())
             continue; // render these over fullscreen so the fade-out is visible
 
-        if (m_isolatedWorkspace && w->shouldRenderOverFullscreen())
+        if (context.isolatedWorkspace && w->shouldRenderOverFullscreen())
             continue;
 
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
     for (auto const& w : Desktop::windowState()->windows()) {
@@ -457,8 +463,8 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        if (shouldRenderWindow(w, pMonitor))
-            renderWindow(w, pMonitor, time, Fullscreen::controller()->getFullscreenModes(pWorkspace).internal != Fullscreen::FSMODE_FULLSCREEN, RENDER_PASS_ALL);
+        if (shouldRenderWindow(context, w, pMonitor))
+            renderWindow(context, w, pMonitor, time, Fullscreen::controller()->getFullscreenModes(pWorkspace).internal != Fullscreen::FSMODE_FULLSCREEN, RENDER_PASS_ALL);
 
         if (w->m_workspace != pWorkspace)
             continue;
@@ -477,7 +483,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (shouldSkipWindow)
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         const bool mismatchedSpecialWorkspace = w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace();
@@ -490,16 +496,16 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (specialWorkspaceOnDifferentMonitor)
             continue; // special on another are rendered as a part of the base pass
 
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
-void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
+void IHyprRenderer::renderWorkspaceWindows(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW lastWindow;
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     std::vector<PHLWINDOWREF> windows;
@@ -511,7 +517,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (isNotRenderable)
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         windows.emplace_back(w);
@@ -535,17 +541,17 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         }
 
         // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
+        renderWindow(context, w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
         w.reset();
     }
 
     if (lastWindow)
-        renderWindow(lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
+        renderWindow(context, lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
 
     lastWindow.reset();
 
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
     for (auto& w : windows) {
@@ -562,7 +568,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
             continue;
 
         // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
+        renderWindow(context, w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
         w.reset();
     }
 
@@ -584,36 +590,27 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
             continue; // special on another are rendered as a part of the base pass
 
         // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
-void IHyprRenderer::bindOffMain() {
-    bindFB(m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
-    draw(CClearPassElement::SClearData{{0, 0, 0, 0}});
+void IHyprRenderer::bindOffMain(CRenderingContext& context) {
+    bindFB(context, context.sceneMonitor->resources()->getUnusedWorkBuffer());
+    draw(context, CClearPassElement::SClearData{{0, 0, 0, 0}});
 }
 
-void IHyprRenderer::bindBackOnMain() {
-    bindFB(m_renderData.mainFB);
+void IHyprRenderer::bindBackOnMain(CRenderingContext& context) {
+    bindFB(context, context.mainFB);
 }
 
-void IHyprRenderer::addPassElement(UP<IPassElement>&& element) {
-    currentPass().add(std::move(element));
+void IHyprRenderer::addPassElement(CRenderingContext& context, UP<IPassElement>&& element) {
+    context.renderPass().add(std::move(element));
 }
 
-CRenderPass& IHyprRenderer::currentPass() {
-    return m_currentPass ? *m_currentPass : m_renderPass;
-}
-
-UP<CScopeGuard> IHyprRenderer::redirectPass(CRenderPass* pass) {
-    const auto oldPass = m_currentPass;
-    m_currentPass      = pass;
-    return makeUnique<CScopeGuard>([this, oldPass] { m_currentPass = oldPass; });
-}
-
-void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const Time::steady_tp& time, bool decorate, eRenderPassMode mode, bool ignorePosition, bool standalone) {
+void IHyprRenderer::renderWindow(CRenderingContext& context, PHLWINDOW pWindow, PHLMONITOR pMonitor, const Time::steady_tp& time, bool decorate, eRenderPassMode mode,
+                                 bool ignorePosition, bool standalone) {
     if (pWindow->isHidden() && !standalone)
         return;
 
@@ -626,8 +623,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     TRACY_GPU_ZONE("RenderWindow");
 
     const auto  PWORKSPACE      = pWindow->m_workspace;
-    const auto  WORKSPACEOFFSET = workspaceRenderOffset(PWORKSPACE, pMonitor);
-    const auto  WINDOWOFFSET    = windowRenderFloatingOffset(pWindow);
+    const auto  WORKSPACEOFFSET = workspaceRenderOffset(context, PWORKSPACE, pMonitor);
+    const auto  WINDOWOFFSET    = windowRenderFloatingOffset(context, pWindow);
     const auto  REALPOS         = pWindow->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + ((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET);
     static auto PDIMAROUND      = CConfigValue<Config::FLOAT>("decoration:dim_around");
 
@@ -657,7 +654,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.dontRound = Fullscreen::controller()->getFullscreenModes(pWindow).internal == Fullscreen::FSMODE_FULLSCREEN;
     renderdata.fadeAlpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) *
         pWindow->presentation().alphaValue(WINDOW_ALPHA_LAYOUT) *
-        ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : workspaceRenderAlpha(PWORKSPACE, pMonitor)) *
+        ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : workspaceRenderAlpha(context, PWORKSPACE, pMonitor)) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) : 1.F) *
         pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_FROM_WORKSPACE);
     renderdata.alpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_ACTIVE);
@@ -665,7 +662,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         decorate && !pWindow->backend().traits().suggestsNoBorder && Fullscreen::controller()->getFullscreenModes(pWindow).internal != Fullscreen::FSMODE_FULLSCREEN;
     renderdata.rounding      = standalone || renderdata.dontRound ? 0 : pWindow->presentation().rounding() * pMonitor->m_scale;
     renderdata.roundingPower = standalone || renderdata.dontRound ? 2.0f : pWindow->presentation().roundingPower();
-    renderdata.blur          = !standalone && !m_bRenderingSnapshot && pWindow->shouldBlur();
+    renderdata.blur          = !standalone && shouldBlur(context, pWindow);
     renderdata.pWindow       = pWindow;
 
     if (standalone) {
@@ -680,25 +677,25 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.pWindow = pWindow;
 
     // for plugins
-    m_renderData.currentWindow = pWindow;
+    context.currentWindow = pWindow;
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
 
     const auto fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
 
-    if (*PDIMAROUND && pWindow->m_ruleApplicator->dimAround().valueOrDefault() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
-        CBox                        monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+    if (*PDIMAROUND && pWindow->m_ruleApplicator->dimAround().valueOrDefault() && !context.renderingSnapshot && mode != RENDER_PASS_POPUP) {
+        CBox                        monbox = {0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y};
         CRectPassElement::SRectData data;
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * fullAlpha);
         data.box   = monbox;
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     renderdata.pos += WINDOWOFFSET;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(PWORKSPACE, pMonitor) &&
+    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(context, PWORKSPACE, pMonitor) &&
         !(pWindow->m_state & WINDOW_STATE_PINNED)) {
         CRegion rg         = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
         renderdata.clipBox = rg.getExtents();
@@ -707,21 +704,23 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     // render window decorations first, if not fullscreen full
     if (mode == RENDER_PASS_ALL || mode == RENDER_PASS_MAIN) {
 
-        const bool      TRANSFORMEDWINDOW = pWindow->effects().hasActiveTransformers();
-        UP<CRenderPass> transformedPass;
-        UP<CScopeGuard> passRedirect;
-        const bool      windowBlur         = renderdata.blur;
-        const bool      windowBlurUsesLive = windowBlur && !shouldUseNewBlurOptimizations(nullptr, pWindow);
-        const auto      backdropScope      = makeShared<SBackdropScope>();
+        const bool                       TRANSFORMEDWINDOW = pWindow->effects().hasActiveTransformers();
+        UP<CRenderPass>                  transformedPass;
+        std::optional<CRenderingContext> transformedContext;
+        CRenderingContext*               elementContext     = &context;
+        const bool                       windowBlur         = renderdata.blur;
+        const bool                       windowBlurUsesLive = windowBlur && !shouldUseNewBlurOptimizations(context, nullptr, pWindow);
+        const auto                       backdropScope      = makeShared<SBackdropScope>();
 
-        addPassElement(makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::BEGIN, backdropScope));
+        addPassElement(context, makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::BEGIN, backdropScope));
 
         if (TRANSFORMEDWINDOW) {
             transformedPass = makeUnique<CRenderPass>();
-            passRedirect    = redirectPass(transformedPass.get());
+            transformedContext.emplace(context, *transformedPass);
+            elementContext  = &*transformedContext;
             renderdata.blur = false;
 
-            pWindow->effects().preWindowRender(&renderdata);
+            pWindow->effects().preWindowRender(*elementContext, &renderdata);
         }
 
         if (renderdata.decorate) {
@@ -729,14 +728,14 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 if (wd->getDecorationLayer() != DECORATION_LAYER_BOTTOM)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(*elementContext, pMonitor, fullAlpha);
             }
 
             for (auto const& wd : pWindow->presentation().decorations()) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_UNDER)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(*elementContext, pMonitor, fullAlpha);
             }
         }
 
@@ -753,16 +752,16 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             data.round          = renderdata.dontRound ? 0 : renderdata.rounding - 1;
             data.blur           = true;
             data.blurA          = renderdata.fadeAlpha;
-            data.xray           = shouldUseNewBlurOptimizations(nullptr, pWindow);
+            data.xray           = shouldUseNewBlurOptimizations(context, nullptr, pWindow);
             data.blurPatternBox = wb;
             data.blurOwner      = pWindow;
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(*elementContext, makeUnique<CRectPassElement>(data));
             renderdata.blur = false;
         }
 
         renderdata.surfaceCounter = 0;
         pWindow->wlSurface()->resource()->breadthfirst(
-            [this, &renderdata, &pWindow](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+            [this, &renderdata, &pWindow, elementContext](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 if (!s->m_current.texture)
                     return;
 
@@ -773,7 +772,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 renderdata.texture     = s->m_current.texture;
                 renderdata.surface     = s;
                 renderdata.mainSurface = s == pWindow->wlSurface()->resource();
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(*elementContext, makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             nullptr);
@@ -785,48 +784,47 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVER)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(*elementContext, pMonitor, fullAlpha);
             }
         }
 
         if (TRANSFORMEDWINDOW) {
-            passRedirect.reset();
-
             CBox currentBox = pWindow->getFullWindowBoundingBox();
             currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET) + WINDOWOFFSET - pMonitor->m_position);
             CBox            transformedBox = pWindow->effects().transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
-            if (!standalone && !m_bRenderingSnapshot) {
-                pWindow->effects().amendTransformedRenderData(transformedBox, &windowMotionBlur);
+            if (!standalone && !context.renderingSnapshot) {
+                pWindow->effects().amendTransformedRenderData(context, transformedBox, &windowMotionBlur);
             }
 
             CBox blurBox = {renderdata.pos.x - pMonitor->m_position.x, renderdata.pos.y - pMonitor->m_position.y, renderdata.w, renderdata.h};
             blurBox.scale(pMonitor->m_scale).round();
 
-            addPassElement(makeUnique<CTransformedWindowPassElement>(CTransformedWindowPassElement::SData{
-                .pass              = std::move(transformedPass),
-                .window            = pWindow,
-                .currentBox        = currentBox,
-                .blurBox           = blurBox,
-                .blur              = windowBlur,
-                .blurUsesLive      = windowBlurUsesLive,
-                .blurA             = renderdata.fadeAlpha,
-                .blurRound         = renderdata.dontRound ? 0 : std::max(renderdata.rounding - 1, 0),
-                .blurRoundingPower = renderdata.roundingPower,
-                .transformedBox    = transformedBox,
-                .motionBlur        = windowMotionBlur,
-                .standalone        = standalone,
-                .renderingSnapshot = m_bRenderingSnapshot,
-            }));
+            addPassElement(context,
+                           makeUnique<CTransformedWindowPassElement>(CTransformedWindowPassElement::SData{
+                               .pass              = std::move(transformedPass),
+                               .window            = pWindow,
+                               .currentBox        = currentBox,
+                               .blurBox           = blurBox,
+                               .blur              = windowBlur,
+                               .blurUsesLive      = windowBlurUsesLive,
+                               .blurA             = renderdata.fadeAlpha,
+                               .blurRound         = renderdata.dontRound ? 0 : std::max(renderdata.rounding - 1, 0),
+                               .blurRoundingPower = renderdata.roundingPower,
+                               .transformedBox    = transformedBox,
+                               .motionBlur        = windowMotionBlur,
+                               .standalone        = standalone,
+                               .renderingSnapshot = context.renderingSnapshot,
+                           }));
 
             renderdata.blur = windowBlur;
         }
 
-        addPassElement(makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::END, backdropScope));
+        addPassElement(context, makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::END, backdropScope));
     }
 
-    m_renderData.clipBox = CBox();
+    context.clipBox = CBox();
 
     if (mode == RENDER_PASS_ALL || mode == RENDER_PASS_POPUP) {
         if (!pWindow->backend().isX11()) {
@@ -840,7 +838,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
 
-            renderdata.blur = !m_bRenderingSnapshot && pWindow->popupHead()->shouldBlur();
+            renderdata.blur = (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene) && shouldBlur(context, pWindow->popupHead());
 
             if (renderdata.blur) {
                 renderdata.discardMode |= DISCARD_ALPHA;
@@ -854,8 +852,9 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             const auto PARENTFADEALPHA = renderdata.fadeAlpha;
 
             pWindow->popupHead()->breadthfirst(
-                [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (!popup->mapped() || !popup->resource() || ((!m_isolatedWorkspace || m_isolatedWorkspaceFullScene) && (!popup->acceptsInput() || !popup->alphaNonZero())))
+                [this, &context, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
+                    if (!popup->mapped() || !popup->resource() ||
+                        ((!context.isolatedWorkspace || context.isolatedWorkspaceFullScene) && (!popup->acceptsInput() || !popup->alphaNonZero())))
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();
@@ -864,7 +863,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                     renderdata.fadeAlpha = PARENTFADEALPHA * popup->alpha()[POPUP_ALPHA_FADE]->value();
 
                     popup->wlSurface()->resource()->breadthfirst(
-                        [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+                        [this, &context, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                             if (!s->m_current.texture)
                                 return;
 
@@ -875,7 +874,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                             renderdata.texture     = s->m_current.texture;
                             renderdata.surface     = s;
                             renderdata.mainSurface = false;
-                            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
                             renderdata.surfaceCounter++;
                         },
                         data);
@@ -893,79 +892,79 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVERLAY)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(context, pMonitor, fullAlpha);
             }
         }
     }
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOW);
 
-    m_renderData.currentWindow.reset();
+    context.currentWindow.reset();
 }
 
-void IHyprRenderer::draw(WP<IPassElement> element, const CRegion& damage) {
+void IHyprRenderer::draw(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage) {
     ASSERT(element);
     if (!element)
         return;
 
-    elementRenderer()->drawElement(element, damage);
+    elementRenderer()->drawElement(context, element, damage);
 }
 
-void IHyprRenderer::draw(const CBorderPassElement::SBorderData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CBorderPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CBorderPassElement::SBorderData& data, const CRegion& damage) {
+    draw(context, makeUnique<CBorderPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CClearPassElement::SClearData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CClearPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CClearPassElement::SClearData& data, const CRegion& damage) {
+    draw(context, makeUnique<CClearPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CFramebufferElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage) {
+    draw(context, makeUnique<CFramebufferElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CRectPassElement::SRectData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CRectPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CRectPassElement::SRectData& data, const CRegion& damage) {
+    draw(context, makeUnique<CRectPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CRendererHintsPassElement::SData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CRendererHintsPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CRendererHintsPassElement::SData& data, const CRegion& damage) {
+    draw(context, makeUnique<CRendererHintsPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CShadowPassElement::SShadowData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CShadowPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CShadowPassElement::SShadowData& data, const CRegion& damage) {
+    draw(context, makeUnique<CShadowPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CSurfacePassElement::SRenderData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CSurfacePassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CSurfacePassElement::SRenderData& data, const CRegion& damage) {
+    draw(context, makeUnique<CSurfacePassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CTexPassElement::SRenderData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CTexPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CTexPassElement::SRenderData& data, const CRegion& damage) {
+    draw(context, makeUnique<CTexPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CTextureMatteElement::STextureMatteData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CTextureMatteElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CTextureMatteElement::STextureMatteData& data, const CRegion& damage) {
+    draw(context, makeUnique<CTextureMatteElement>(data), damage);
 }
 
-void IHyprRenderer::bindFB(SP<IFramebuffer> fb) {
+void IHyprRenderer::bindFB(CRenderingContext& context, SP<IFramebuffer> fb) {
     fb->bind();
-    m_renderData.currentFB = fb;
+    context.currentFB = fb;
 }
 
-UP<CScopeGuard> IHyprRenderer::bindTempFB(SP<IFramebuffer> fb) {
-    const auto oldFB = m_renderData.currentFB;
-    bindFB(fb);
-    return makeUnique<CScopeGuard>([this, oldFB] { bindFB(oldFB); });
+UP<CScopeGuard> IHyprRenderer::bindTempFB(CRenderingContext& context, SP<IFramebuffer> fb) {
+    const auto oldFB = context.currentFB;
+    bindFB(context, fb);
+    return makeUnique<CScopeGuard>([this, &context, oldFB] { bindFB(context, oldFB); });
 }
 
-bool IHyprRenderer::preBlurQueued(PHLMONITORREF pMonitor) {
+bool IHyprRenderer::preBlurQueued(const CRenderingContext& context) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Config::INTEGER>("decoration:blur:new_optimizations");
     static auto PBLUR            = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
 
-    if (!pMonitor)
+    if (!context.sceneMonitor)
         return false;
-    return pMonitor->m_blurFBDirty && *PBLURNEWOPTIMIZE && *PBLUR && pMonitor->m_blurFBShouldRender;
+    return context.sceneMonitor->m_blurFBDirty && *PBLURNEWOPTIMIZE && *PBLUR && context.precomputeBlur;
 }
 
 SP<ITexture> IHyprRenderer::createTexture(const SP<Aquamarine::IBuffer> buffer, bool keepDataCopy) {
@@ -998,7 +997,7 @@ SP<ITexture> IHyprRenderer::createTexture(const SP<Aquamarine::IBuffer> buffer, 
     return tex;
 }
 
-void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::steady_tp& time, bool popups, bool lockscreen) {
+void IHyprRenderer::renderLayer(CRenderingContext& context, PHLLS pLayer, PHLMONITOR pMonitor, const Time::steady_tp& time, bool popups, bool lockscreen) {
     if (!pLayer)
         return;
 
@@ -1012,11 +1011,11 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
 
     static auto PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
 
-    if (*PDIMAROUND && pLayer->m_ruleApplicator->dimAround().valueOrDefault() && !m_bRenderingSnapshot && !popups) {
+    if (*PDIMAROUND && pLayer->m_ruleApplicator->dimAround().valueOrDefault() && !context.renderingSnapshot && !popups) {
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pLayer->alpha()[LS_ALPHA_FADE]->value());
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     TRACY_GPU_ZONE("RenderLayer");
@@ -1026,7 +1025,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time, REALPOS};
     renderdata.fadeAlpha                        = pLayer->alpha()[LS_ALPHA_FADE]->value();
-    renderdata.blur                             = !m_bRenderingSnapshot && pLayer->shouldBlur();
+    renderdata.blur                             = shouldBlur(context, pLayer);
     renderdata.surface                          = pLayer->wlSurface()->resource();
     renderdata.decorate                         = false;
     renderdata.w                                = REALSIZ.x;
@@ -1042,7 +1041,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
 
     if (!popups)
         pLayer->wlSurface()->resource()->breadthfirst(
-            [this, &renderdata, &pLayer](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+            [this, &context, &renderdata, &pLayer](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 if (!s->m_current.texture)
                     return;
 
@@ -1053,7 +1052,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = s->m_current.texture;
                 renderdata.surface     = s;
                 renderdata.mainSurface = s == pLayer->wlSurface()->resource();
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -1071,7 +1070,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
     renderdata.surfaceCounter = 0;
     if (popups) {
         pLayer->popupHead()->breadthfirst(
-            [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
+            [this, &context, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
                 if (!popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
                     return;
 
@@ -1088,14 +1087,14 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = SURF->m_current.texture;
                 renderdata.surface     = SURF;
                 renderdata.mainSurface = false;
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
     }
 }
 
-void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, const Time::steady_tp& time) {
+void IHyprRenderer::renderIMEPopup(CRenderingContext& context, CInputPopup* pPopup, PHLMONITOR pMonitor, const Time::steady_tp& time) {
     const auto                       POS = pPopup->globalBox().pos();
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time, POS};
@@ -1118,7 +1117,7 @@ void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, con
     }
 
     SURF->breadthfirst(
-        [this, &renderdata, &SURF](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+        [this, &context, &renderdata, &SURF](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;
 
@@ -1129,13 +1128,13 @@ void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, con
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == SURF;
-            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
 }
 
-void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, PHLMONITOR pMonitor, const Time::steady_tp& time) {
+void IHyprRenderer::renderSessionLockSurface(CRenderingContext& context, WP<SSessionLockSurface> pSurface, PHLMONITOR pMonitor, const Time::steady_tp& time) {
     static auto                      PSESSIONLOCKXRAY = CConfigValue<Config::BOOL>("misc:session_lock_xray");
     static auto                      PSESSIONLOCKBLUR = CConfigValue<Config::BOOL>("misc:session_lock_blur");
 
@@ -1148,7 +1147,7 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
     renderdata.h        = pMonitor->m_size.y;
 
     renderdata.surface->breadthfirst(
-        [this, &renderdata, &pSurface](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+        [this, &context, &renderdata, &pSurface](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;
 
@@ -1159,13 +1158,14 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == pSurface->surface->surface();
-            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
 }
 
-void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time, const Vector2D& translate, const float& scale) {
+void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time, const Vector2D& translate,
+                                                 const float& scale) {
     static auto PXPMODE          = CConfigValue<Config::INTEGER>("render:xp_mode");
     static auto PSESSIONLOCKXRAY = CConfigValue<Config::INTEGER>("misc:session_lock_xray");
 
@@ -1186,70 +1186,70 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
-    CScopeGuard x([&RENDERMODIFDATA] {
+    CScopeGuard x([&context, &RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
     if UNLIKELY (!pWorkspace) {
         // allow rendering without a workspace. In this case, just render layers.
 
-        renderBackground(pMonitor);
+        renderBackground(context, pMonitor);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        if (!m_isolatedWorkspace)
+        if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
 
         return;
     }
 
     if LIKELY (!*PXPMODE) {
-        renderBackground(pMonitor);
+        renderBackground(context, pMonitor);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        if (!m_isolatedWorkspace)
+        if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
     }
 
     // pre window pass
-    if (preBlurQueued(pMonitor))
-        addPassElement(makeUnique<CPreBlurElement>());
+    if (preBlurQueued(context))
+        addPassElement(context, makeUnique<CPreBlurElement>());
 
     if UNLIKELY /* subjective? */ (Fullscreen::controller()->hasFullscreen(pWorkspace))
-        renderWorkspaceWindowsFullscreen(pMonitor, pWorkspace, time);
+        renderWorkspaceWindowsFullscreen(context, pMonitor, pWorkspace, time);
     else
-        renderWorkspaceWindows(pMonitor, pWorkspace, time);
+        renderWorkspaceWindows(context, pMonitor, pWorkspace, time);
 
     // and then special
     if UNLIKELY (pMonitor->m_specialDim->value() != 0.F) {
@@ -1257,7 +1257,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
         data.color = CHyprColor(0, 0, 0, pMonitor->m_specialDim->value());
 
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     if UNLIKELY (pMonitor->m_specialBlur->value() != 0.F) {
@@ -1267,7 +1267,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.blur  = true;
         data.blurA = pMonitor->m_specialBlur->value();
 
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     std::vector<PHLWORKSPACE> specialWorkspaces;
@@ -1282,13 +1282,13 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     }
 
     for (const auto& workspace : specialWorkspaces) {
-        if (workspaceRenderAlpha(workspace, pMonitor) <= 0.F)
+        if (workspaceRenderAlpha(context, workspace, pMonitor) <= 0.F)
             continue;
 
         if (Fullscreen::controller()->hasFullscreen(workspace))
-            renderWorkspaceWindowsFullscreen(pMonitor, workspace, time);
+            renderWorkspaceWindowsFullscreen(context, pMonitor, workspace, time);
         else
-            renderWorkspaceWindows(pMonitor, workspace, time);
+            renderWorkspaceWindows(context, pMonitor, workspace, time);
     }
 
     // pinned always above
@@ -1299,38 +1299,38 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         if (!(w->m_state & WINDOW_STATE_PINNED) || !w->isFloating())
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         // render the bad boy
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOWS);
 
     // Render surfaces above windows for monitor
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-        renderLayer(ls.lock(), pMonitor, time);
+        renderLayer(context, ls.lock(), pMonitor, time);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
+    renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
-        renderLayer(ls.lock(), pMonitor, time);
+        renderLayer(context, ls.lock(), pMonitor, time);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
+    renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
 
     for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
         for (auto const& ls : lsl) {
-            renderLayer(ls.lock(), pMonitor, time, true);
+            renderLayer(context, ls.lock(), pMonitor, time, true);
         }
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_POPUP);
+    renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_POPUP);
 
-    renderDragIcon(pMonitor, time);
+    renderDragIcon(context, pMonitor, time);
 }
 
-void IHyprRenderer::renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
+void IHyprRenderer::renderIME(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
     Vector2D translate = {geometry.x, geometry.y};
     float    scale     = sc<float>(geometry.width) / pMonitor->m_transformedSize.x;
 
@@ -1349,22 +1349,22 @@ void IHyprRenderer::renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, c
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
-    CScopeGuard x([&RENDERMODIFDATA] {
+    CScopeGuard x([&context, &RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
     // Render IME popups above everything
     for (auto const& imep : g_pInputManager->m_relay.m_inputMethodPopups) {
         if (imep->shouldBeRendered())
-            renderIMEPopup(imep.get(), pMonitor, now);
+            renderIMEPopup(context, imep.get(), pMonitor, now);
     }
 }
 
-SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
+SP<ITexture> IHyprRenderer::getBackground(CRenderingContext& context, PHLMONITOR pMonitor) {
 
     if (m_backgroundResourceFailed)
         return nullptr;
@@ -1401,18 +1401,14 @@ SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
             auto fb = createFB("BGTex scale");
             fb->alloc(monW, monH);
 
-            auto       guard = bindTempFB(fb);
-
-            const auto oldProjType     = m_renderData.projectionType;
-            const auto oldFbSize       = m_renderData.fbSize;
-            const auto oldTransformDmg = m_renderData.transformDamage;
-
-            m_renderData.fbSize = Vector2D{monW, monH};
-            setProjectionType(RPT_EXPORT);
-            m_renderData.transformDamage = false;
+            CRenderingContext child{context, context.renderPass()};
+            auto              guard = bindTempFB(child, fb);
+            child.fbSize            = Vector2D{monW, monH};
+            setProjectionType(child, RPT_EXPORT);
+            child.transformDamage = false;
             setViewport(0, 0, monW, monH);
 
-            draw(CClearPassElement::SClearData{{0.F, 0.F, 0.F, 0.F}});
+            draw(child, CClearPassElement::SClearData{{0.F, 0.F, 0.F, 0.F}});
 
             const double texW = origW * scale;
             const double texH = origH * scale;
@@ -1420,12 +1416,7 @@ SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
             const double offY = (monH - texH) / 2.0;
 
             CRegion      fullDamage = {0, 0, monW, monH};
-            draw(CTexPassElement::SRenderData{.tex = backgroundTexture, .box = CBox{offX, offY, texW, texH}, .damage = fullDamage}, fullDamage);
-
-            m_renderData.fbSize          = oldFbSize;
-            m_renderData.transformDamage = oldTransformDmg;
-            setProjectionType(oldProjType);
-            setViewport(0, 0, (int)m_renderData.currentFB->m_size.x, (int)m_renderData.currentFB->m_size.y);
+            draw(child, CTexPassElement::SRenderData{.tex = backgroundTexture, .box = CBox{offX, offY, texW, texH}, .damage = fullDamage}, fullDamage);
 
             backgroundTexture = fb->getTexture();
 
@@ -1443,44 +1434,44 @@ SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
     return backgroundTexture;
 }
 
-void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
+void IHyprRenderer::renderBackground(CRenderingContext& context, PHLMONITOR pMonitor) {
     static auto PRENDERTEX       = CConfigValue<Config::INTEGER>("misc:disable_hyprland_logo");
     static auto PBACKGROUNDCOLOR = CConfigValue<Config::INTEGER>("misc:background_color");
     static auto PNOSPLASH        = CConfigValue<Config::INTEGER>("misc:disable_splash_rendering");
 
     if (*PRENDERTEX /* inverted cfg flag */ || pMonitor->m_backgroundOpacity->isBeingAnimated())
-        addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+        addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
     if (!*PRENDERTEX) {
         static auto PBACKGROUNDCOLOR = CConfigValue<Config::INTEGER>("misc:background_color");
 
         if (!pMonitor->m_background)
-            pMonitor->m_background = getBackground(pMonitor);
+            pMonitor->m_background = getBackground(context, pMonitor);
 
         if (!pMonitor->m_background)
-            addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+            addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
         else {
             CTexPassElement::SRenderData data;
-            const double                 MONRATIO = m_renderData.pMonitor->m_transformedSize.x / m_renderData.pMonitor->m_transformedSize.y;
+            const double                 MONRATIO = context.sceneMonitor->m_transformedSize.x / context.sceneMonitor->m_transformedSize.y;
             const double                 WPRATIO  = pMonitor->m_background->m_size.x / pMonitor->m_background->m_size.y;
             Vector2D                     origin;
             double                       scale = 1.0;
 
             if (MONRATIO > WPRATIO) {
-                scale    = m_renderData.pMonitor->m_transformedSize.x / pMonitor->m_background->m_size.x;
-                origin.y = (m_renderData.pMonitor->m_transformedSize.y - pMonitor->m_background->m_size.y * scale) / 2.0;
+                scale    = context.sceneMonitor->m_transformedSize.x / pMonitor->m_background->m_size.x;
+                origin.y = (context.sceneMonitor->m_transformedSize.y - pMonitor->m_background->m_size.y * scale) / 2.0;
             } else {
-                scale    = m_renderData.pMonitor->m_transformedSize.y / pMonitor->m_background->m_size.y;
-                origin.x = (m_renderData.pMonitor->m_transformedSize.x - pMonitor->m_background->m_size.x * scale) / 2.0;
+                scale    = context.sceneMonitor->m_transformedSize.y / pMonitor->m_background->m_size.y;
+                origin.x = (context.sceneMonitor->m_transformedSize.x - pMonitor->m_background->m_size.x * scale) / 2.0;
             }
 
             if (MONRATIO != WPRATIO)
-                addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+                addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
             data.box = {origin, pMonitor->m_background->m_size * scale};
-            data.a   = m_renderData.pMonitor->m_backgroundOpacity->value();
+            data.a   = context.sceneMonitor->m_backgroundOpacity->value();
             data.tex = pMonitor->m_background;
-            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 
@@ -1494,7 +1485,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             CTexPassElement::SRenderData data;
             data.box = {{(monitorSize.x - pMonitor->m_splash->m_size.x) / 2.0, monitorSize.y * 0.98 - pMonitor->m_splash->m_size.y}, pMonitor->m_splash->m_size};
             data.tex = pMonitor->m_splash;
-            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 }
@@ -1596,15 +1587,15 @@ SP<ITexture> IHyprRenderer::loadAsset(const std::string& filename) {
     return tex;
 }
 
-SP<ITexture> IHyprRenderer::getBlurTexture(PHLMONITORREF pMonitor) {
+SP<ITexture> IHyprRenderer::getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor) {
     return pMonitor->resources()->m_blurFB->getTexture();
 }
 
-bool IHyprRenderer::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow) {
+bool IHyprRenderer::shouldUseNewBlurOptimizations(const CRenderingContext& context, PHLLS pLayer, PHLWINDOW pWindow) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Config::INTEGER>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Config::INTEGER>("decoration:blur:xray");
 
-    if (m_isolatedWorkspaceFullScene || !getBlurTexture(m_renderData.pMonitor))
+    if (context.isolatedWorkspaceFullScene || !getBlurTexture(context, context.sceneMonitor))
         return false;
 
     if (blurProviderRequiresLiveBlur())
@@ -1743,7 +1734,7 @@ void IHyprRenderer::ensureLockTexturesRendered(bool load) {
     }
 }
 
-void IHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
+void IHyprRenderer::renderLockscreen(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
     TRACY_GPU_ZONE("RenderLockscreen");
 
     const bool LOCKED = g_pSessionLockManager->isSessionLocked();
@@ -1754,7 +1745,7 @@ void IHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
 
     const bool RENDERPRIMER = g_pSessionLockManager->shallConsiderLockMissing() || g_pSessionLockManager->clientLocked() || g_pSessionLockManager->clientDenied();
     if (RENDERPRIMER)
-        renderSessionLockPrimer(pMonitor);
+        renderSessionLockPrimer(context, pMonitor);
 
     const auto PSLS              = g_pSessionLockManager->getSessionLockSurfaceForMonitor(pMonitor->m_id);
     const bool RENDERLOCKMISSING = (PSLS.expired() || g_pSessionLockManager->clientDenied()) && g_pSessionLockManager->shallConsiderLockMissing();
@@ -1762,26 +1753,26 @@ void IHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
     ensureLockTexturesRendered(RENDERLOCKMISSING);
 
     if (RENDERLOCKMISSING)
-        renderSessionLockMissing(pMonitor);
+        renderSessionLockMissing(context, pMonitor);
     else if (PSLS) {
-        renderSessionLockSurface(PSLS, pMonitor, now);
+        renderSessionLockSurface(context, PSLS, pMonitor, now);
         g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->m_id);
 
         // render layers and then their popups for abovelock rule
         for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
             for (auto const& ls : lsl) {
-                renderLayer(ls.lock(), pMonitor, now, false, true);
+                renderLayer(context, ls.lock(), pMonitor, now, false, true);
             }
         }
         for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
             for (auto const& ls : lsl) {
-                renderLayer(ls.lock(), pMonitor, now, true, true);
+                renderLayer(context, ls.lock(), pMonitor, now, true, true);
             }
         }
     }
 }
 
-void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
+void IHyprRenderer::renderSessionLockPrimer(CRenderingContext& context, PHLMONITOR pMonitor) {
     static auto PSESSIONLOCKXRAY = CConfigValue<Config::INTEGER>("misc:session_lock_xray");
     if (*PSESSIONLOCKXRAY)
         return;
@@ -1790,10 +1781,10 @@ void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
     data.color = CHyprColor(0, 0, 0, 1.f);
     data.box   = CBox{{}, pMonitor->m_transformedSize};
 
-    addPassElement(makeUnique<CRectPassElement>(data));
+    addPassElement(context, makeUnique<CRectPassElement>(data));
 }
 
-void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
+void IHyprRenderer::renderSessionLockMissing(CRenderingContext& context, PHLMONITOR pMonitor) {
     if (g_pCompositor->m_startLocked && !g_pCompositor->m_startLockedCommand.empty())
         return;
 
@@ -1810,7 +1801,7 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
     data.box = monbox;
     data.a   = 1;
 
-    addPassElement(makeUnique<CTexPassElement>(data));
+    addPassElement(context, makeUnique<CTexPassElement>(data));
 
     if (!ANY_PRESENT && m_lockTtyTextTexture) {
         // also render text for the tty number
@@ -1818,51 +1809,51 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
         data.tex    = m_lockTtyTextTexture;
         data.box    = texbox;
 
-        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 
-bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode, SP<IHLBuffer> buffer, SP<IFramebuffer> fb, bool simple) {
-    m_renderPass.clear();
-    m_backdropCaptures.clear();
-    clearCMSettingsCache();
-    m_renderMode          = mode;
-    m_renderData.pMonitor = pMonitor;
+bool IHyprRenderer::beginRender(CRenderingContext& context, CRegion& damage, eRenderMode mode, SP<IHLBuffer> buffer, SP<IFramebuffer> fb, bool simple) {
+    context.renderPass().clear();
+    context.backdropCaptures.clear();
+    context.cmSettingsCache->entries.clear();
+    context.renderMode  = mode;
+    const auto pMonitor = context.outputMonitor.lock();
 
     if (simple) {
-        m_renderData.fbSize = fb ? fb->m_size : buffer->m_texture->m_size;
-        setProjectionType(RPT_EXPORT);
+        context.fbSize = fb ? fb->m_size : buffer->m_texture->m_size;
+        setProjectionType(context, RPT_EXPORT);
     } else
-        setProjectionType(RPT_MONITOR);
+        setProjectionType(context, RPT_MONITOR);
 
-    const auto RESOURCES     = g_pHyprRenderer->m_renderData.pMonitor->resources();
+    const auto RESOURCES     = context.sceneMonitor->resources();
     const bool HAS_MIRROR_FB = RESOURCES->hasMirrorFB();
 
     if (HAS_MIRROR_FB && !RESOURCES->shouldKeepMirrorFB())
         RESOURCES->releaseMirrorFB();
 
-    if (m_renderMode == RENDER_MODE_FULL_FAKE)
-        return beginFullFakeRenderInternal(pMonitor, damage, fb, simple);
+    if (context.renderMode == RENDER_MODE_FULL_FAKE)
+        return beginFullFakeRenderInternal(context, damage, fb, simple);
 
     int bufferAge = 0;
 
     if (!buffer) {
-        m_currentBuffer = pMonitor->m_output->swapchain->next(&bufferAge);
-        if (!m_currentBuffer) {
+        context.buffer = pMonitor->m_output->swapchain->next(&bufferAge);
+        if (!context.buffer) {
             Log::logger->log(Log::ERR, "Failed to acquire swapchain buffer for {}", pMonitor->m_name);
             return false;
         }
     } else
-        m_currentBuffer = buffer;
+        context.buffer = buffer;
 
     initRender();
 
-    if (!initRenderBuffer(m_currentBuffer, pMonitor->m_output->state->state().drmFormat)) {
+    if (!initRenderBuffer(context, context.buffer, pMonitor->m_output->state->state().drmFormat)) {
         Log::logger->log(Log::ERR, "failed to start a render pass for output {}, no RBO could be obtained", pMonitor->m_name);
         return false;
     }
 
-    if (m_renderMode == RENDER_MODE_NORMAL) {
+    if (context.renderMode == RENDER_MODE_NORMAL) {
         damage = pMonitor->m_damage.getBufferDamage(bufferAge);
         pMonitor->m_damage.rotate();
 
@@ -1870,7 +1861,7 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
             damage.add(pMonitor->resources()->pendingMirrorFBDamage());
     }
 
-    const auto  res     = beginRenderInternal(pMonitor, damage, simple);
+    const auto  res     = beginRenderInternal(context, damage, simple);
     static bool initial = true;
     if (initial) {
         initAssets();
@@ -1880,9 +1871,9 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
     return res;
 }
 
-void IHyprRenderer::setDamage(const CRegion& damage_, std::optional<CRegion> finalDamage) {
-    m_renderData.damage.set(damage_);
-    m_renderData.finalDamage.set(finalDamage.value_or(damage_));
+void IHyprRenderer::setDamage(CRenderingContext& context, const CRegion& damage_, std::optional<CRegion> finalDamage) {
+    context.damage.set(damage_);
+    context.finalDamage.set(finalDamage.value_or(damage_));
 }
 
 static Mat3x3 getFBProjection(PHLMONITORREF pMonitor, const Vector2D& size) {
@@ -1893,74 +1884,68 @@ static Mat3x3 getFBProjection(PHLMONITORREF pMonitor, const Vector2D& size) {
     return Mat3x3::identity().translate(size / 2.0).transform(Math::wlTransformToHyprutils(pMonitor->m_transform)).translate(-tfmd / 2.0);
 }
 
-void IHyprRenderer::setProjectionType(const Vector2D& fbSize) {
-    m_renderData.fbSize = fbSize;
-    setProjectionType(RPT_FB);
+void IHyprRenderer::setProjectionType(CRenderingContext& context, const Vector2D& fbSize) {
+    context.fbSize = fbSize;
+    setProjectionType(context, RPT_FB);
 }
 
-void IHyprRenderer::setProjectionType(eRenderProjectionType projectionType) {
-    m_renderData.projectionType = projectionType;
+void IHyprRenderer::setProjectionType(CRenderingContext& context, eRenderProjectionType projectionType) {
+    context.projectionType = projectionType;
     switch (projectionType) {
         case RPT_MONITOR:
-        case RPT_EXPORT: m_renderData.targetProjection = Mat3x3::identity(); break;
-        case RPT_OUTPUT: m_renderData.targetProjection = m_renderData.pMonitor->getTransformMatrix(); break;
-        case RPT_FB: m_renderData.targetProjection = getFBProjection(m_renderData.pMonitor, m_renderData.fbSize); break;
+        case RPT_EXPORT: context.targetProjection = Mat3x3::identity(); break;
+        case RPT_OUTPUT: context.targetProjection = context.sceneMonitor->getTransformMatrix(); break;
+        case RPT_FB: context.targetProjection = getFBProjection(context.sceneMonitor, context.fbSize); break;
         default: UNREACHABLE();
     }
 }
 
-Mat3x3 IHyprRenderer::getBoxProjection(const CBox& box, std::optional<eTransform> transform) {
-    return m_renderData.targetProjection.projectBox(box, transform.value_or(HYPRUTILS_TRANSFORM_NORMAL), box.rot);
+Mat3x3 IHyprRenderer::getBoxProjection(const CRenderingContext& context, const CBox& box, std::optional<eTransform> transform) {
+    return context.targetProjection.projectBox(box, transform.value_or(HYPRUTILS_TRANSFORM_NORMAL), box.rot);
 }
 
-Mat3x3 IHyprRenderer::projectBoxToTarget(const CBox& box, std::optional<eTransform> transform) {
-    const auto TARGET_SIZE = m_renderData.projectionType == RPT_MONITOR ? m_renderData.pMonitor->m_transformedSize : m_renderData.fbSize;
+Mat3x3 IHyprRenderer::projectBoxToTarget(const CRenderingContext& context, const CBox& box, std::optional<eTransform> transform) {
+    const auto TARGET_SIZE = context.projectionType == RPT_MONITOR ? context.sceneMonitor->m_transformedSize : context.fbSize;
     const auto OUTPUT_PROJECTION =
-        m_renderData.projectionType == RPT_OUTPUT ? m_renderData.pMonitor->getScaleMatrix() : Mat3x3::outputProjection(TARGET_SIZE, HYPRUTILS_TRANSFORM_NORMAL);
+        context.projectionType == RPT_OUTPUT ? context.sceneMonitor->getScaleMatrix() : Mat3x3::outputProjection(TARGET_SIZE, HYPRUTILS_TRANSFORM_NORMAL);
 
-    return OUTPUT_PROJECTION.copy().multiply(getBoxProjection(box, transform));
+    return OUTPUT_PROJECTION.copy().multiply(getBoxProjection(context, box, transform));
 }
 
-SP<IFramebuffer> IHyprRenderer::blurMainFramebuffer(float strength, const CRegion& originalDamage, const SBlurContext& context) {
-    const auto renderTarget = m_renderData.currentFB;
-    const auto blurSource   = !m_backdropCaptures.empty() && m_backdropCaptures.back().framebuffer ? m_backdropCaptures.back().framebuffer : renderTarget;
+SP<IFramebuffer> IHyprRenderer::blurMainFramebuffer(CRenderingContext& context, float strength, const CRegion& originalDamage, const SBlurContext& blurContext) {
+    const auto renderTarget = context.currentFB;
+    const auto blurSource   = !context.backdropCaptures.empty() && context.backdropCaptures.back().framebuffer ? context.backdropCaptures.back().framebuffer : renderTarget;
 
     if (!blurSource || !blurSource->getTexture()) {
         Log::logger->log(Log::ERR, "BUG THIS: null fb texture while attempting to blur main fb?! (introspection off?!)");
-        return m_renderData.pMonitor->resources()->m_blurFB; // return something to sample from at least
+        return context.sceneMonitor->resources()->m_blurFB;
     }
 
-    auto guard = bindTempFB(renderTarget); // blurFramebuffer messes with FB bindings
-    return blurFramebuffer(blurSource, strength, originalDamage, context);
+    auto guard = bindTempFB(context, renderTarget); // blurFramebuffer messes with FB bindings
+    return blurFramebuffer(context, blurSource, strength, originalDamage, blurContext);
 }
 
-void IHyprRenderer::beginBackdropScope(SP<SBackdropScope> scope) {
+void IHyprRenderer::beginBackdropScope(CRenderingContext& context, SP<SBackdropScope> scope) {
     RASSERT(scope, "Cannot begin a null backdrop scope");
 
     SP<IFramebuffer> backdrop;
-    if (scope->required && !scope->damage.empty() && m_renderData.currentFB && m_renderData.currentFB->getTexture()) {
-        backdrop = m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+    if (scope->required && !scope->damage.empty() && context.currentFB && context.currentFB->getTexture()) {
+        backdrop = context.sceneMonitor->resources()->getUnusedWorkBuffer();
         if (backdrop) {
-            const auto renderTarget     = m_renderData.currentFB;
-            const auto savedDamage      = m_renderData.damage.copy();
-            const auto savedRenderModif = m_renderData.renderModif;
-            const auto savedNearest     = m_renderData.useNearestNeighbor;
-            const auto backend          = glBackend();
-            const auto savedBlend       = backend && backend->blendEnabled();
+            const auto renderTarget = context.currentFB;
+            const auto backend      = glBackend();
+            const auto savedBlend   = backend && backend->blendEnabled();
 
             {
-                auto guard                      = bindTempFB(backdrop);
-                m_renderData.damage             = scope->damage;
-                m_renderData.renderModif        = {};
-                m_renderData.useNearestNeighbor = true;
+                CRenderingContext child{context, context.renderPass()};
+                auto              guard  = bindTempFB(child, backdrop);
+                child.damage             = scope->damage;
+                child.renderModif        = {};
+                child.useNearestNeighbor = true;
                 blend(false);
-                renderOffToMain(renderTarget);
+                renderOffToMain(child, renderTarget);
                 blend(savedBlend);
             }
-
-            m_renderData.damage             = savedDamage;
-            m_renderData.renderModif        = savedRenderModif;
-            m_renderData.useNearestNeighbor = savedNearest;
         } else {
             static bool warned = false;
             if (!warned) {
@@ -1970,17 +1955,17 @@ void IHyprRenderer::beginBackdropScope(SP<SBackdropScope> scope) {
         }
     }
 
-    m_backdropCaptures.emplace_back(SBackdropCapture{.scope = std::move(scope), .framebuffer = std::move(backdrop)});
+    context.backdropCaptures.emplace_back(SBackdropCapture{.scope = std::move(scope), .framebuffer = std::move(backdrop)});
 }
 
-void IHyprRenderer::endBackdropScope(SP<SBackdropScope> scope) {
-    RASSERT(!m_backdropCaptures.empty() && m_backdropCaptures.back().scope == scope, "Unbalanced runtime backdrop scope");
-    m_backdropCaptures.pop_back();
+void IHyprRenderer::endBackdropScope(CRenderingContext& context, SP<SBackdropScope> scope) {
+    RASSERT(!context.backdropCaptures.empty() && context.backdropCaptures.back().scope == scope, "Unbalanced runtime backdrop scope");
+    context.backdropCaptures.pop_back();
 }
 
-void IHyprRenderer::scheduleFrameForAnimatedBlur(const CRegion& damage, bool usesPrecomputedBlur) {
-    const auto monitor = m_renderData.pMonitor;
-    if (m_renderMode != RENDER_MODE_NORMAL || !monitor || monitor->isMirror() || damage.empty())
+void IHyprRenderer::scheduleFrameForAnimatedBlur(const CRenderingContext& context, const CRegion& damage, bool usesPrecomputedBlur) {
+    const auto monitor = context.sceneMonitor;
+    if (context.renderMode != RENDER_MODE_NORMAL || !monitor || monitor->isMirror() || damage.empty())
         return;
 
     if (usesPrecomputedBlur)
@@ -1989,33 +1974,34 @@ void IHyprRenderer::scheduleFrameForAnimatedBlur(const CRegion& damage, bool use
     monitor->addDamage(damage);
 }
 
-void IHyprRenderer::preBlurForCurrentMonitor(const CRegion& fakeDamage) {
+void IHyprRenderer::preBlurForCurrentMonitor(CRenderingContext& context, const CRegion& fakeDamage) {
 
-    const auto blurredFB  = blurMainFramebuffer(1, fakeDamage);
+    const auto blurredFB  = blurMainFramebuffer(context, 1, fakeDamage);
     const auto blurredTex = blurredFB->getTexture();
 
     // render onto blurFB
-    auto guard = bindTempFB(m_renderData.pMonitor->resources()->m_blurFB);
+    auto guard = bindTempFB(context, context.sceneMonitor->resources()->m_blurFB);
 
-    draw(CClearPassElement::SClearData{{0, 0, 0, 0}});
+    draw(context, CClearPassElement::SClearData{{0, 0, 0, 0}});
 
-    draw(
-        CTexPassElement::SRenderData{
-            .tex    = blurredTex,
-            .box    = CBox{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y},
-            .damage = fakeDamage,
-        },
-        fakeDamage); // .noAA = true
+    draw(context,
+         CTexPassElement::SRenderData{
+             .tex    = blurredTex,
+             .box    = CBox{0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y},
+             .damage = fakeDamage,
+         },
+         fakeDamage); // .noAA = true
 }
 
-static bool isSDR2HDR(const NColorManagement::SImageDescription& imageDescription, const NColorManagement::SImageDescription& targetImageDescription) {
+static bool isSDR2HDR(const CRenderingContext& context, const NColorManagement::SImageDescription& imageDescription,
+                      const NColorManagement::SImageDescription& targetImageDescription) {
     // might be too strict
     return (imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_SRGB ||
             imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22) &&
         (targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ||
          targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_HLG ||
          (targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR &&
-          g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ));
+          context.sceneMonitor->m_imageDescription->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ));
 }
 
 static bool isHDR2SDR(const NColorManagement::SImageDescription& imageDescription, const NColorManagement::SImageDescription& targetImageDescription) {
@@ -2026,17 +2012,14 @@ static bool isHDR2SDR(const NColorManagement::SImageDescription& imageDescriptio
          targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22);
 }
 
-void IHyprRenderer::clearCMSettingsCache() {
-    m_cmSettingsCache.clear();
-}
-
-SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
-                                         SP<CWLSurfaceResource> surface, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance, bool shouldUseSurface) {
+SCMSettings IHyprRenderer::getCMSettings(const CRenderingContext& context, const NColorManagement::PImageDescription imageDescription,
+                                         const NColorManagement::PImageDescription targetImageDescription, SP<CWLSurfaceResource> surface, bool modifySDR, float sdrMinLuminance,
+                                         int sdrMaxLuminance, bool shouldUseSurface) {
     const auto srcId = imageDescription->id();
     const auto dstId = targetImageDescription->id();
-    void*      sPtr  = shouldUseSurface ? m_renderData.surface.get() : nullptr;
+    void*      sPtr  = shouldUseSurface ? context.surface.get() : nullptr;
 
-    for (auto const& entry : m_cmSettingsCache) {
+    for (auto const& entry : context.cmSettingsCache->entries) {
         if (entry.srcDescId == srcId && entry.dstDescId == dstId && entry.surfacePtr == sPtr && entry.modifySDR == modifySDR && entry.sdrMinLuminance == sdrMinLuminance &&
             entry.sdrMaxLuminance == sdrMaxLuminance)
             return entry.settings;
@@ -2045,11 +2028,11 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     const auto                          sdrEOTF = NTransferFunction::fromConfig();
     NColorManagement::eTransferFunction srcTF;
 
-    const int                           tonemapMode = shouldUseSurface && m_renderData.currentWindow ? m_renderData.currentWindow->m_ruleApplicator->tonemap().valueOr(1) : 1;
+    const int                           tonemapMode = shouldUseSurface && context.currentWindow ? context.currentWindow->m_ruleApplicator->tonemap().valueOr(1) : 1;
 
-    if (shouldUseSurface && m_renderData.surface.valid() &&
+    if (shouldUseSurface && context.surface.valid() &&
         (imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_GAMMA22 || imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_SRGB)) {
-        if (m_renderData.surface->m_colorManagement.valid()) {
+        if (context.surface->m_colorManagement.valid()) {
             if (sdrEOTF == NTransferFunction::TF_FORCED_GAMMA22 && imageDescription->value().transferFunction == NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_SRGB)
                 srcTF = NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_GAMMA22;
             else
@@ -2063,7 +2046,7 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     } else
         srcTF = imageDescription->value().transferFunction;
 
-    const bool  needsSDRmod     = modifySDR && isSDR2HDR(imageDescription->value(), targetImageDescription->value());
+    const bool  needsSDRmod     = modifySDR && isSDR2HDR(context, imageDescription->value(), targetImageDescription->value());
     const bool  needsHDRmod     = !needsSDRmod && isHDR2SDR(imageDescription->value(), targetImageDescription->value());
     const float maxLuminance    = needsHDRmod ?
         imageDescription->value().getTFMaxLuminance(-1) :
@@ -2074,8 +2057,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     auto        toXYZ  = targetImageDescription->getPrimaries()->value().toXYZ();
 
     const bool  needsMod = needsSDRmod &&
-        ((m_renderData.pMonitor->m_sdrSaturation > 0 && m_renderData.pMonitor->m_sdrSaturation != 1.0f) ||
-         (m_renderData.pMonitor->m_sdrBrightness > 0 && m_renderData.pMonitor->m_sdrBrightness != 1.0f));
+        ((context.sceneMonitor->m_sdrSaturation > 0 && context.sceneMonitor->m_sdrSaturation != 1.0f) ||
+         (context.sceneMonitor->m_sdrBrightness > 0 && context.sceneMonitor->m_sdrBrightness != 1.0f));
 
     const bool needsTonemap = maxLuminance >= dstMaxLuminance * 1.01;
 
@@ -2097,11 +2080,11 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
         .dstMaxLuminance         = dstMaxLuminance,
         .dstPrimaries2XYZ        = toXYZ.mat(),
         .needsSDRmod             = needsMod,
-        .sdrSaturation           = needsSDRmod && m_renderData.pMonitor->m_sdrSaturation > 0 ? m_renderData.pMonitor->m_sdrSaturation : 1.0f,
-        .sdrBrightnessMultiplier = needsSDRmod && m_renderData.pMonitor->m_sdrBrightness > 0 ? m_renderData.pMonitor->m_sdrBrightness : 1.0f,
+        .sdrSaturation           = needsSDRmod && context.sceneMonitor->m_sdrSaturation > 0 ? context.sceneMonitor->m_sdrSaturation : 1.0f,
+        .sdrBrightnessMultiplier = needsSDRmod && context.sceneMonitor->m_sdrBrightness > 0 ? context.sceneMonitor->m_sdrBrightness : 1.0f,
     };
 
-    m_cmSettingsCache.push_back({
+    context.cmSettingsCache->entries.push_back({
         .srcDescId       = srcId,
         .dstDescId       = dstId,
         .surfacePtr      = sPtr,
@@ -2114,8 +2097,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     return result;
 }
 
-void IHyprRenderer::renderMirrored() {
-    auto monitor  = m_renderData.pMonitor;
+void IHyprRenderer::renderMirrored(CRenderingContext& context) {
+    auto monitor  = context.sceneMonitor;
     auto mirrored = monitor->m_mirrorOf;
 
     // saveBufferForMirror should create it
@@ -2130,13 +2113,13 @@ void IHyprRenderer::renderMirrored() {
 
     const auto MIRROR_TEX = mirrored->resources()->getMirrorTexture();
 
-    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
 
     CTexPassElement::SRenderData data;
     data.tex = MIRROR_TEX;
     data.box = monbox;
 
-    addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+    addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
 }
 
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
@@ -2231,6 +2214,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     pMonitor->m_renderingActive = true;
 
+    CRenderPass       pass;
+    CRenderingContext context{pMonitor, pass};
+
     // Most frames have no fading-out windows or layers for this monitor.
     if (!Desktop::fadingOutState()->fadeouts().empty())
         Desktop::fadingOutState()->cleanupForMonitor(pMonitor);
@@ -2249,20 +2235,20 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         zoomLock = true;
     }
 
-    m_renderData.mouseZoomFactor = 1.f;
+    context.mouseZoomFactor = 1.f;
     if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->position()).run())
-        m_renderData.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
+        context.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
 
     if (pMonitor->m_zoomAnimProgress->value() != 1) {
-        m_renderData.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
-        m_renderData.mouseZoomUseMouse  = false;
-        m_renderData.useNearestNeighbor = false;
+        context.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
+        context.mouseZoomUseMouse  = false;
+        context.useNearestNeighbor = false;
     }
 
-    const bool ZOOM_DAMAGE_ENTIRE = pMonitor->m_zoomController.shouldDamageEntire(m_renderData.mouseZoomFactor);
+    const bool ZOOM_DAMAGE_ENTIRE = pMonitor->m_zoomController.shouldDamageEntire(context.mouseZoomFactor);
 
     CRegion    damage, finalDamage;
-    if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {
+    if (!beginRender(context, damage, RENDER_MODE_NORMAL)) {
         Log::logger->log(Log::ERR, "renderer: couldn't beginRender()!");
         return;
     }
@@ -2275,7 +2261,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     finalDamage = damage;
 
     // update damage in renderdata as we modified it
-    setDamage(damage, finalDamage);
+    setDamage(context, damage, finalDamage);
 
     if (pMonitor->m_forceFullFrames > 0) {
         pMonitor->m_forceFullFrames -= 1;
@@ -2288,19 +2274,19 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     bool renderCursor = !pMonitor->isMirror();
 
     if (pMonitor->m_solitaryClient && !pMonitor->resources()->m_sceneStack.hasOverride() && (!finalDamage.empty() || *PSOLDAMAGE))
-        renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
+        renderWindow(context, pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
-        pMonitor->resources()->m_sceneStack.current()->draw(NOW);
+        pMonitor->resources()->m_sceneStack.current()->draw(context, NOW);
 
         if (pMonitor == Desktop::focusState()->monitor()) {
-            Notification::overlay()->draw(pMonitor);
-            ErrorOverlay::overlay()->draw();
+            Notification::overlay()->draw(context, pMonitor);
+            ErrorOverlay::overlay()->draw(context);
         }
 
         // for drawing the debug overlay
         if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
             renderStartOverlay = std::chrono::high_resolution_clock::now();
-            Debug::overlay()->draw();
+            Debug::overlay()->draw(context);
             endRenderOverlay = std::chrono::high_resolution_clock::now();
         }
 
@@ -2308,7 +2294,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             CRectPassElement::SRectData data;
             data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
             data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(context, makeUnique<CRectPassElement>(data));
             damageBlinkCleanup = 1;
         } else if (*PDAMAGEBLINK) {
             damageBlinkCleanup++;
@@ -2326,7 +2312,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     if (renderCursor) {
         TRACY_GPU_ZONE("RenderCursor");
-        Pointer::mgr()->renderSoftwareCursorsFor(pMonitor->m_self.lock(), NOW, m_renderData.damage);
+        Pointer::mgr()->renderSoftwareCursorsFor(context, pMonitor->m_self.lock(), NOW, context.damage);
     }
 
     if (pMonitor->m_dpmsBlackOpacity->value() != 0.F) {
@@ -2334,22 +2320,22 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = Colors::BLACK.modifyA(pMonitor->m_dpmsBlackOpacity->value());
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     Event::bus()->m_events.render.stage.emit(RENDER_LAST_MOMENT);
 
-    endRender();
+    endRender(context);
 
     TRACY_GPU_COLLECT;
 
     if (!pMonitor->needsACopyFB())
-        pMonitor->resources()->markMirrorFBStale(m_renderData.damage);
+        pMonitor->resources()->markMirrorFBStale(context.damage);
 
     if (!pMonitor->m_mirrors.empty())
-        damageMirrorsWith(pMonitor, m_renderData.damage);
+        damageMirrorsWith(pMonitor, context.damage);
 
-    CRegion    frameDamage{m_renderData.damage};
+    CRegion    frameDamage{context.damage};
 
     const auto TRANSFORM = Math::invertTransform(pMonitor->m_transform);
     frameDamage.transform(Math::wlTransformToHyprutils(TRANSFORM), pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y);
@@ -2620,7 +2606,7 @@ bool IHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
     return ok;
 }
 
-void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry) {
+void IHyprRenderer::renderWorkspace(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry) {
     Vector2D translate = {geometry.x, geometry.y};
     float    scale     = sc<float>(geometry.width) / pMonitor->m_transformedSize.x;
 
@@ -2632,147 +2618,114 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
         translate = Vector2D{};
     }
 
-    renderAllClientsForWorkspace(pMonitor, pWorkspace, now, translate, scale);
+    renderAllClientsForWorkspace(context, pMonitor, pWorkspace, now, translate, scale);
 }
 
-bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
-    return renderWorkspaceToBufferInternal(workspace, framebuffer, Time::steadyNow(), sendFeedback, false);
+bool IHyprRenderer::renderWorkspaceToBuffer(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, Time::steadyNow(), sendFeedback, false);
 }
 
-bool IHyprRenderer::renderWorkspaceSceneToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
-    return renderWorkspaceToBufferInternal(workspace, framebuffer, time, sendFeedback, true);
+bool IHyprRenderer::renderWorkspaceSceneToBuffer(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true);
 }
 
-bool IHyprRenderer::renderWorkspaceToBufferInternal(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback, bool fullScene) {
+bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
+                                                    bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != MONITOR)
+    auto&      parent  = context;
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB || parent.sceneMonitor != MONITOR)
         return false;
-    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+    if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
 
     if (!framebuffer->imageDescription())
         framebuffer->setImageDescription(MONITOR->workBufferImageDescription());
 
-    CRenderPass pass;
-    const auto  OLDRENDERDATA                 = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
-    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
-    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER           = MONITOR->m_blurFBShouldRender;
-    auto* const OLDPASS                       = m_currentPass;
+    CRenderPass       pass;
+    CRenderingContext child{parent, pass, MONITOR};
+    CRegion           damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
 
-    CScopeGuard restore([&] {
-        m_currentPass                 = OLDPASS;
-        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
-        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
-        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
-        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
-        MONITOR->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
-        m_renderData                  = OLDRENDERDATA;
-    });
-    auto        framebufferGuard = bindTempFB(framebuffer);
+    child.isolatedWorkspace          = workspace;
+    child.isolatedWorkspaceFullScene = fullScene;
+    child.blockSurfaceFeedback       = !sendFeedback;
+    child.renderingSnapshot          = !fullScene;
+    child.precomputeBlur             = false;
+    child.mainFB                     = framebuffer;
+    child.outFB.reset();
+    child.fbSize                     = MONITOR->m_transformedSize;
+    child.damage                     = damage;
+    child.finalDamage                = damage;
+    child.renderModif                = {};
+    child.mouseZoomFactor            = 1.F;
+    child.mouseZoomUseMouse          = false;
+    child.transformDamage            = false;
+    child.noSimplify                 = false;
+    child.renderingTransformedSource = false;
+    child.blockScreenShader          = true;
+    child.currentWindow.reset();
+    child.surface.reset();
+    child.clipBox = {};
 
-    CRegion     damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
-    m_currentPass                 = &pass;
-    m_isolatedWorkspace           = workspace;
-    m_isolatedWorkspaceFullScene  = fullScene;
-    m_bBlockSurfaceFeedback       = !sendFeedback;
-    m_bRenderingSnapshot          = !fullScene;
-    MONITOR->m_blurFBShouldRender = false;
-    m_renderData.pMonitor         = MONITOR;
-    m_renderData.mainFB           = framebuffer;
-    m_renderData.outFB.reset();
-    m_renderData.fbSize                     = MONITOR->m_transformedSize;
-    m_renderData.damage                     = damage;
-    m_renderData.finalDamage                = damage;
-    m_renderData.renderModif                = {};
-    m_renderData.mouseZoomFactor            = 1.F;
-    m_renderData.mouseZoomUseMouse          = false;
-    m_renderData.transformDamage            = false;
-    m_renderData.noSimplify                 = false;
-    m_renderData.renderingTransformedSource = false;
-    m_renderData.blockScreenShader          = true;
-    m_renderData.currentWindow.reset();
-    m_renderData.surface.reset();
-    m_renderData.clipBox = {};
-    setProjectionType(RPT_EXPORT);
+    auto framebufferGuard = bindTempFB(child, framebuffer);
+    setProjectionType(child, RPT_EXPORT);
 
-    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
     if (fullScene) {
-        renderAllClientsForWorkspace(MONITOR, workspace, time);
+        renderAllClientsForWorkspace(child, MONITOR, workspace, time);
         const CBox renderBox = {{}, MONITOR->m_transformedSize};
-        renderLockscreen(MONITOR, time, renderBox);
-        renderIME(MONITOR, time, renderBox);
+        renderLockscreen(child, MONITOR, time, renderBox);
+        renderIME(child, MONITOR, time, renderBox);
     } else if (Fullscreen::controller()->hasFullscreen(workspace))
-        renderWorkspaceWindowsFullscreen(MONITOR, workspace, time);
+        renderWorkspaceWindowsFullscreen(child, MONITOR, workspace, time);
     else
-        renderWorkspaceWindows(MONITOR, workspace, time);
+        renderWorkspaceWindows(child, MONITOR, workspace, time);
 
-    m_currentPass = OLDPASS;
-    pass.render(damage);
+    pass.render(child, damage);
 
     return true;
 }
 
-bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
-    if (!monitor || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != monitor->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != monitor)
+bool IHyprRenderer::renderMonitorToBuffer(CRenderingContext& context, PHLMONITOR monitor, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    auto& parent = context;
+    if (!monitor || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != monitor->m_transformedSize || !parent.currentFB || parent.sceneMonitor != monitor)
         return false;
-    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+    if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
 
     if (!framebuffer->imageDescription())
         framebuffer->setImageDescription(monitor->workBufferImageDescription());
 
-    CRenderPass pass;
-    const auto  OLDRENDERDATA                 = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
-    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
-    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER           = monitor->m_blurFBShouldRender;
-    auto* const OLDPASS                       = m_currentPass;
+    CRenderPass       pass;
+    CRenderingContext child{parent, pass, monitor};
+    CRegion           damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
 
-    CScopeGuard restore([&] {
-        m_currentPass                 = OLDPASS;
-        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
-        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
-        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
-        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
-        monitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
-        m_renderData                  = OLDRENDERDATA;
-    });
-    auto        framebufferGuard = bindTempFB(framebuffer);
+    child.isolatedWorkspace.reset();
+    child.isolatedWorkspaceFullScene = false;
+    child.blockSurfaceFeedback       = !sendFeedback;
+    child.renderingSnapshot          = false;
+    child.mainFB                     = framebuffer;
+    child.outFB.reset();
+    child.fbSize                     = monitor->m_transformedSize;
+    child.damage                     = damage;
+    child.finalDamage                = damage;
+    child.renderModif                = {};
+    child.mouseZoomFactor            = 1.F;
+    child.mouseZoomUseMouse          = false;
+    child.transformDamage            = false;
+    child.noSimplify                 = false;
+    child.renderingTransformedSource = false;
+    child.blockScreenShader          = true;
+    child.currentWindow.reset();
+    child.surface.reset();
+    child.clipBox = {};
 
-    CRegion     damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
-    m_currentPass = &pass;
-    m_isolatedWorkspace.reset();
-    m_isolatedWorkspaceFullScene = false;
-    m_bBlockSurfaceFeedback      = !sendFeedback;
-    m_bRenderingSnapshot         = false;
-    m_renderData.pMonitor        = monitor;
-    m_renderData.mainFB          = framebuffer;
-    m_renderData.outFB.reset();
-    m_renderData.fbSize                     = monitor->m_transformedSize;
-    m_renderData.damage                     = damage;
-    m_renderData.finalDamage                = damage;
-    m_renderData.renderModif                = {};
-    m_renderData.mouseZoomFactor            = 1.F;
-    m_renderData.mouseZoomUseMouse          = false;
-    m_renderData.transformDamage            = false;
-    m_renderData.noSimplify                 = false;
-    m_renderData.renderingTransformedSource = false;
-    m_renderData.blockScreenShader          = true;
-    m_renderData.currentWindow.reset();
-    m_renderData.surface.reset();
-    m_renderData.clipBox = {};
-    setProjectionType(RPT_EXPORT);
+    auto framebufferGuard = bindTempFB(child, framebuffer);
+    setProjectionType(child, RPT_EXPORT);
 
-    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
-    CMonitorScene{monitor}.draw(time);
+    addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    CMonitorScene{monitor}.draw(child, time);
 
-    m_currentPass = OLDPASS;
-    pass.render(damage);
+    pass.render(child, damage);
 
     return true;
 }
@@ -3040,7 +2993,7 @@ void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
 
     const bool OVERVIEW_SELECTED = Overview::overview()->shouldRenderWorkspace(PWINDOWWORKSPACE);
     for (auto const& m : State::monitorState()->monitors()) {
-        if (forceFull || shouldRenderWindow(pWindow, m) || (OVERVIEW_SELECTED && m == PWORKSPACEMONITOR)) { // only damage if window is rendered on monitor
+        if (forceFull || shouldRenderWindowOnMonitor(pWindow, m) || (OVERVIEW_SELECTED && m == PWORKSPACEMONITOR)) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->m_position.x, windowBox.y - m->m_position.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->m_scale).round();
             m->addDamage(fixedDamageBox);
@@ -3116,8 +3069,8 @@ void IHyprRenderer::damageMirrorsWith(PHLMONITOR pMonitor, const CRegion& pRegio
     }
 }
 
-void IHyprRenderer::renderDragIcon(PHLMONITOR pMonitor, const Time::steady_tp& time) {
-    PROTO::data->renderDND(pMonitor, time);
+void IHyprRenderer::renderDragIcon(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& time) {
+    PROTO::data->renderDND(context, pMonitor, time);
 }
 
 void IHyprRenderer::setCursorSurface(SP<Desktop::View::CWLSurface> surf, int hotspotX, int hotspotY, bool force) {
@@ -3295,10 +3248,6 @@ void IHyprRenderer::initiateManualCrash() {
     **rc<Config::INTEGER* const*>(Config::mgr()->getConfigValue("debug:damage_tracking").dataptr) = 0;
 }
 
-const SRenderData& IHyprRenderer::renderData() {
-    return m_renderData;
-}
-
 SP<IRenderbuffer> IHyprRenderer::getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
     auto it = std::ranges::find_if(m_renderbuffers, [&](const auto& other) { return other->m_hlBuffer == buffer; });
 
@@ -3314,12 +3263,12 @@ SP<IRenderbuffer> IHyprRenderer::getOrCreateRenderbuffer(SP<Aquamarine::IBuffer>
     return buf;
 }
 
-bool IHyprRenderer::beginFullFakeRender(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb) {
-    return beginRender(pMonitor, damage, RENDER_MODE_FULL_FAKE, nullptr, fb, true);
+bool IHyprRenderer::beginFullFakeRender(CRenderingContext& context, CRegion& damage, SP<IFramebuffer> fb) {
+    return beginRender(context, damage, RENDER_MODE_FULL_FAKE, nullptr, fb, true);
 }
 
-bool IHyprRenderer::beginRenderToBuffer(PHLMONITOR pMonitor, CRegion& damage, SP<IHLBuffer> buffer, bool simple) {
-    return beginRender(pMonitor, damage, RENDER_MODE_TO_BUFFER, buffer, nullptr, simple);
+bool IHyprRenderer::beginRenderToBuffer(CRenderingContext& context, CRegion& damage, SP<IHLBuffer> buffer, bool simple) {
+    return beginRender(context, damage, RENDER_MODE_TO_BUFFER, buffer, nullptr, simple);
 }
 
 void IHyprRenderer::onRenderbufferDestroy(IRenderbuffer* rb) {
@@ -3379,24 +3328,25 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(PHLWINDOW pWindow) {
     PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
-    beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+    CRenderPass       pass;
+    CRenderingContext context{PMONITOR, pass};
+    beginFullFakeRender(context, fakeDamage, PFRAMEBUFFER);
 
-    m_bRenderingSnapshot = true;
+    context.renderingSnapshot = true;
 
-    draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
-    startRenderPass();
+    draw(context, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+    startRenderPass(context);
 
     Log::logger->log(Log::DEBUG, "renderer: cleared a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
-    renderWindow(pWindow, PMONITOR, Time::steadyNow(), !pWindow->backend().traits().suggestsNoBorder, RENDER_PASS_ALL);
+    renderWindow(context, pWindow, PMONITOR, Time::steadyNow(), !pWindow->backend().traits().suggestsNoBorder, RENDER_PASS_ALL);
 
     Log::logger->log(Log::DEBUG, "renderer: rendered a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
-    endRender();
+    endRender(context);
 
     Log::logger->log(Log::DEBUG, "renderer: made a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
-    m_bRenderingSnapshot = false;
     return PFRAMEBUFFER;
 }
 
@@ -3419,25 +3369,26 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(PHLLS pLayer) {
     PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
-    beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+    CRenderPass       pass;
+    CRenderingContext context{PMONITOR, pass};
+    beginFullFakeRender(context, fakeDamage, PFRAMEBUFFER);
 
-    m_bRenderingSnapshot = true;
+    context.renderingSnapshot = true;
 
-    draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
-    startRenderPass();
+    draw(context, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+    startRenderPass(context);
 
     Log::logger->log(Log::DEBUG, "renderer: cleared a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
     // draw the layer
-    renderLayer(pLayer, PMONITOR, Time::steadyNow());
+    renderLayer(context, pLayer, PMONITOR, Time::steadyNow());
 
     Log::logger->log(Log::DEBUG, "renderer: rendered a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
-    endRender();
+    endRender(context);
 
     Log::logger->log(Log::DEBUG, "renderer: made a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
-    m_bRenderingSnapshot = false;
     return PFRAMEBUFFER;
 }
 
@@ -3460,11 +3411,13 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
-    beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+    CRenderPass       pass;
+    CRenderingContext context{PMONITOR, pass};
+    beginFullFakeRender(context, fakeDamage, PFRAMEBUFFER);
 
-    m_bRenderingSnapshot = true;
+    context.renderingSnapshot = true;
 
-    draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+    draw(context, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
 
     CSurfacePassElement::SRenderData renderdata;
     renderdata.pos             = popup->coordsGlobal();
@@ -3476,7 +3429,7 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     renderdata.blur            = false;
 
     popup->wlSurface()->resource()->breadthfirst(
-        [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+        [this, &context, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;
 
@@ -3487,18 +3440,17 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = false;
-            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         nullptr);
 
-    endRender();
+    endRender(context);
 
-    m_bRenderingSnapshot = false;
     return PFRAMEBUFFER;
 }
 
-void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace) {
+void IHyprRenderer::renderFadeouts(CRenderingContext& context, PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace) {
     if (!monitor)
         return;
 
@@ -3527,7 +3479,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             CRectPassElement::SRectData data;
             data.box   = {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y};
             data.color = CHyprColor(0, 0, 0, EFFECTS.dimAroundAlpha);
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(context, makeUnique<CRectPassElement>(data));
         }
 
         if (EFFECTS.preBlur) {
@@ -3539,7 +3491,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             data.round         = EFFECTS.preBlur->round;
             data.roundingPower = EFFECTS.preBlur->roundingPower;
             data.xray          = EFFECTS.preBlur->xray;
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(context, makeUnique<CRectPassElement>(data));
         }
 
         CTexPassElement::SRenderData data;
@@ -3554,15 +3506,56 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
         data.ignoreAlpha           = EFFECTS.textureBlur.ignoreAlpha;
         data.blockBlurOptimization = EFFECTS.textureBlur.blockBlurOptimization;
 
-        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 
-NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription() {
-    if (!m_renderData.pMonitor)
+NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription(const CRenderingContext& context) {
+    if (!context.sceneMonitor)
         return LINEAR_IMAGE_DESCRIPTION;
 
-    return m_renderData.pMonitor->workBufferImageDescription();
+    return context.sceneMonitor->workBufferImageDescription();
+}
+
+bool IHyprRenderer::shouldBlur(const CRenderingContext& context, PHLLS ls) {
+    if (context.renderingSnapshot)
+        return false;
+
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    auto surface = ls->wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    return ls->m_ruleApplicator->blur().valueOrDefault();
+}
+
+bool IHyprRenderer::shouldBlur(const CRenderingContext& context, PHLWINDOW w) {
+    if (context.renderingSnapshot)
+        return false;
+
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    const bool DONT_BLUR = w->m_ruleApplicator->noBlur().valueOrDefault() || w->m_ruleApplicator->RGBX().valueOrDefault() || w->presentation().opaque();
+    if (DONT_BLUR)
+        return false;
+
+    auto surface = w->wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    return true;
+}
+
+bool IHyprRenderer::shouldBlur(const CRenderingContext&, WP<Desktop::View::CPopup> p) {
+    static CConfigValue PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
+    static CConfigValue PBLUR       = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+
+    return *PBLURPOPUPS && *PBLUR;
 }
 
 SP<ITexture> IHyprRenderer::renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth,
@@ -3656,8 +3649,8 @@ static auto            colorConversionCache = []() {
 }();
 
 //
-CHyprColor IHyprRenderer::getConvertedColor(const CHyprColor& color) {
-    const auto DESCR = m_renderData.currentFB ? m_renderData.currentFB->imageDescription() : workBufferImageDescription();
+CHyprColor IHyprRenderer::getConvertedColor(const CRenderingContext& context, const CHyprColor& color) {
+    const auto DESCR = context.currentFB ? context.currentFB->imageDescription() : workBufferImageDescription(context);
 
     if (!DESCR) {
         Log::logger->log(Log::ERR, "getConvertedColor: failed to get image description");
@@ -3672,7 +3665,7 @@ CHyprColor IHyprRenderer::getConvertedColor(const CHyprColor& color) {
     if (const auto IT = colorConversionCache.find(key); IT != colorConversionCache.end())
         return IT->second;
 
-    const auto converted = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);
+    const auto converted = convertColor(context, color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);
     colorConversionCache.emplace(key, converted);
 
     return converted;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2233,7 +2233,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     Event::bus()->m_events.render.stage.emit(RENDER_PRE);
 
     pMonitor->m_renderingActive = true;
-    CScopeGuard renderingGuard([pMonitor] { pMonitor->m_renderingActive = false; });
+    CScopeGuard       renderingGuard([pMonitor] { pMonitor->m_renderingActive = false; });
 
     CRenderPass       pass;
     CRenderingContext context{pMonitor, pass};
@@ -2266,7 +2266,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         context.useNearestNeighbor = false;
     }
 
-    const bool ZOOM_DAMAGE_ENTIRE = pMonitor->m_zoomController.shouldDamageEntire(context.mouseZoomFactor);
+    const bool                                        ZOOM_DAMAGE_ENTIRE = pMonitor->m_zoomController.shouldDamageEntire(context.mouseZoomFactor);
 
     CRegion                                           damage, finalDamage;
     std::optional<Monitor::CDamageRing::CTransaction> damageTransaction;
@@ -2351,7 +2351,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     TRACY_GPU_COLLECT;
 
-    CRegion frameDamage{context.damage};
+    CRegion    frameDamage{context.damage};
 
     const auto TRANSFORM = Math::invertTransform(pMonitor->m_transform);
     frameDamage.transform(Math::wlTransformToHyprutils(TRANSFORM), pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2646,7 +2646,7 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
                                                     bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     auto&      parent  = context;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB || parent.sceneMonitor != MONITOR)
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB)
         return false;
     if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2631,11 +2631,22 @@ bool IHyprRenderer::renderWorkspaceSceneToBuffer(CRenderingContext& context, PHL
     return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true);
 }
 
+bool IHyprRenderer::renderWorkspaceSceneToBufferScaled(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
+                                                       bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true, true);
+}
+
 bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
-                                                    bool sendFeedback, bool fullScene) {
+                                                    bool sendFeedback, bool fullScene, bool scaleToBuffer) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     auto&      parent  = context;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB)
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || !parent.currentFB)
+        return false;
+    if (framebuffer->m_size.x <= 0 || framebuffer->m_size.y <= 0 || MONITOR->m_transformedSize.x <= 0 || MONITOR->m_transformedSize.y <= 0)
+        return false;
+    if (!scaleToBuffer && framebuffer->m_size != MONITOR->m_transformedSize)
+        return false;
+    if (scaleToBuffer && !DELTALESSTHAN(framebuffer->m_size.x / framebuffer->m_size.y, MONITOR->m_transformedSize.x / MONITOR->m_transformedSize.y, 0.01))
         return false;
     if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
@@ -2645,7 +2656,7 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     CRenderPass       pass;
     CRenderingContext child{parent, pass, MONITOR};
-    CRegion           damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
+    CRegion           damage{0, 0, sc<int>(framebuffer->m_size.x), sc<int>(framebuffer->m_size.y)};
 
     child.isolatedWorkspace          = workspace;
     child.isolatedWorkspaceFullScene = fullScene;
@@ -2654,14 +2665,14 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
     child.precomputeBlur             = false;
     child.mainFB                     = framebuffer;
     child.outFB.reset();
-    child.fbSize                     = MONITOR->m_transformedSize;
+    child.fbSize                     = framebuffer->m_size;
     child.damage                     = damage;
     child.finalDamage                = damage;
     child.renderModif                = {};
     child.mouseZoomFactor            = 1.F;
     child.mouseZoomUseMouse          = false;
     child.transformDamage            = false;
-    child.noSimplify                 = false;
+    child.noSimplify                 = scaleToBuffer;
     child.renderingTransformedSource = false;
     child.blockScreenShader          = true;
     child.currentWindow.reset();
@@ -2673,9 +2684,17 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
     if (fullScene) {
-        renderAllClientsForWorkspace(child, MONITOR, workspace, time);
-        const CBox renderBox = {{}, MONITOR->m_transformedSize};
-        renderLockscreen(child, MONITOR, time, renderBox);
+        const float SCALE = scaleToBuffer ? framebuffer->m_size.x / MONITOR->m_transformedSize.x : 1.F;
+        renderAllClientsForWorkspace(child, MONITOR, workspace, time, {}, SCALE);
+        const CBox renderBox = {{}, MONITOR->m_transformedSize * SCALE};
+        if (scaleToBuffer) {
+            SRenderModifData renderModif;
+            renderModif.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, SCALE);
+            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{renderModif}));
+            renderLockscreen(child, MONITOR, time, renderBox);
+            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+        } else
+            renderLockscreen(child, MONITOR, time, renderBox);
         renderIME(child, MONITOR, time, renderBox);
     } else if (Fullscreen::controller()->hasFullscreen(workspace))
         renderWorkspaceWindowsFullscreen(child, MONITOR, workspace, time);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -234,39 +234,22 @@ WP<Render::GL::CHyprOpenGLImpl> IHyprRenderer::glBackend() {
     return Render::GL::g_pHyprOpenGL;
 }
 
-bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
-    if (!pWindow->presentation().visibleOnMonitor(pMonitor))
+static bool shouldRenderWindowOnMonitor(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
+    if (!pWindow->presentation().visibleOnMonitor(pMonitor) || !pWindow->m_workspace)
         return false;
-
-    if (!pWindow->m_workspace)
-        return false;
-
-    if (m_isolatedWorkspace) {
-        if (pWindow->m_state & WINDOW_STATE_PINNED)
-            return m_isolatedWorkspaceFullScene;
-
-        if (pWindow->m_workspace == m_isolatedWorkspace)
-            return true;
-
-        const auto WORKSPACE_MONITOR = pWindow->m_workspace->m_monitor.lock();
-        return m_isolatedWorkspaceFullScene && pWindow->onSpecialWorkspace() && WORKSPACE_MONITOR &&
-            (WORKSPACE_MONITOR->m_activeSpecialWorkspace == pWindow->m_workspace || WORKSPACE_MONITOR->m_workspaceTransition->participates(pWindow->m_workspace));
-    }
 
     if (pWindow->m_state & WINDOW_STATE_PINNED)
         return true;
 
-    // if the window is being moved to a workspace that is not invisible, and the alpha is > 0.F, render it.
     if (pWindow->presentation().movingFromMonitor() && pWindow->presentation().alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE)->isBeingAnimated() &&
-        pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) > 0.F && pWindow->m_workspace && !pWindow->m_workspace->isVisible())
+        pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) > 0.F && !pWindow->m_workspace->isVisible())
         return true;
 
     const auto PWINDOWWORKSPACE = pWindow->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_monitor == pMonitor) {
+    if (PWINDOWWORKSPACE->m_monitor == pMonitor) {
         if (pMonitor->m_workspaceTransition->participates(PWINDOWWORKSPACE))
             return true;
 
-        // if hidden behind fullscreen
         if (Fullscreen::controller()->hasFullscreen(PWINDOWWORKSPACE) && !pWindow->isAllowedOverFullscreen() &&
             pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) == 0)
             return false;
@@ -278,28 +261,25 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (pWindow->m_monitor == pMonitor)
         return true;
 
-    if ((!pWindow->m_workspace || !pWindow->m_workspace->isVisible()) && pWindow->m_monitor != pMonitor)
+    if (!pWindow->m_workspace->isVisible() && pWindow->m_monitor != pMonitor)
         return false;
 
-    // if not, check if it maybe is active on a different monitor.
-    if (pWindow->m_workspace && pWindow->m_workspace->isVisible() && pWindow->isFloating() /* tiled windows can't be multi-ws */)
-        return !Fullscreen::controller()->isFullscreen(pWindow); // Do not draw fullscreen windows on other monitors
+    if (pWindow->m_workspace->isVisible() && pWindow->isFloating())
+        return !Fullscreen::controller()->isFullscreen(pWindow);
 
     if (pMonitor->m_activeSpecialWorkspace == pWindow->m_workspace)
         return true;
 
-    // if window is tiled and it's flying in, don't render on other mons (for slide)
     if (!pWindow->isFloating() && pWindow->positionAnimation()->isBeingAnimated() && pWindow->presentation().animatingIn() && pWindow->m_monitor != pMonitor)
         return false;
 
     if (pWindow->positionAnimation()->isBeingAnimated()) {
-        const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
-        if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
+        const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE->m_monitor.lock();
+        if (!PWINDOWWORKSPACE->m_isSpecialWorkspace && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
             return false;
-        // render window if window and monitor intersect
-        // (when moving out of or through a monitor)
+
         CBox windowBox = pWindow->getFullWindowBoundingBox();
-        if (PWINDOWWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
+        if (PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
             windowBox.translate(PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWINDOWWORKSPACE));
         windowBox.translate(pWindow->presentation().floatingOffset());
 
@@ -309,6 +289,32 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     }
 
     return false;
+}
+
+bool IHyprRenderer::shouldRenderWindow(const CRenderingContext& context, PHLWINDOW pWindow, PHLMONITOR pMonitor) {
+    if (!pWindow->presentation().visibleOnMonitor(pMonitor))
+        return false;
+
+    if (!pWindow->m_workspace)
+        return false;
+
+    if (context.isolatedWorkspace) {
+        if (pWindow->m_state & WINDOW_STATE_PINNED)
+            return context.isolatedWorkspaceFullScene;
+
+        if (pWindow->m_workspace == context.isolatedWorkspace)
+            return true;
+
+        const auto WORKSPACE_MONITOR = pWindow->m_workspace->m_monitor.lock();
+        return context.isolatedWorkspaceFullScene && pWindow->onSpecialWorkspace() && WORKSPACE_MONITOR &&
+            (WORKSPACE_MONITOR->m_activeSpecialWorkspace == pWindow->m_workspace || WORKSPACE_MONITOR->m_workspaceTransition->participates(pWindow->m_workspace));
+    }
+
+    return shouldRenderWindowOnMonitor(pWindow, pMonitor);
+}
+
+bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
+    return shouldRenderWindowOnMonitor(pWindow, pMonitor);
 }
 
 bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
@@ -340,36 +346,36 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     return false;
 }
 
-float IHyprRenderer::workspaceRenderAlpha(PHLWORKSPACE workspace, PHLMONITOR) const {
-    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+float IHyprRenderer::workspaceRenderAlpha(const CRenderingContext& context, PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (context.isolatedWorkspace && workspace == context.isolatedWorkspace))
         return 1.F;
 
     const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
     return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->alphaValue(workspace) : 1.F;
 }
 
-Vector2D IHyprRenderer::workspaceRenderOffset(PHLWORKSPACE workspace, PHLMONITOR) const {
-    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+Vector2D IHyprRenderer::workspaceRenderOffset(const CRenderingContext& context, PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (context.isolatedWorkspace && workspace == context.isolatedWorkspace))
         return {};
 
     const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
     return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->offsetValue(workspace) : Vector2D{};
 }
 
-bool IHyprRenderer::workspaceRenderIsAnimating(PHLWORKSPACE workspace, PHLMONITOR) const {
-    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+bool IHyprRenderer::workspaceRenderIsAnimating(const CRenderingContext& context, PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (context.isolatedWorkspace && workspace == context.isolatedWorkspace))
         return false;
 
     const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
     return WORKSPACEMONITOR && WORKSPACEMONITOR->m_workspaceTransition->isAnimating(workspace);
 }
 
-Vector2D IHyprRenderer::windowRenderFloatingOffset(PHLWINDOW window) const {
-    return window && !(m_isolatedWorkspace && window->m_workspace == m_isolatedWorkspace) ? window->presentation().floatingOffset() : Vector2D{};
+Vector2D IHyprRenderer::windowRenderFloatingOffset(const CRenderingContext& context, PHLWINDOW window) const {
+    return window && !(context.isolatedWorkspace && window->m_workspace == context.isolatedWorkspace) ? window->presentation().floatingOffset() : Vector2D{};
 }
 
-bool IHyprRenderer::renderingWorkspaceToBuffer() const {
-    return !!m_isolatedWorkspace;
+bool IHyprRenderer::renderingWorkspaceToBuffer(const CRenderingContext& context) const {
+    return !!context.isolatedWorkspace;
 }
 
 bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
@@ -382,17 +388,17 @@ bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
     return true;
 }
 
-void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
+void IHyprRenderer::renderWorkspaceWindowsFullscreen(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW pWorkspaceWindow = nullptr;
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     // pre-filter renderable windows once for the tiled + floating passes
     std::vector<PHLWINDOW> windows;
     windows.reserve(Desktop::windowState()->windows().size());
     for (auto const& w : Desktop::windowState()->windows()) {
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         if (w->presentation().alphaValue(WINDOW_ALPHA_FADE) * w->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) == 0.f)
@@ -412,10 +418,10 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
     for (auto const& w : windows) {
@@ -431,13 +437,13 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (w->isFadingOutUnderFullscreen())
             continue; // render these over fullscreen so the fade-out is visible
 
-        if (m_isolatedWorkspace && w->shouldRenderOverFullscreen())
+        if (context.isolatedWorkspace && w->shouldRenderOverFullscreen())
             continue;
 
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
     for (auto const& w : Desktop::windowState()->windows()) {
@@ -458,8 +464,8 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        if (shouldRenderWindow(w, pMonitor))
-            renderWindow(w, pMonitor, time, Fullscreen::controller()->getFullscreenModes(pWorkspace).internal != Fullscreen::FSMODE_FULLSCREEN, RENDER_PASS_ALL);
+        if (shouldRenderWindow(context, w, pMonitor))
+            renderWindow(context, w, pMonitor, time, Fullscreen::controller()->getFullscreenModes(pWorkspace).internal != Fullscreen::FSMODE_FULLSCREEN, RENDER_PASS_ALL);
 
         if (w->m_workspace != pWorkspace)
             continue;
@@ -478,7 +484,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (shouldSkipWindow)
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         const bool mismatchedSpecialWorkspace = w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace();
@@ -491,16 +497,16 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (specialWorkspaceOnDifferentMonitor)
             continue; // special on another are rendered as a part of the base pass
 
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
-void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
+void IHyprRenderer::renderWorkspaceWindows(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW lastWindow;
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     std::vector<PHLWINDOWREF> windows;
@@ -512,7 +518,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (isNotRenderable)
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         windows.emplace_back(w);
@@ -536,17 +542,17 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         }
 
         // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
+        renderWindow(context, w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
         w.reset();
     }
 
     if (lastWindow)
-        renderWindow(lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
+        renderWindow(context, lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
 
     lastWindow.reset();
 
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
     for (auto& w : windows) {
@@ -563,7 +569,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
             continue;
 
         // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
+        renderWindow(context, w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
         w.reset();
     }
 
@@ -585,36 +591,27 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
             continue; // special on another are rendered as a part of the base pass
 
         // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
-    if (!m_isolatedWorkspace || m_isolatedWorkspaceFullScene)
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene)
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
-void IHyprRenderer::bindOffMain() {
-    bindFB(m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
-    draw(CClearPassElement::SClearData{{0, 0, 0, 0}});
+void IHyprRenderer::bindOffMain(CRenderingContext& context) {
+    bindFB(context, context.sceneMonitor->resources()->getUnusedWorkBuffer());
+    draw(context, CClearPassElement::SClearData{{0, 0, 0, 0}});
 }
 
-void IHyprRenderer::bindBackOnMain() {
-    bindFB(m_renderData.mainFB);
+void IHyprRenderer::bindBackOnMain(CRenderingContext& context) {
+    bindFB(context, context.mainFB);
 }
 
-void IHyprRenderer::addPassElement(UP<IPassElement>&& element) {
-    currentPass().add(std::move(element));
+void IHyprRenderer::addPassElement(CRenderingContext& context, UP<IPassElement>&& element) {
+    context.renderPass().add(std::move(element));
 }
 
-CRenderPass& IHyprRenderer::currentPass() {
-    return m_currentPass ? *m_currentPass : m_renderPass;
-}
-
-UP<CScopeGuard> IHyprRenderer::redirectPass(CRenderPass* pass) {
-    const auto oldPass = m_currentPass;
-    m_currentPass      = pass;
-    return makeUnique<CScopeGuard>([this, oldPass] { m_currentPass = oldPass; });
-}
-
-void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const Time::steady_tp& time, bool decorate, eRenderPassMode mode, bool ignorePosition, bool standalone) {
+void IHyprRenderer::renderWindow(CRenderingContext& context, PHLWINDOW pWindow, PHLMONITOR pMonitor, const Time::steady_tp& time, bool decorate, eRenderPassMode mode,
+                                 bool ignorePosition, bool standalone) {
     if (pWindow->isHidden() && !standalone)
         return;
 
@@ -627,8 +624,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     TRACY_GPU_ZONE("RenderWindow");
 
     const auto  PWORKSPACE      = pWindow->m_workspace;
-    const auto  WORKSPACEOFFSET = workspaceRenderOffset(PWORKSPACE, pMonitor);
-    const auto  WINDOWOFFSET    = windowRenderFloatingOffset(pWindow);
+    const auto  WORKSPACEOFFSET = workspaceRenderOffset(context, PWORKSPACE, pMonitor);
+    const auto  WINDOWOFFSET    = windowRenderFloatingOffset(context, pWindow);
     const auto  REALPOS         = pWindow->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + ((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET);
     static auto PDIMAROUND      = CConfigValue<Config::FLOAT>("decoration:dim_around");
 
@@ -658,7 +655,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.dontRound = Fullscreen::controller()->getFullscreenModes(pWindow).internal == Fullscreen::FSMODE_FULLSCREEN;
     renderdata.fadeAlpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) *
         pWindow->presentation().alphaValue(WINDOW_ALPHA_LAYOUT) *
-        ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : workspaceRenderAlpha(PWORKSPACE, pMonitor)) *
+        ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : workspaceRenderAlpha(context, PWORKSPACE, pMonitor)) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) : 1.F) *
         pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_FROM_WORKSPACE);
     renderdata.alpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_ACTIVE);
@@ -666,7 +663,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         decorate && !pWindow->backend().traits().suggestsNoBorder && Fullscreen::controller()->getFullscreenModes(pWindow).internal != Fullscreen::FSMODE_FULLSCREEN;
     renderdata.rounding      = standalone || renderdata.dontRound ? 0 : pWindow->presentation().rounding() * pMonitor->m_scale;
     renderdata.roundingPower = standalone || renderdata.dontRound ? 2.0f : pWindow->presentation().roundingPower();
-    renderdata.blur          = !standalone && !m_bRenderingSnapshot && pWindow->shouldBlur();
+    renderdata.blur          = !standalone && shouldBlur(context, pWindow);
     renderdata.pWindow       = pWindow;
 
     if (standalone) {
@@ -681,25 +678,25 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.pWindow = pWindow;
 
     // for plugins
-    m_renderData.currentWindow = pWindow;
+    context.currentWindow = pWindow;
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
 
     const auto fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
 
-    if (*PDIMAROUND && pWindow->m_ruleApplicator->dimAround().valueOrDefault() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
-        CBox                        monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+    if (*PDIMAROUND && pWindow->m_ruleApplicator->dimAround().valueOrDefault() && !context.renderingSnapshot && mode != RENDER_PASS_POPUP) {
+        CBox                        monbox = {0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y};
         CRectPassElement::SRectData data;
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * fullAlpha);
         data.box   = monbox;
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     renderdata.pos += WINDOWOFFSET;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(PWORKSPACE, pMonitor) &&
+    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(context, PWORKSPACE, pMonitor) &&
         !(pWindow->m_state & WINDOW_STATE_PINNED)) {
         CRegion rg         = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
         renderdata.clipBox = rg.getExtents();
@@ -708,21 +705,23 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     // render window decorations first, if not fullscreen full
     if (mode == RENDER_PASS_ALL || mode == RENDER_PASS_MAIN) {
 
-        const bool      TRANSFORMEDWINDOW = pWindow->effects().hasActiveTransformers();
-        UP<CRenderPass> transformedPass;
-        UP<CScopeGuard> passRedirect;
-        const bool      windowBlur         = renderdata.blur;
-        const bool      windowBlurUsesLive = windowBlur && !shouldUseNewBlurOptimizations(nullptr, pWindow);
-        const auto      backdropScope      = makeShared<SBackdropScope>();
+        const bool                       TRANSFORMEDWINDOW = pWindow->effects().hasActiveTransformers();
+        UP<CRenderPass>                  transformedPass;
+        std::optional<CRenderingContext> transformedContext;
+        CRenderingContext*               elementContext     = &context;
+        const bool                       windowBlur         = renderdata.blur;
+        const bool                       windowBlurUsesLive = windowBlur && !shouldUseNewBlurOptimizations(context, nullptr, pWindow);
+        const auto                       backdropScope      = makeShared<SBackdropScope>();
 
-        addPassElement(makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::BEGIN, backdropScope));
+        addPassElement(context, makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::BEGIN, backdropScope));
 
         if (TRANSFORMEDWINDOW) {
             transformedPass = makeUnique<CRenderPass>();
-            passRedirect    = redirectPass(transformedPass.get());
+            transformedContext.emplace(context, *transformedPass);
+            elementContext  = &*transformedContext;
             renderdata.blur = false;
 
-            pWindow->effects().preWindowRender(&renderdata);
+            pWindow->effects().preWindowRender(*elementContext, &renderdata);
         }
 
         if (renderdata.decorate) {
@@ -730,14 +729,14 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 if (wd->getDecorationLayer() != DECORATION_LAYER_BOTTOM)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(*elementContext, pMonitor, fullAlpha);
             }
 
             for (auto const& wd : pWindow->presentation().decorations()) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_UNDER)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(*elementContext, pMonitor, fullAlpha);
             }
         }
 
@@ -754,16 +753,16 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             data.round          = renderdata.dontRound ? 0 : renderdata.rounding - 1;
             data.blur           = true;
             data.blurA          = renderdata.fadeAlpha;
-            data.xray           = shouldUseNewBlurOptimizations(nullptr, pWindow);
+            data.xray           = shouldUseNewBlurOptimizations(context, nullptr, pWindow);
             data.blurPatternBox = wb;
             data.blurOwner      = pWindow;
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(*elementContext, makeUnique<CRectPassElement>(data));
             renderdata.blur = false;
         }
 
         renderdata.surfaceCounter = 0;
         pWindow->wlSurface()->resource()->breadthfirst(
-            [this, &renderdata, &pWindow](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+            [this, &renderdata, &pWindow, elementContext](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 if (!s->m_current.texture)
                     return;
 
@@ -774,7 +773,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 renderdata.texture     = s->m_current.texture;
                 renderdata.surface     = s;
                 renderdata.mainSurface = s == pWindow->wlSurface()->resource();
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(*elementContext, makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             nullptr);
@@ -786,48 +785,47 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVER)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(*elementContext, pMonitor, fullAlpha);
             }
         }
 
         if (TRANSFORMEDWINDOW) {
-            passRedirect.reset();
-
             CBox currentBox = pWindow->getFullWindowBoundingBox();
             currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET) + WINDOWOFFSET - pMonitor->m_position);
             CBox            transformedBox = pWindow->effects().transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
-            if (!standalone && !m_bRenderingSnapshot) {
-                pWindow->effects().amendTransformedRenderData(transformedBox, &windowMotionBlur);
+            if (!standalone && !context.renderingSnapshot) {
+                pWindow->effects().amendTransformedRenderData(context, transformedBox, &windowMotionBlur);
             }
 
             CBox blurBox = {renderdata.pos.x - pMonitor->m_position.x, renderdata.pos.y - pMonitor->m_position.y, renderdata.w, renderdata.h};
             blurBox.scale(pMonitor->m_scale).round();
 
-            addPassElement(makeUnique<CTransformedWindowPassElement>(CTransformedWindowPassElement::SData{
-                .pass              = std::move(transformedPass),
-                .window            = pWindow,
-                .currentBox        = currentBox,
-                .blurBox           = blurBox,
-                .blur              = windowBlur,
-                .blurUsesLive      = windowBlurUsesLive,
-                .blurA             = renderdata.fadeAlpha,
-                .blurRound         = renderdata.dontRound ? 0 : std::max(renderdata.rounding - 1, 0),
-                .blurRoundingPower = renderdata.roundingPower,
-                .transformedBox    = transformedBox,
-                .motionBlur        = windowMotionBlur,
-                .standalone        = standalone,
-                .renderingSnapshot = m_bRenderingSnapshot,
-            }));
+            addPassElement(context,
+                           makeUnique<CTransformedWindowPassElement>(CTransformedWindowPassElement::SData{
+                               .pass              = std::move(transformedPass),
+                               .window            = pWindow,
+                               .currentBox        = currentBox,
+                               .blurBox           = blurBox,
+                               .blur              = windowBlur,
+                               .blurUsesLive      = windowBlurUsesLive,
+                               .blurA             = renderdata.fadeAlpha,
+                               .blurRound         = renderdata.dontRound ? 0 : std::max(renderdata.rounding - 1, 0),
+                               .blurRoundingPower = renderdata.roundingPower,
+                               .transformedBox    = transformedBox,
+                               .motionBlur        = windowMotionBlur,
+                               .standalone        = standalone,
+                               .renderingSnapshot = context.renderingSnapshot,
+                           }));
 
             renderdata.blur = windowBlur;
         }
 
-        addPassElement(makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::END, backdropScope));
+        addPassElement(context, makeUnique<CBackdropScopePassElement>(CBackdropScopePassElement::eAction::END, backdropScope));
     }
 
-    m_renderData.clipBox = CBox();
+    context.clipBox = CBox();
 
     if (mode == RENDER_PASS_ALL || mode == RENDER_PASS_POPUP) {
         if (!pWindow->backend().isX11()) {
@@ -841,7 +839,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
 
-            renderdata.blur = !m_bRenderingSnapshot && pWindow->popupHead()->shouldBlur();
+            renderdata.blur = (!context.isolatedWorkspace || context.isolatedWorkspaceFullScene) && shouldBlur(context, pWindow->popupHead());
 
             if (renderdata.blur) {
                 renderdata.discardMode |= DISCARD_ALPHA;
@@ -855,8 +853,9 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             const auto PARENTFADEALPHA = renderdata.fadeAlpha;
 
             pWindow->popupHead()->breadthfirst(
-                [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (!popup->mapped() || !popup->resource() || ((!m_isolatedWorkspace || m_isolatedWorkspaceFullScene) && (!popup->acceptsInput() || !popup->alphaNonZero())))
+                [this, &context, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
+                    if (!popup->mapped() || !popup->resource() ||
+                        ((!context.isolatedWorkspace || context.isolatedWorkspaceFullScene) && (!popup->acceptsInput() || !popup->alphaNonZero())))
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();
@@ -865,7 +864,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                     renderdata.fadeAlpha = PARENTFADEALPHA * popup->alpha()[POPUP_ALPHA_FADE]->value();
 
                     popup->wlSurface()->resource()->breadthfirst(
-                        [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+                        [this, &context, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                             if (!s->m_current.texture)
                                 return;
 
@@ -876,7 +875,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                             renderdata.texture     = s->m_current.texture;
                             renderdata.surface     = s;
                             renderdata.mainSurface = false;
-                            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
                             renderdata.surfaceCounter++;
                         },
                         data);
@@ -894,79 +893,79 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVERLAY)
                     continue;
 
-                wd->draw(pMonitor, fullAlpha);
+                wd->draw(context, pMonitor, fullAlpha);
             }
         }
     }
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOW);
 
-    m_renderData.currentWindow.reset();
+    context.currentWindow.reset();
 }
 
-void IHyprRenderer::draw(WP<IPassElement> element, const CRegion& damage) {
+void IHyprRenderer::draw(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage) {
     ASSERT(element);
     if (!element)
         return;
 
-    elementRenderer()->drawElement(element, damage);
+    elementRenderer()->drawElement(context, element, damage);
 }
 
-void IHyprRenderer::draw(const CBorderPassElement::SBorderData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CBorderPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CBorderPassElement::SBorderData& data, const CRegion& damage) {
+    draw(context, makeUnique<CBorderPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CClearPassElement::SClearData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CClearPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CClearPassElement::SClearData& data, const CRegion& damage) {
+    draw(context, makeUnique<CClearPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CFramebufferElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage) {
+    draw(context, makeUnique<CFramebufferElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CRectPassElement::SRectData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CRectPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CRectPassElement::SRectData& data, const CRegion& damage) {
+    draw(context, makeUnique<CRectPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CRendererHintsPassElement::SData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CRendererHintsPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CRendererHintsPassElement::SData& data, const CRegion& damage) {
+    draw(context, makeUnique<CRendererHintsPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CShadowPassElement::SShadowData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CShadowPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CShadowPassElement::SShadowData& data, const CRegion& damage) {
+    draw(context, makeUnique<CShadowPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CSurfacePassElement::SRenderData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CSurfacePassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CSurfacePassElement::SRenderData& data, const CRegion& damage) {
+    draw(context, makeUnique<CSurfacePassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CTexPassElement::SRenderData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CTexPassElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CTexPassElement::SRenderData& data, const CRegion& damage) {
+    draw(context, makeUnique<CTexPassElement>(data), damage);
 }
 
-void IHyprRenderer::draw(const CTextureMatteElement::STextureMatteData& data, const CRegion& damage) {
-    elementRenderer()->drawElement(makeUnique<CTextureMatteElement>(data), damage);
+void IHyprRenderer::draw(CRenderingContext& context, const CTextureMatteElement::STextureMatteData& data, const CRegion& damage) {
+    draw(context, makeUnique<CTextureMatteElement>(data), damage);
 }
 
-void IHyprRenderer::bindFB(SP<IFramebuffer> fb) {
+void IHyprRenderer::bindFB(CRenderingContext& context, SP<IFramebuffer> fb) {
     fb->bind();
-    m_renderData.currentFB = fb;
+    context.currentFB = fb;
 }
 
-UP<CScopeGuard> IHyprRenderer::bindTempFB(SP<IFramebuffer> fb) {
-    const auto oldFB = m_renderData.currentFB;
-    bindFB(fb);
-    return makeUnique<CScopeGuard>([this, oldFB] { bindFB(oldFB); });
+UP<CScopeGuard> IHyprRenderer::bindTempFB(CRenderingContext& context, SP<IFramebuffer> fb) {
+    const auto oldFB = context.currentFB;
+    bindFB(context, fb);
+    return makeUnique<CScopeGuard>([this, &context, oldFB] { bindFB(context, oldFB); });
 }
 
-bool IHyprRenderer::preBlurQueued(PHLMONITORREF pMonitor) {
+bool IHyprRenderer::preBlurQueued(const CRenderingContext& context) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Config::INTEGER>("decoration:blur:new_optimizations");
     static auto PBLUR            = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
 
-    if (!pMonitor)
+    if (!context.sceneMonitor)
         return false;
-    return pMonitor->m_blurFBDirty && *PBLURNEWOPTIMIZE && *PBLUR && pMonitor->m_blurFBShouldRender;
+    return context.sceneMonitor->m_blurFBDirty && *PBLURNEWOPTIMIZE && *PBLUR && context.precomputeBlur;
 }
 
 SP<ITexture> IHyprRenderer::createTexture(const SP<Aquamarine::IBuffer> buffer, bool keepDataCopy) {
@@ -999,7 +998,7 @@ SP<ITexture> IHyprRenderer::createTexture(const SP<Aquamarine::IBuffer> buffer, 
     return tex;
 }
 
-void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::steady_tp& time, bool popups, bool lockscreen) {
+void IHyprRenderer::renderLayer(CRenderingContext& context, PHLLS pLayer, PHLMONITOR pMonitor, const Time::steady_tp& time, bool popups, bool lockscreen) {
     if (!pLayer)
         return;
 
@@ -1013,11 +1012,11 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
 
     static auto PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
 
-    if (*PDIMAROUND && pLayer->m_ruleApplicator->dimAround().valueOrDefault() && !m_bRenderingSnapshot && !popups) {
+    if (*PDIMAROUND && pLayer->m_ruleApplicator->dimAround().valueOrDefault() && !context.renderingSnapshot && !popups) {
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pLayer->alpha()[LS_ALPHA_FADE]->value());
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     TRACY_GPU_ZONE("RenderLayer");
@@ -1027,7 +1026,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time, REALPOS};
     renderdata.fadeAlpha                        = pLayer->alpha()[LS_ALPHA_FADE]->value();
-    renderdata.blur                             = !m_bRenderingSnapshot && pLayer->shouldBlur();
+    renderdata.blur                             = shouldBlur(context, pLayer);
     renderdata.surface                          = pLayer->wlSurface()->resource();
     renderdata.decorate                         = false;
     renderdata.w                                = REALSIZ.x;
@@ -1043,7 +1042,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
 
     if (!popups)
         pLayer->wlSurface()->resource()->breadthfirst(
-            [this, &renderdata, &pLayer](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+            [this, &context, &renderdata, &pLayer](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 if (!s->m_current.texture)
                     return;
 
@@ -1054,7 +1053,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = s->m_current.texture;
                 renderdata.surface     = s;
                 renderdata.mainSurface = s == pLayer->wlSurface()->resource();
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -1072,7 +1071,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
     renderdata.surfaceCounter = 0;
     if (popups) {
         pLayer->popupHead()->breadthfirst(
-            [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
+            [this, &context, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
                 if (!popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
                     return;
 
@@ -1089,14 +1088,14 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = SURF->m_current.texture;
                 renderdata.surface     = SURF;
                 renderdata.mainSurface = false;
-                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
     }
 }
 
-void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, const Time::steady_tp& time) {
+void IHyprRenderer::renderIMEPopup(CRenderingContext& context, CInputPopup* pPopup, PHLMONITOR pMonitor, const Time::steady_tp& time) {
     const auto                       POS = pPopup->globalBox().pos();
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time, POS};
@@ -1119,7 +1118,7 @@ void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, con
     }
 
     SURF->breadthfirst(
-        [this, &renderdata, &SURF](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+        [this, &context, &renderdata, &SURF](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;
 
@@ -1130,13 +1129,13 @@ void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, con
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == SURF;
-            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
 }
 
-void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, PHLMONITOR pMonitor, const Time::steady_tp& time) {
+void IHyprRenderer::renderSessionLockSurface(CRenderingContext& context, WP<SSessionLockSurface> pSurface, PHLMONITOR pMonitor, const Time::steady_tp& time) {
     static auto                      PSESSIONLOCKXRAY = CConfigValue<Config::BOOL>("misc:session_lock_xray");
     static auto                      PSESSIONLOCKBLUR = CConfigValue<Config::BOOL>("misc:session_lock_blur");
 
@@ -1149,7 +1148,7 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
     renderdata.h        = pMonitor->m_size.y;
 
     renderdata.surface->breadthfirst(
-        [this, &renderdata, &pSurface](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+        [this, &context, &renderdata, &pSurface](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;
 
@@ -1160,13 +1159,14 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == pSurface->surface->surface();
-            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
 }
 
-void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time, const Vector2D& translate, const float& scale) {
+void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time, const Vector2D& translate,
+                                                 const float& scale) {
     static auto PXPMODE          = CConfigValue<Config::INTEGER>("render:xp_mode");
     static auto PSESSIONLOCKXRAY = CConfigValue<Config::INTEGER>("misc:session_lock_xray");
 
@@ -1187,70 +1187,70 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
-    CScopeGuard x([&RENDERMODIFDATA] {
+    CScopeGuard x([&context, &RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
     if UNLIKELY (!pWorkspace) {
         // allow rendering without a workspace. In this case, just render layers.
 
-        renderBackground(pMonitor);
+        renderBackground(context, pMonitor);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        if (!m_isolatedWorkspace)
+        if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
 
         return;
     }
 
     if LIKELY (!*PXPMODE) {
-        renderBackground(pMonitor);
+        renderBackground(context, pMonitor);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
-        if (!m_isolatedWorkspace)
+        if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
-            renderLayer(ls.lock(), pMonitor, time);
+            renderLayer(context, ls.lock(), pMonitor, time);
         }
-        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
+        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
     }
 
     // pre window pass
-    if (preBlurQueued(pMonitor))
-        addPassElement(makeUnique<CPreBlurElement>());
+    if (preBlurQueued(context))
+        addPassElement(context, makeUnique<CPreBlurElement>());
 
     if UNLIKELY /* subjective? */ (Fullscreen::controller()->hasFullscreen(pWorkspace))
-        renderWorkspaceWindowsFullscreen(pMonitor, pWorkspace, time);
+        renderWorkspaceWindowsFullscreen(context, pMonitor, pWorkspace, time);
     else
-        renderWorkspaceWindows(pMonitor, pWorkspace, time);
+        renderWorkspaceWindows(context, pMonitor, pWorkspace, time);
 
     // and then special
     if UNLIKELY (pMonitor->m_specialDim->value() != 0.F) {
@@ -1258,7 +1258,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
         data.color = CHyprColor(0, 0, 0, pMonitor->m_specialDim->value());
 
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     if UNLIKELY (pMonitor->m_specialBlur->value() != 0.F) {
@@ -1268,7 +1268,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.blur  = true;
         data.blurA = pMonitor->m_specialBlur->value();
 
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     std::vector<PHLWORKSPACE> specialWorkspaces;
@@ -1283,13 +1283,13 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     }
 
     for (const auto& workspace : specialWorkspaces) {
-        if (workspaceRenderAlpha(workspace, pMonitor) <= 0.F)
+        if (workspaceRenderAlpha(context, workspace, pMonitor) <= 0.F)
             continue;
 
         if (Fullscreen::controller()->hasFullscreen(workspace))
-            renderWorkspaceWindowsFullscreen(pMonitor, workspace, time);
+            renderWorkspaceWindowsFullscreen(context, pMonitor, workspace, time);
         else
-            renderWorkspaceWindows(pMonitor, workspace, time);
+            renderWorkspaceWindows(context, pMonitor, workspace, time);
     }
 
     // pinned always above
@@ -1300,38 +1300,38 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         if (!(w->m_state & WINDOW_STATE_PINNED) || !w->isFloating())
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
+        if (!shouldRenderWindow(context, w, pMonitor))
             continue;
 
         // render the bad boy
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(context, w, pMonitor, time, true, RENDER_PASS_ALL);
     }
 
-    if (!m_isolatedWorkspace)
+    if (!context.isolatedWorkspace)
         Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOWS);
 
     // Render surfaces above windows for monitor
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-        renderLayer(ls.lock(), pMonitor, time);
+        renderLayer(context, ls.lock(), pMonitor, time);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
+    renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
-        renderLayer(ls.lock(), pMonitor, time);
+        renderLayer(context, ls.lock(), pMonitor, time);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
+    renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
 
     for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
         for (auto const& ls : lsl) {
-            renderLayer(ls.lock(), pMonitor, time, true);
+            renderLayer(context, ls.lock(), pMonitor, time, true);
         }
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_POPUP);
+    renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_POPUP);
 
-    renderDragIcon(pMonitor, time);
+    renderDragIcon(context, pMonitor, time);
 }
 
-void IHyprRenderer::renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
+void IHyprRenderer::renderIME(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
     Vector2D translate = {geometry.x, geometry.y};
     float    scale     = sc<float>(geometry.width) / pMonitor->m_transformedSize.x;
 
@@ -1350,22 +1350,22 @@ void IHyprRenderer::renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, c
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
-    CScopeGuard x([&RENDERMODIFDATA] {
+    CScopeGuard x([&context, &RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
     // Render IME popups above everything
     for (auto const& imep : g_pInputManager->m_relay.m_inputMethodPopups) {
         if (imep->shouldBeRendered())
-            renderIMEPopup(imep.get(), pMonitor, now);
+            renderIMEPopup(context, imep.get(), pMonitor, now);
     }
 }
 
-SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
+SP<ITexture> IHyprRenderer::getBackground(CRenderingContext& context, PHLMONITOR pMonitor) {
 
     if (m_backgroundResourceFailed)
         return nullptr;
@@ -1402,18 +1402,14 @@ SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
             auto fb = createFB("BGTex scale");
             fb->alloc(monW, monH);
 
-            auto       guard = bindTempFB(fb);
-
-            const auto oldProjType     = m_renderData.projectionType;
-            const auto oldFbSize       = m_renderData.fbSize;
-            const auto oldTransformDmg = m_renderData.transformDamage;
-
-            m_renderData.fbSize = Vector2D{monW, monH};
-            setProjectionType(RPT_EXPORT);
-            m_renderData.transformDamage = false;
+            CRenderingContext child{context, context.renderPass()};
+            auto              guard = bindTempFB(child, fb);
+            child.fbSize            = Vector2D{monW, monH};
+            setProjectionType(child, RPT_EXPORT);
+            child.transformDamage = false;
             setViewport(0, 0, monW, monH);
 
-            draw(CClearPassElement::SClearData{{0.F, 0.F, 0.F, 0.F}});
+            draw(child, CClearPassElement::SClearData{{0.F, 0.F, 0.F, 0.F}});
 
             const double texW = origW * scale;
             const double texH = origH * scale;
@@ -1421,12 +1417,7 @@ SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
             const double offY = (monH - texH) / 2.0;
 
             CRegion      fullDamage = {0, 0, monW, monH};
-            draw(CTexPassElement::SRenderData{.tex = backgroundTexture, .box = CBox{offX, offY, texW, texH}, .damage = fullDamage}, fullDamage);
-
-            m_renderData.fbSize          = oldFbSize;
-            m_renderData.transformDamage = oldTransformDmg;
-            setProjectionType(oldProjType);
-            setViewport(0, 0, (int)m_renderData.currentFB->m_size.x, (int)m_renderData.currentFB->m_size.y);
+            draw(child, CTexPassElement::SRenderData{.tex = backgroundTexture, .box = CBox{offX, offY, texW, texH}, .damage = fullDamage}, fullDamage);
 
             backgroundTexture = fb->getTexture();
 
@@ -1444,44 +1435,44 @@ SP<ITexture> IHyprRenderer::getBackground(PHLMONITOR pMonitor) {
     return backgroundTexture;
 }
 
-void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
+void IHyprRenderer::renderBackground(CRenderingContext& context, PHLMONITOR pMonitor) {
     static auto PRENDERTEX       = CConfigValue<Config::INTEGER>("misc:disable_hyprland_logo");
     static auto PBACKGROUNDCOLOR = CConfigValue<Config::INTEGER>("misc:background_color");
     static auto PNOSPLASH        = CConfigValue<Config::INTEGER>("misc:disable_splash_rendering");
 
     if (*PRENDERTEX /* inverted cfg flag */ || pMonitor->m_backgroundOpacity->isBeingAnimated())
-        addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+        addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
     if (!*PRENDERTEX) {
         static auto PBACKGROUNDCOLOR = CConfigValue<Config::INTEGER>("misc:background_color");
 
         if (!pMonitor->m_background)
-            pMonitor->m_background = getBackground(pMonitor);
+            pMonitor->m_background = getBackground(context, pMonitor);
 
         if (!pMonitor->m_background)
-            addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+            addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
         else {
             CTexPassElement::SRenderData data;
-            const double                 MONRATIO = m_renderData.pMonitor->m_transformedSize.x / m_renderData.pMonitor->m_transformedSize.y;
+            const double                 MONRATIO = context.sceneMonitor->m_transformedSize.x / context.sceneMonitor->m_transformedSize.y;
             const double                 WPRATIO  = pMonitor->m_background->m_size.x / pMonitor->m_background->m_size.y;
             Vector2D                     origin;
             double                       scale = 1.0;
 
             if (MONRATIO > WPRATIO) {
-                scale    = m_renderData.pMonitor->m_transformedSize.x / pMonitor->m_background->m_size.x;
-                origin.y = (m_renderData.pMonitor->m_transformedSize.y - pMonitor->m_background->m_size.y * scale) / 2.0;
+                scale    = context.sceneMonitor->m_transformedSize.x / pMonitor->m_background->m_size.x;
+                origin.y = (context.sceneMonitor->m_transformedSize.y - pMonitor->m_background->m_size.y * scale) / 2.0;
             } else {
-                scale    = m_renderData.pMonitor->m_transformedSize.y / pMonitor->m_background->m_size.y;
-                origin.x = (m_renderData.pMonitor->m_transformedSize.x - pMonitor->m_background->m_size.x * scale) / 2.0;
+                scale    = context.sceneMonitor->m_transformedSize.y / pMonitor->m_background->m_size.y;
+                origin.x = (context.sceneMonitor->m_transformedSize.x - pMonitor->m_background->m_size.x * scale) / 2.0;
             }
 
             if (MONRATIO != WPRATIO)
-                addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+                addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
             data.box = {origin, pMonitor->m_background->m_size * scale};
-            data.a   = m_renderData.pMonitor->m_backgroundOpacity->value();
+            data.a   = context.sceneMonitor->m_backgroundOpacity->value();
             data.tex = pMonitor->m_background;
-            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 
@@ -1495,7 +1486,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             CTexPassElement::SRenderData data;
             data.box = {{(monitorSize.x - pMonitor->m_splash->m_size.x) / 2.0, monitorSize.y * 0.98 - pMonitor->m_splash->m_size.y}, pMonitor->m_splash->m_size};
             data.tex = pMonitor->m_splash;
-            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 }
@@ -1597,15 +1588,15 @@ SP<ITexture> IHyprRenderer::loadAsset(const std::string& filename) {
     return tex;
 }
 
-SP<ITexture> IHyprRenderer::getBlurTexture(PHLMONITORREF pMonitor) {
+SP<ITexture> IHyprRenderer::getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor) {
     return pMonitor->resources()->m_blurFB->getTexture();
 }
 
-bool IHyprRenderer::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow) {
+bool IHyprRenderer::shouldUseNewBlurOptimizations(const CRenderingContext& context, PHLLS pLayer, PHLWINDOW pWindow) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Config::INTEGER>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Config::INTEGER>("decoration:blur:xray");
 
-    if (m_isolatedWorkspaceFullScene || !getBlurTexture(m_renderData.pMonitor))
+    if (context.isolatedWorkspaceFullScene || !getBlurTexture(context, context.sceneMonitor))
         return false;
 
     if (blurProviderRequiresLiveBlur())
@@ -1744,7 +1735,7 @@ void IHyprRenderer::ensureLockTexturesRendered(bool load) {
     }
 }
 
-void IHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
+void IHyprRenderer::renderLockscreen(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {
     TRACY_GPU_ZONE("RenderLockscreen");
 
     const bool LOCKED = g_pSessionLockManager->isSessionLocked();
@@ -1755,7 +1746,7 @@ void IHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
 
     const bool RENDERPRIMER = g_pSessionLockManager->shallConsiderLockMissing() || g_pSessionLockManager->clientLocked() || g_pSessionLockManager->clientDenied();
     if (RENDERPRIMER)
-        renderSessionLockPrimer(pMonitor);
+        renderSessionLockPrimer(context, pMonitor);
 
     const auto PSLS              = g_pSessionLockManager->getSessionLockSurfaceForMonitor(pMonitor->m_id);
     const bool RENDERLOCKMISSING = (PSLS.expired() || g_pSessionLockManager->clientDenied()) && g_pSessionLockManager->shallConsiderLockMissing();
@@ -1763,26 +1754,26 @@ void IHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
     ensureLockTexturesRendered(RENDERLOCKMISSING);
 
     if (RENDERLOCKMISSING)
-        renderSessionLockMissing(pMonitor);
+        renderSessionLockMissing(context, pMonitor);
     else if (PSLS) {
-        renderSessionLockSurface(PSLS, pMonitor, now);
+        renderSessionLockSurface(context, PSLS, pMonitor, now);
         g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->m_id);
 
         // render layers and then their popups for abovelock rule
         for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
             for (auto const& ls : lsl) {
-                renderLayer(ls.lock(), pMonitor, now, false, true);
+                renderLayer(context, ls.lock(), pMonitor, now, false, true);
             }
         }
         for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
             for (auto const& ls : lsl) {
-                renderLayer(ls.lock(), pMonitor, now, true, true);
+                renderLayer(context, ls.lock(), pMonitor, now, true, true);
             }
         }
     }
 }
 
-void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
+void IHyprRenderer::renderSessionLockPrimer(CRenderingContext& context, PHLMONITOR pMonitor) {
     static auto PSESSIONLOCKXRAY = CConfigValue<Config::INTEGER>("misc:session_lock_xray");
     if (*PSESSIONLOCKXRAY)
         return;
@@ -1791,10 +1782,10 @@ void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
     data.color = CHyprColor(0, 0, 0, 1.f);
     data.box   = CBox{{}, pMonitor->m_transformedSize};
 
-    addPassElement(makeUnique<CRectPassElement>(data));
+    addPassElement(context, makeUnique<CRectPassElement>(data));
 }
 
-void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
+void IHyprRenderer::renderSessionLockMissing(CRenderingContext& context, PHLMONITOR pMonitor) {
     if (g_pCompositor->m_startLocked && !g_pCompositor->m_startLockedCommand.empty())
         return;
 
@@ -1811,7 +1802,7 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
     data.box = monbox;
     data.a   = 1;
 
-    addPassElement(makeUnique<CTexPassElement>(data));
+    addPassElement(context, makeUnique<CTexPassElement>(data));
 
     if (!ANY_PRESENT && m_lockTtyTextTexture) {
         // also render text for the tty number
@@ -1819,53 +1810,53 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
         data.tex    = m_lockTtyTextTexture;
         data.box    = texbox;
 
-        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 
-bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode, SP<IHLBuffer> buffer, SP<IFramebuffer> fb, bool simple,
+bool IHyprRenderer::beginRender(CRenderingContext& context, CRegion& damage, eRenderMode mode, SP<IHLBuffer> buffer, SP<IFramebuffer> fb, bool simple,
                                 std::optional<Monitor::CDamageRing::CTransaction>* damageTransaction) {
-    m_renderPass.clear();
-    m_backdropCaptures.clear();
-    clearCMSettingsCache();
-    m_renderMode          = mode;
-    m_renderData.pMonitor = pMonitor;
+    context.renderPass().clear();
+    context.backdropCaptures.clear();
+    context.cmSettingsCache->entries.clear();
+    context.renderMode  = mode;
+    const auto pMonitor = context.outputMonitor.lock();
 
     if (simple) {
-        m_renderData.fbSize = fb ? fb->m_size : buffer->m_texture->m_size;
-        setProjectionType(RPT_EXPORT);
+        context.fbSize = fb ? fb->m_size : buffer->m_texture->m_size;
+        setProjectionType(context, RPT_EXPORT);
     } else
-        setProjectionType(RPT_MONITOR);
+        setProjectionType(context, RPT_MONITOR);
 
-    const auto RESOURCES     = g_pHyprRenderer->m_renderData.pMonitor->resources();
+    const auto RESOURCES     = context.sceneMonitor->resources();
     const bool HAS_MIRROR_FB = RESOURCES->hasMirrorFB();
 
     if (HAS_MIRROR_FB && !RESOURCES->shouldKeepMirrorFB())
         RESOURCES->releaseMirrorFB();
 
-    if (m_renderMode == RENDER_MODE_FULL_FAKE)
-        return beginFullFakeRenderInternal(pMonitor, damage, fb, simple);
+    if (context.renderMode == RENDER_MODE_FULL_FAKE)
+        return beginFullFakeRenderInternal(context, damage, fb, simple);
 
     int bufferAge = 0;
 
     if (!buffer) {
-        m_currentBuffer = pMonitor->m_output->swapchain->next(&bufferAge);
-        if (!m_currentBuffer) {
+        context.buffer = pMonitor->m_output->swapchain->next(&bufferAge);
+        if (!context.buffer) {
             Log::logger->log(Log::ERR, "Failed to acquire swapchain buffer for {}", pMonitor->m_name);
             return false;
         }
     } else
-        m_currentBuffer = buffer;
+        context.buffer = buffer;
 
     initRender();
 
-    if (!initRenderBuffer(m_currentBuffer, pMonitor->m_output->state->state().drmFormat)) {
+    if (!initRenderBuffer(context, context.buffer, pMonitor->m_output->state->state().drmFormat)) {
         Log::logger->log(Log::ERR, "failed to start a render pass for output {}, no RBO could be obtained", pMonitor->m_name);
         return false;
     }
 
     std::optional<Monitor::CDamageRing::CTransaction> transaction;
-    if (m_renderMode == RENDER_MODE_NORMAL) {
+    if (context.renderMode == RENDER_MODE_NORMAL) {
         transaction.emplace(pMonitor->m_damage.beginTransaction());
         damage = transaction->getBufferDamage(bufferAge);
 
@@ -1873,7 +1864,7 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
             damage.add(pMonitor->resources()->pendingMirrorFBDamage());
     }
 
-    const auto  res     = beginRenderInternal(pMonitor, damage, simple);
+    const auto  res     = beginRenderInternal(context, damage, simple);
     static bool initial = true;
     if (initial) {
         initAssets();
@@ -1881,7 +1872,7 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
     }
 
     if (!res) {
-        if (m_renderMode == RENDER_MODE_NORMAL && !buffer)
+        if (context.renderMode == RENDER_MODE_NORMAL && !buffer)
             pMonitor->m_output->swapchain->rollback();
         return false;
     }
@@ -1896,9 +1887,9 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
     return true;
 }
 
-void IHyprRenderer::setDamage(const CRegion& damage_, std::optional<CRegion> finalDamage) {
-    m_renderData.damage.set(damage_);
-    m_renderData.finalDamage.set(finalDamage.value_or(damage_));
+void IHyprRenderer::setDamage(CRenderingContext& context, const CRegion& damage_, std::optional<CRegion> finalDamage) {
+    context.damage.set(damage_);
+    context.finalDamage.set(finalDamage.value_or(damage_));
 }
 
 static Mat3x3 getFBProjection(PHLMONITORREF pMonitor, const Vector2D& size) {
@@ -1909,74 +1900,68 @@ static Mat3x3 getFBProjection(PHLMONITORREF pMonitor, const Vector2D& size) {
     return Mat3x3::identity().translate(size / 2.0).transform(Math::wlTransformToHyprutils(pMonitor->m_transform)).translate(-tfmd / 2.0);
 }
 
-void IHyprRenderer::setProjectionType(const Vector2D& fbSize) {
-    m_renderData.fbSize = fbSize;
-    setProjectionType(RPT_FB);
+void IHyprRenderer::setProjectionType(CRenderingContext& context, const Vector2D& fbSize) {
+    context.fbSize = fbSize;
+    setProjectionType(context, RPT_FB);
 }
 
-void IHyprRenderer::setProjectionType(eRenderProjectionType projectionType) {
-    m_renderData.projectionType = projectionType;
+void IHyprRenderer::setProjectionType(CRenderingContext& context, eRenderProjectionType projectionType) {
+    context.projectionType = projectionType;
     switch (projectionType) {
         case RPT_MONITOR:
-        case RPT_EXPORT: m_renderData.targetProjection = Mat3x3::identity(); break;
-        case RPT_OUTPUT: m_renderData.targetProjection = m_renderData.pMonitor->getTransformMatrix(); break;
-        case RPT_FB: m_renderData.targetProjection = getFBProjection(m_renderData.pMonitor, m_renderData.fbSize); break;
+        case RPT_EXPORT: context.targetProjection = Mat3x3::identity(); break;
+        case RPT_OUTPUT: context.targetProjection = context.sceneMonitor->getTransformMatrix(); break;
+        case RPT_FB: context.targetProjection = getFBProjection(context.sceneMonitor, context.fbSize); break;
         default: UNREACHABLE();
     }
 }
 
-Mat3x3 IHyprRenderer::getBoxProjection(const CBox& box, std::optional<eTransform> transform) {
-    return m_renderData.targetProjection.projectBox(box, transform.value_or(HYPRUTILS_TRANSFORM_NORMAL), box.rot);
+Mat3x3 IHyprRenderer::getBoxProjection(const CRenderingContext& context, const CBox& box, std::optional<eTransform> transform) {
+    return context.targetProjection.projectBox(box, transform.value_or(HYPRUTILS_TRANSFORM_NORMAL), box.rot);
 }
 
-Mat3x3 IHyprRenderer::projectBoxToTarget(const CBox& box, std::optional<eTransform> transform) {
-    const auto TARGET_SIZE = m_renderData.projectionType == RPT_MONITOR ? m_renderData.pMonitor->m_transformedSize : m_renderData.fbSize;
+Mat3x3 IHyprRenderer::projectBoxToTarget(const CRenderingContext& context, const CBox& box, std::optional<eTransform> transform) {
+    const auto TARGET_SIZE = context.projectionType == RPT_MONITOR ? context.sceneMonitor->m_transformedSize : context.fbSize;
     const auto OUTPUT_PROJECTION =
-        m_renderData.projectionType == RPT_OUTPUT ? m_renderData.pMonitor->getScaleMatrix() : Mat3x3::outputProjection(TARGET_SIZE, HYPRUTILS_TRANSFORM_NORMAL);
+        context.projectionType == RPT_OUTPUT ? context.sceneMonitor->getScaleMatrix() : Mat3x3::outputProjection(TARGET_SIZE, HYPRUTILS_TRANSFORM_NORMAL);
 
-    return OUTPUT_PROJECTION.copy().multiply(getBoxProjection(box, transform));
+    return OUTPUT_PROJECTION.copy().multiply(getBoxProjection(context, box, transform));
 }
 
-SP<IFramebuffer> IHyprRenderer::blurMainFramebuffer(float strength, const CRegion& originalDamage, const SBlurContext& context) {
-    const auto renderTarget = m_renderData.currentFB;
-    const auto blurSource   = !m_backdropCaptures.empty() && m_backdropCaptures.back().framebuffer ? m_backdropCaptures.back().framebuffer : renderTarget;
+SP<IFramebuffer> IHyprRenderer::blurMainFramebuffer(CRenderingContext& context, float strength, const CRegion& originalDamage, const SBlurContext& blurContext) {
+    const auto renderTarget = context.currentFB;
+    const auto blurSource   = !context.backdropCaptures.empty() && context.backdropCaptures.back().framebuffer ? context.backdropCaptures.back().framebuffer : renderTarget;
 
     if (!blurSource || !blurSource->getTexture()) {
         Log::logger->log(Log::ERR, "BUG THIS: null fb texture while attempting to blur main fb?! (introspection off?!)");
-        return m_renderData.pMonitor->resources()->m_blurFB; // return something to sample from at least
+        return context.sceneMonitor->resources()->m_blurFB;
     }
 
-    auto guard = bindTempFB(renderTarget); // blurFramebuffer messes with FB bindings
-    return blurFramebuffer(blurSource, strength, originalDamage, context);
+    auto guard = bindTempFB(context, renderTarget); // blurFramebuffer messes with FB bindings
+    return blurFramebuffer(context, blurSource, strength, originalDamage, blurContext);
 }
 
-void IHyprRenderer::beginBackdropScope(SP<SBackdropScope> scope) {
+void IHyprRenderer::beginBackdropScope(CRenderingContext& context, SP<SBackdropScope> scope) {
     RASSERT(scope, "Cannot begin a null backdrop scope");
 
     SP<IFramebuffer> backdrop;
-    if (scope->required && !scope->damage.empty() && m_renderData.currentFB && m_renderData.currentFB->getTexture()) {
-        backdrop = m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+    if (scope->required && !scope->damage.empty() && context.currentFB && context.currentFB->getTexture()) {
+        backdrop = context.sceneMonitor->resources()->getUnusedWorkBuffer();
         if (backdrop) {
-            const auto renderTarget     = m_renderData.currentFB;
-            const auto savedDamage      = m_renderData.damage.copy();
-            const auto savedRenderModif = m_renderData.renderModif;
-            const auto savedNearest     = m_renderData.useNearestNeighbor;
-            const auto backend          = glBackend();
-            const auto savedBlend       = backend && backend->blendEnabled();
+            const auto renderTarget = context.currentFB;
+            const auto backend      = glBackend();
+            const auto savedBlend   = backend && backend->blendEnabled();
 
             {
-                auto guard                      = bindTempFB(backdrop);
-                m_renderData.damage             = scope->damage;
-                m_renderData.renderModif        = {};
-                m_renderData.useNearestNeighbor = true;
+                CRenderingContext child{context, context.renderPass()};
+                auto              guard  = bindTempFB(child, backdrop);
+                child.damage             = scope->damage;
+                child.renderModif        = {};
+                child.useNearestNeighbor = true;
                 blend(false);
-                renderOffToMain(renderTarget);
+                renderOffToMain(child, renderTarget);
                 blend(savedBlend);
             }
-
-            m_renderData.damage             = savedDamage;
-            m_renderData.renderModif        = savedRenderModif;
-            m_renderData.useNearestNeighbor = savedNearest;
         } else {
             static bool warned = false;
             if (!warned) {
@@ -1986,17 +1971,17 @@ void IHyprRenderer::beginBackdropScope(SP<SBackdropScope> scope) {
         }
     }
 
-    m_backdropCaptures.emplace_back(SBackdropCapture{.scope = std::move(scope), .framebuffer = std::move(backdrop)});
+    context.backdropCaptures.emplace_back(SBackdropCapture{.scope = std::move(scope), .framebuffer = std::move(backdrop)});
 }
 
-void IHyprRenderer::endBackdropScope(SP<SBackdropScope> scope) {
-    RASSERT(!m_backdropCaptures.empty() && m_backdropCaptures.back().scope == scope, "Unbalanced runtime backdrop scope");
-    m_backdropCaptures.pop_back();
+void IHyprRenderer::endBackdropScope(CRenderingContext& context, SP<SBackdropScope> scope) {
+    RASSERT(!context.backdropCaptures.empty() && context.backdropCaptures.back().scope == scope, "Unbalanced runtime backdrop scope");
+    context.backdropCaptures.pop_back();
 }
 
-void IHyprRenderer::scheduleFrameForAnimatedBlur(const CRegion& damage, bool usesPrecomputedBlur) {
-    const auto monitor = m_renderData.pMonitor;
-    if (m_renderMode != RENDER_MODE_NORMAL || !monitor || monitor->isMirror() || damage.empty())
+void IHyprRenderer::scheduleFrameForAnimatedBlur(const CRenderingContext& context, const CRegion& damage, bool usesPrecomputedBlur) {
+    const auto monitor = context.sceneMonitor;
+    if (context.renderMode != RENDER_MODE_NORMAL || !monitor || monitor->isMirror() || damage.empty())
         return;
 
     if (usesPrecomputedBlur)
@@ -2005,33 +1990,34 @@ void IHyprRenderer::scheduleFrameForAnimatedBlur(const CRegion& damage, bool use
     monitor->addDamage(damage);
 }
 
-void IHyprRenderer::preBlurForCurrentMonitor(const CRegion& fakeDamage) {
+void IHyprRenderer::preBlurForCurrentMonitor(CRenderingContext& context, const CRegion& fakeDamage) {
 
-    const auto blurredFB  = blurMainFramebuffer(1, fakeDamage);
+    const auto blurredFB  = blurMainFramebuffer(context, 1, fakeDamage);
     const auto blurredTex = blurredFB->getTexture();
 
     // render onto blurFB
-    auto guard = bindTempFB(m_renderData.pMonitor->resources()->m_blurFB);
+    auto guard = bindTempFB(context, context.sceneMonitor->resources()->m_blurFB);
 
-    draw(CClearPassElement::SClearData{{0, 0, 0, 0}});
+    draw(context, CClearPassElement::SClearData{{0, 0, 0, 0}});
 
-    draw(
-        CTexPassElement::SRenderData{
-            .tex    = blurredTex,
-            .box    = CBox{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y},
-            .damage = fakeDamage,
-        },
-        fakeDamage); // .noAA = true
+    draw(context,
+         CTexPassElement::SRenderData{
+             .tex    = blurredTex,
+             .box    = CBox{0, 0, context.sceneMonitor->m_transformedSize.x, context.sceneMonitor->m_transformedSize.y},
+             .damage = fakeDamage,
+         },
+         fakeDamage); // .noAA = true
 }
 
-static bool isSDR2HDR(const NColorManagement::SImageDescription& imageDescription, const NColorManagement::SImageDescription& targetImageDescription) {
+static bool isSDR2HDR(const CRenderingContext& context, const NColorManagement::SImageDescription& imageDescription,
+                      const NColorManagement::SImageDescription& targetImageDescription) {
     // might be too strict
     return (imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_SRGB ||
             imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22) &&
         (targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ||
          targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_HLG ||
          (targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR &&
-          g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ));
+          context.sceneMonitor->m_imageDescription->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ));
 }
 
 static bool isHDR2SDR(const NColorManagement::SImageDescription& imageDescription, const NColorManagement::SImageDescription& targetImageDescription) {
@@ -2042,17 +2028,14 @@ static bool isHDR2SDR(const NColorManagement::SImageDescription& imageDescriptio
          targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22);
 }
 
-void IHyprRenderer::clearCMSettingsCache() {
-    m_cmSettingsCache.clear();
-}
-
-SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
-                                         SP<CWLSurfaceResource> surface, bool modifySDR, float sdrMinLuminance, int sdrMaxLuminance, bool shouldUseSurface) {
+SCMSettings IHyprRenderer::getCMSettings(const CRenderingContext& context, const NColorManagement::PImageDescription imageDescription,
+                                         const NColorManagement::PImageDescription targetImageDescription, SP<CWLSurfaceResource> surface, bool modifySDR, float sdrMinLuminance,
+                                         int sdrMaxLuminance, bool shouldUseSurface) {
     const auto srcId = imageDescription->id();
     const auto dstId = targetImageDescription->id();
-    void*      sPtr  = shouldUseSurface ? m_renderData.surface.get() : nullptr;
+    void*      sPtr  = shouldUseSurface ? context.surface.get() : nullptr;
 
-    for (auto const& entry : m_cmSettingsCache) {
+    for (auto const& entry : context.cmSettingsCache->entries) {
         if (entry.srcDescId == srcId && entry.dstDescId == dstId && entry.surfacePtr == sPtr && entry.modifySDR == modifySDR && entry.sdrMinLuminance == sdrMinLuminance &&
             entry.sdrMaxLuminance == sdrMaxLuminance)
             return entry.settings;
@@ -2061,11 +2044,11 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     const auto                          sdrEOTF = NTransferFunction::fromConfig();
     NColorManagement::eTransferFunction srcTF;
 
-    const int                           tonemapMode = shouldUseSurface && m_renderData.currentWindow ? m_renderData.currentWindow->m_ruleApplicator->tonemap().valueOr(1) : 1;
+    const int                           tonemapMode = shouldUseSurface && context.currentWindow ? context.currentWindow->m_ruleApplicator->tonemap().valueOr(1) : 1;
 
-    if (shouldUseSurface && m_renderData.surface.valid() &&
+    if (shouldUseSurface && context.surface.valid() &&
         (imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_GAMMA22 || imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_SRGB)) {
-        if (m_renderData.surface->m_colorManagement.valid()) {
+        if (context.surface->m_colorManagement.valid()) {
             if (sdrEOTF == NTransferFunction::TF_FORCED_GAMMA22 && imageDescription->value().transferFunction == NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_SRGB)
                 srcTF = NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_GAMMA22;
             else
@@ -2079,7 +2062,7 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     } else
         srcTF = imageDescription->value().transferFunction;
 
-    const bool  needsSDRmod     = modifySDR && isSDR2HDR(imageDescription->value(), targetImageDescription->value());
+    const bool  needsSDRmod     = modifySDR && isSDR2HDR(context, imageDescription->value(), targetImageDescription->value());
     const bool  needsHDRmod     = !needsSDRmod && isHDR2SDR(imageDescription->value(), targetImageDescription->value());
     const float maxLuminance    = needsHDRmod ?
         imageDescription->value().getTFMaxLuminance(-1) :
@@ -2090,8 +2073,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     auto        toXYZ  = targetImageDescription->getPrimaries()->value().toXYZ();
 
     const bool  needsMod = needsSDRmod &&
-        ((m_renderData.pMonitor->m_sdrSaturation > 0 && m_renderData.pMonitor->m_sdrSaturation != 1.0f) ||
-         (m_renderData.pMonitor->m_sdrBrightness > 0 && m_renderData.pMonitor->m_sdrBrightness != 1.0f));
+        ((context.sceneMonitor->m_sdrSaturation > 0 && context.sceneMonitor->m_sdrSaturation != 1.0f) ||
+         (context.sceneMonitor->m_sdrBrightness > 0 && context.sceneMonitor->m_sdrBrightness != 1.0f));
 
     const bool needsTonemap = maxLuminance >= dstMaxLuminance * 1.01;
 
@@ -2113,11 +2096,11 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
         .dstMaxLuminance         = dstMaxLuminance,
         .dstPrimaries2XYZ        = toXYZ.mat(),
         .needsSDRmod             = needsMod,
-        .sdrSaturation           = needsSDRmod && m_renderData.pMonitor->m_sdrSaturation > 0 ? m_renderData.pMonitor->m_sdrSaturation : 1.0f,
-        .sdrBrightnessMultiplier = needsSDRmod && m_renderData.pMonitor->m_sdrBrightness > 0 ? m_renderData.pMonitor->m_sdrBrightness : 1.0f,
+        .sdrSaturation           = needsSDRmod && context.sceneMonitor->m_sdrSaturation > 0 ? context.sceneMonitor->m_sdrSaturation : 1.0f,
+        .sdrBrightnessMultiplier = needsSDRmod && context.sceneMonitor->m_sdrBrightness > 0 ? context.sceneMonitor->m_sdrBrightness : 1.0f,
     };
 
-    m_cmSettingsCache.push_back({
+    context.cmSettingsCache->entries.push_back({
         .srcDescId       = srcId,
         .dstDescId       = dstId,
         .surfacePtr      = sPtr,
@@ -2130,8 +2113,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     return result;
 }
 
-void IHyprRenderer::renderMirrored() {
-    auto monitor  = m_renderData.pMonitor;
+void IHyprRenderer::renderMirrored(CRenderingContext& context) {
+    auto monitor  = context.sceneMonitor;
     auto mirrored = monitor->m_mirrorOf;
 
     // saveBufferForMirror should create it
@@ -2146,13 +2129,13 @@ void IHyprRenderer::renderMirrored() {
 
     const auto MIRROR_TEX = mirrored->resources()->getMirrorTexture();
 
-    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    addPassElement(context, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
 
     CTexPassElement::SRenderData data;
     data.tex = MIRROR_TEX;
     data.box = monbox;
 
-    addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+    addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
 }
 
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
@@ -2250,6 +2233,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     pMonitor->m_renderingActive = true;
     CScopeGuard renderingGuard([pMonitor] { pMonitor->m_renderingActive = false; });
 
+    CRenderPass       pass;
+    CRenderingContext context{pMonitor, pass};
+
     // Most frames have no fading-out windows or layers for this monitor.
     if (!Desktop::fadingOutState()->fadeouts().empty())
         Desktop::fadingOutState()->cleanupForMonitor(pMonitor);
@@ -2268,21 +2254,21 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         zoomLock = true;
     }
 
-    m_renderData.mouseZoomFactor = 1.f;
+    context.mouseZoomFactor = 1.f;
     if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->position()).run())
-        m_renderData.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
+        context.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
 
     if (pMonitor->m_zoomAnimProgress->value() != 1) {
-        m_renderData.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
-        m_renderData.mouseZoomUseMouse  = false;
-        m_renderData.useNearestNeighbor = false;
+        context.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
+        context.mouseZoomUseMouse  = false;
+        context.useNearestNeighbor = false;
     }
 
-    const bool                                        ZOOM_DAMAGE_ENTIRE = pMonitor->m_zoomController.shouldDamageEntire(m_renderData.mouseZoomFactor);
+    const bool ZOOM_DAMAGE_ENTIRE = pMonitor->m_zoomController.shouldDamageEntire(context.mouseZoomFactor);
 
     CRegion                                           damage, finalDamage;
     std::optional<Monitor::CDamageRing::CTransaction> damageTransaction;
-    if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL, {}, nullptr, false, &damageTransaction)) {
+    if (!beginRender(context, damage, RENDER_MODE_NORMAL, {}, nullptr, false, &damageTransaction)) {
         Log::logger->log(Log::ERR, "renderer: couldn't beginRender()!");
         return;
     }
@@ -2295,7 +2281,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     finalDamage = damage;
 
     // update damage in renderdata as we modified it
-    setDamage(damage, finalDamage);
+    setDamage(context, damage, finalDamage);
 
     if (pMonitor->m_forceFullFrames > 0) {
         pMonitor->m_forceFullFrames -= 1;
@@ -2308,19 +2294,19 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     bool renderCursor = !pMonitor->isMirror();
 
     if (pMonitor->m_solitaryClient && !pMonitor->resources()->m_sceneStack.hasOverride() && (!finalDamage.empty() || *PSOLDAMAGE))
-        renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
+        renderWindow(context, pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
-        pMonitor->resources()->m_sceneStack.current()->draw(NOW);
+        pMonitor->resources()->m_sceneStack.current()->draw(context, NOW);
 
         if (pMonitor == Desktop::focusState()->monitor()) {
-            Notification::overlay()->draw(pMonitor);
-            ErrorOverlay::overlay()->draw();
+            Notification::overlay()->draw(context, pMonitor);
+            ErrorOverlay::overlay()->draw(context);
         }
 
         // for drawing the debug overlay
         if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
             renderStartOverlay = std::chrono::high_resolution_clock::now();
-            Debug::overlay()->draw();
+            Debug::overlay()->draw(context);
             endRenderOverlay = std::chrono::high_resolution_clock::now();
         }
 
@@ -2328,7 +2314,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             CRectPassElement::SRectData data;
             data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
             data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(context, makeUnique<CRectPassElement>(data));
             damageBlinkCleanup = 1;
         } else if (*PDAMAGEBLINK) {
             damageBlinkCleanup++;
@@ -2346,7 +2332,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     if (renderCursor) {
         TRACY_GPU_ZONE("RenderCursor");
-        Pointer::mgr()->renderSoftwareCursorsFor(pMonitor->m_self.lock(), NOW, m_renderData.damage);
+        Pointer::mgr()->renderSoftwareCursorsFor(context, pMonitor->m_self.lock(), NOW, context.damage);
     }
 
     if (pMonitor->m_dpmsBlackOpacity->value() != 0.F) {
@@ -2354,16 +2340,16 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = Colors::BLACK.modifyA(pMonitor->m_dpmsBlackOpacity->value());
-        addPassElement(makeUnique<CRectPassElement>(data));
+        addPassElement(context, makeUnique<CRectPassElement>(data));
     }
 
     Event::bus()->m_events.render.stage.emit(RENDER_LAST_MOMENT);
 
-    endRender();
+    endRender(context);
 
     TRACY_GPU_COLLECT;
 
-    CRegion    frameDamage{m_renderData.damage};
+    CRegion frameDamage{context.damage};
 
     const auto TRANSFORM = Math::invertTransform(pMonitor->m_transform);
     frameDamage.transform(Math::wlTransformToHyprutils(TRANSFORM), pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y);
@@ -2379,11 +2365,11 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     pMonitor->m_output->state->addDamage(frameDamage);
     bool submitted = true;
     if (commit)
-        submitted = commitPendingAndDoExplicitSync(pMonitor, std::move(damageTransaction), m_renderData.damage);
+        submitted = commitPendingAndDoExplicitSync(pMonitor, std::move(damageTransaction), context.damage);
     else {
         if (damageTransaction)
             damageTransaction->commit();
-        pMonitor->m_commitCoordinator->stageRenderedDamage(m_renderData.damage, pMonitor->needsACopyFB());
+        pMonitor->m_commitCoordinator->stageRenderedDamage(context.damage, pMonitor->needsACopyFB());
     }
 
     if (shouldTear && submitted)
@@ -2633,7 +2619,7 @@ bool IHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor, std::opt
     return ok;
 }
 
-void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry) {
+void IHyprRenderer::renderWorkspace(CRenderingContext& context, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry) {
     Vector2D translate = {geometry.x, geometry.y};
     float    scale     = sc<float>(geometry.width) / pMonitor->m_transformedSize.x;
 
@@ -2645,147 +2631,114 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
         translate = Vector2D{};
     }
 
-    renderAllClientsForWorkspace(pMonitor, pWorkspace, now, translate, scale);
+    renderAllClientsForWorkspace(context, pMonitor, pWorkspace, now, translate, scale);
 }
 
-bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
-    return renderWorkspaceToBufferInternal(workspace, framebuffer, Time::steadyNow(), sendFeedback, false);
+bool IHyprRenderer::renderWorkspaceToBuffer(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, Time::steadyNow(), sendFeedback, false);
 }
 
-bool IHyprRenderer::renderWorkspaceSceneToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
-    return renderWorkspaceToBufferInternal(workspace, framebuffer, time, sendFeedback, true);
+bool IHyprRenderer::renderWorkspaceSceneToBuffer(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true);
 }
 
-bool IHyprRenderer::renderWorkspaceToBufferInternal(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback, bool fullScene) {
+bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
+                                                    bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != MONITOR)
+    auto&      parent  = context;
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB || parent.sceneMonitor != MONITOR)
         return false;
-    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+    if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
 
     if (!framebuffer->imageDescription())
         framebuffer->setImageDescription(MONITOR->workBufferImageDescription());
 
-    CRenderPass pass;
-    const auto  OLDRENDERDATA                 = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
-    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
-    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER           = MONITOR->m_blurFBShouldRender;
-    auto* const OLDPASS                       = m_currentPass;
+    CRenderPass       pass;
+    CRenderingContext child{parent, pass, MONITOR};
+    CRegion           damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
 
-    CScopeGuard restore([&] {
-        m_currentPass                 = OLDPASS;
-        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
-        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
-        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
-        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
-        MONITOR->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
-        m_renderData                  = OLDRENDERDATA;
-    });
-    auto        framebufferGuard = bindTempFB(framebuffer);
+    child.isolatedWorkspace          = workspace;
+    child.isolatedWorkspaceFullScene = fullScene;
+    child.blockSurfaceFeedback       = !sendFeedback;
+    child.renderingSnapshot          = !fullScene;
+    child.precomputeBlur             = false;
+    child.mainFB                     = framebuffer;
+    child.outFB.reset();
+    child.fbSize                     = MONITOR->m_transformedSize;
+    child.damage                     = damage;
+    child.finalDamage                = damage;
+    child.renderModif                = {};
+    child.mouseZoomFactor            = 1.F;
+    child.mouseZoomUseMouse          = false;
+    child.transformDamage            = false;
+    child.noSimplify                 = false;
+    child.renderingTransformedSource = false;
+    child.blockScreenShader          = true;
+    child.currentWindow.reset();
+    child.surface.reset();
+    child.clipBox = {};
 
-    CRegion     damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
-    m_currentPass                 = &pass;
-    m_isolatedWorkspace           = workspace;
-    m_isolatedWorkspaceFullScene  = fullScene;
-    m_bBlockSurfaceFeedback       = !sendFeedback;
-    m_bRenderingSnapshot          = !fullScene;
-    MONITOR->m_blurFBShouldRender = false;
-    m_renderData.pMonitor         = MONITOR;
-    m_renderData.mainFB           = framebuffer;
-    m_renderData.outFB.reset();
-    m_renderData.fbSize                     = MONITOR->m_transformedSize;
-    m_renderData.damage                     = damage;
-    m_renderData.finalDamage                = damage;
-    m_renderData.renderModif                = {};
-    m_renderData.mouseZoomFactor            = 1.F;
-    m_renderData.mouseZoomUseMouse          = false;
-    m_renderData.transformDamage            = false;
-    m_renderData.noSimplify                 = false;
-    m_renderData.renderingTransformedSource = false;
-    m_renderData.blockScreenShader          = true;
-    m_renderData.currentWindow.reset();
-    m_renderData.surface.reset();
-    m_renderData.clipBox = {};
-    setProjectionType(RPT_EXPORT);
+    auto framebufferGuard = bindTempFB(child, framebuffer);
+    setProjectionType(child, RPT_EXPORT);
 
-    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
     if (fullScene) {
-        renderAllClientsForWorkspace(MONITOR, workspace, time);
+        renderAllClientsForWorkspace(child, MONITOR, workspace, time);
         const CBox renderBox = {{}, MONITOR->m_transformedSize};
-        renderLockscreen(MONITOR, time, renderBox);
-        renderIME(MONITOR, time, renderBox);
+        renderLockscreen(child, MONITOR, time, renderBox);
+        renderIME(child, MONITOR, time, renderBox);
     } else if (Fullscreen::controller()->hasFullscreen(workspace))
-        renderWorkspaceWindowsFullscreen(MONITOR, workspace, time);
+        renderWorkspaceWindowsFullscreen(child, MONITOR, workspace, time);
     else
-        renderWorkspaceWindows(MONITOR, workspace, time);
+        renderWorkspaceWindows(child, MONITOR, workspace, time);
 
-    m_currentPass = OLDPASS;
-    pass.render(damage);
+    pass.render(child, damage);
 
     return true;
 }
 
-bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
-    if (!monitor || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != monitor->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != monitor)
+bool IHyprRenderer::renderMonitorToBuffer(CRenderingContext& context, PHLMONITOR monitor, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    auto& parent = context;
+    if (!monitor || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != monitor->m_transformedSize || !parent.currentFB || parent.sceneMonitor != monitor)
         return false;
-    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+    if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
 
     if (!framebuffer->imageDescription())
         framebuffer->setImageDescription(monitor->workBufferImageDescription());
 
-    CRenderPass pass;
-    const auto  OLDRENDERDATA                 = m_renderData;
-    const auto  OLDISOLATEDWORKSPACE          = m_isolatedWorkspace;
-    const bool  OLDISOLATEDWORKSPACEFULLSCENE = m_isolatedWorkspaceFullScene;
-    const bool  OLDBLOCKFEEDBACK              = m_bBlockSurfaceFeedback;
-    const bool  OLDRENDERINGSNAPSHOT          = m_bRenderingSnapshot;
-    const bool  OLDBLURSHOULDRENDER           = monitor->m_blurFBShouldRender;
-    auto* const OLDPASS                       = m_currentPass;
+    CRenderPass       pass;
+    CRenderingContext child{parent, pass, monitor};
+    CRegion           damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
 
-    CScopeGuard restore([&] {
-        m_currentPass                 = OLDPASS;
-        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
-        m_isolatedWorkspaceFullScene  = OLDISOLATEDWORKSPACEFULLSCENE;
-        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
-        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
-        monitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
-        m_renderData                  = OLDRENDERDATA;
-    });
-    auto        framebufferGuard = bindTempFB(framebuffer);
+    child.isolatedWorkspace.reset();
+    child.isolatedWorkspaceFullScene = false;
+    child.blockSurfaceFeedback       = !sendFeedback;
+    child.renderingSnapshot          = false;
+    child.mainFB                     = framebuffer;
+    child.outFB.reset();
+    child.fbSize                     = monitor->m_transformedSize;
+    child.damage                     = damage;
+    child.finalDamage                = damage;
+    child.renderModif                = {};
+    child.mouseZoomFactor            = 1.F;
+    child.mouseZoomUseMouse          = false;
+    child.transformDamage            = false;
+    child.noSimplify                 = false;
+    child.renderingTransformedSource = false;
+    child.blockScreenShader          = true;
+    child.currentWindow.reset();
+    child.surface.reset();
+    child.clipBox = {};
 
-    CRegion     damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
-    m_currentPass = &pass;
-    m_isolatedWorkspace.reset();
-    m_isolatedWorkspaceFullScene = false;
-    m_bBlockSurfaceFeedback      = !sendFeedback;
-    m_bRenderingSnapshot         = false;
-    m_renderData.pMonitor        = monitor;
-    m_renderData.mainFB          = framebuffer;
-    m_renderData.outFB.reset();
-    m_renderData.fbSize                     = monitor->m_transformedSize;
-    m_renderData.damage                     = damage;
-    m_renderData.finalDamage                = damage;
-    m_renderData.renderModif                = {};
-    m_renderData.mouseZoomFactor            = 1.F;
-    m_renderData.mouseZoomUseMouse          = false;
-    m_renderData.transformDamage            = false;
-    m_renderData.noSimplify                 = false;
-    m_renderData.renderingTransformedSource = false;
-    m_renderData.blockScreenShader          = true;
-    m_renderData.currentWindow.reset();
-    m_renderData.surface.reset();
-    m_renderData.clipBox = {};
-    setProjectionType(RPT_EXPORT);
+    auto framebufferGuard = bindTempFB(child, framebuffer);
+    setProjectionType(child, RPT_EXPORT);
 
-    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
-    CMonitorScene{monitor}.draw(time);
+    addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    CMonitorScene{monitor}.draw(child, time);
 
-    m_currentPass = OLDPASS;
-    pass.render(damage);
+    pass.render(child, damage);
 
     return true;
 }
@@ -3053,7 +3006,7 @@ void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
 
     const bool OVERVIEW_SELECTED = Overview::overview()->shouldRenderWorkspace(PWINDOWWORKSPACE);
     for (auto const& m : State::monitorState()->monitors()) {
-        if (forceFull || shouldRenderWindow(pWindow, m) || (OVERVIEW_SELECTED && m == PWORKSPACEMONITOR)) { // only damage if window is rendered on monitor
+        if (forceFull || shouldRenderWindowOnMonitor(pWindow, m) || (OVERVIEW_SELECTED && m == PWORKSPACEMONITOR)) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->m_position.x, windowBox.y - m->m_position.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->m_scale).round();
             m->addDamage(fixedDamageBox);
@@ -3129,8 +3082,8 @@ void IHyprRenderer::damageMirrorsWith(PHLMONITOR pMonitor, const CRegion& pRegio
     }
 }
 
-void IHyprRenderer::renderDragIcon(PHLMONITOR pMonitor, const Time::steady_tp& time) {
-    PROTO::data->renderDND(pMonitor, time);
+void IHyprRenderer::renderDragIcon(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& time) {
+    PROTO::data->renderDND(context, pMonitor, time);
 }
 
 void IHyprRenderer::setCursorSurface(SP<Desktop::View::CWLSurface> surf, int hotspotX, int hotspotY, bool force) {
@@ -3308,10 +3261,6 @@ void IHyprRenderer::initiateManualCrash() {
     **rc<Config::INTEGER* const*>(Config::mgr()->getConfigValue("debug:damage_tracking").dataptr) = 0;
 }
 
-const SRenderData& IHyprRenderer::renderData() {
-    return m_renderData;
-}
-
 SP<IRenderbuffer> IHyprRenderer::getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
     auto it = std::ranges::find_if(m_renderbuffers, [&](const auto& other) { return other->m_hlBuffer == buffer; });
 
@@ -3327,12 +3276,12 @@ SP<IRenderbuffer> IHyprRenderer::getOrCreateRenderbuffer(SP<Aquamarine::IBuffer>
     return buf;
 }
 
-bool IHyprRenderer::beginFullFakeRender(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb) {
-    return beginRender(pMonitor, damage, RENDER_MODE_FULL_FAKE, nullptr, fb, true);
+bool IHyprRenderer::beginFullFakeRender(CRenderingContext& context, CRegion& damage, SP<IFramebuffer> fb) {
+    return beginRender(context, damage, RENDER_MODE_FULL_FAKE, nullptr, fb, true);
 }
 
-bool IHyprRenderer::beginRenderToBuffer(PHLMONITOR pMonitor, CRegion& damage, SP<IHLBuffer> buffer, bool simple) {
-    return beginRender(pMonitor, damage, RENDER_MODE_TO_BUFFER, buffer, nullptr, simple);
+bool IHyprRenderer::beginRenderToBuffer(CRenderingContext& context, CRegion& damage, SP<IHLBuffer> buffer, bool simple) {
+    return beginRender(context, damage, RENDER_MODE_TO_BUFFER, buffer, nullptr, simple);
 }
 
 void IHyprRenderer::onRenderbufferDestroy(IRenderbuffer* rb) {
@@ -3392,24 +3341,25 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(PHLWINDOW pWindow) {
     PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
-    beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+    CRenderPass       pass;
+    CRenderingContext context{PMONITOR, pass};
+    beginFullFakeRender(context, fakeDamage, PFRAMEBUFFER);
 
-    m_bRenderingSnapshot = true;
+    context.renderingSnapshot = true;
 
-    draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
-    startRenderPass();
+    draw(context, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+    startRenderPass(context);
 
     Log::logger->log(Log::DEBUG, "renderer: cleared a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
-    renderWindow(pWindow, PMONITOR, Time::steadyNow(), !pWindow->backend().traits().suggestsNoBorder, RENDER_PASS_ALL);
+    renderWindow(context, pWindow, PMONITOR, Time::steadyNow(), !pWindow->backend().traits().suggestsNoBorder, RENDER_PASS_ALL);
 
     Log::logger->log(Log::DEBUG, "renderer: rendered a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
-    endRender();
+    endRender(context);
 
     Log::logger->log(Log::DEBUG, "renderer: made a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
-    m_bRenderingSnapshot = false;
     return PFRAMEBUFFER;
 }
 
@@ -3432,25 +3382,26 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(PHLLS pLayer) {
     PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
-    beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+    CRenderPass       pass;
+    CRenderingContext context{PMONITOR, pass};
+    beginFullFakeRender(context, fakeDamage, PFRAMEBUFFER);
 
-    m_bRenderingSnapshot = true;
+    context.renderingSnapshot = true;
 
-    draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
-    startRenderPass();
+    draw(context, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+    startRenderPass(context);
 
     Log::logger->log(Log::DEBUG, "renderer: cleared a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
     // draw the layer
-    renderLayer(pLayer, PMONITOR, Time::steadyNow());
+    renderLayer(context, pLayer, PMONITOR, Time::steadyNow());
 
     Log::logger->log(Log::DEBUG, "renderer: rendered a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
-    endRender();
+    endRender(context);
 
     Log::logger->log(Log::DEBUG, "renderer: made a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
-    m_bRenderingSnapshot = false;
     return PFRAMEBUFFER;
 }
 
@@ -3473,11 +3424,13 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     PFRAMEBUFFER->alloc(PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
-    beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+    CRenderPass       pass;
+    CRenderingContext context{PMONITOR, pass};
+    beginFullFakeRender(context, fakeDamage, PFRAMEBUFFER);
 
-    m_bRenderingSnapshot = true;
+    context.renderingSnapshot = true;
 
-    draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+    draw(context, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
 
     CSurfacePassElement::SRenderData renderdata;
     renderdata.pos             = popup->coordsGlobal();
@@ -3489,7 +3442,7 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     renderdata.blur            = false;
 
     popup->wlSurface()->resource()->breadthfirst(
-        [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
+        [this, &context, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
             if (!s->m_current.texture)
                 return;
 
@@ -3500,18 +3453,17 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = false;
-            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(context, makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         nullptr);
 
-    endRender();
+    endRender(context);
 
-    m_bRenderingSnapshot = false;
     return PFRAMEBUFFER;
 }
 
-void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace) {
+void IHyprRenderer::renderFadeouts(CRenderingContext& context, PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace) {
     if (!monitor)
         return;
 
@@ -3540,7 +3492,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             CRectPassElement::SRectData data;
             data.box   = {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y};
             data.color = CHyprColor(0, 0, 0, EFFECTS.dimAroundAlpha);
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(context, makeUnique<CRectPassElement>(data));
         }
 
         if (EFFECTS.preBlur) {
@@ -3552,7 +3504,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             data.round         = EFFECTS.preBlur->round;
             data.roundingPower = EFFECTS.preBlur->roundingPower;
             data.xray          = EFFECTS.preBlur->xray;
-            addPassElement(makeUnique<CRectPassElement>(data));
+            addPassElement(context, makeUnique<CRectPassElement>(data));
         }
 
         CTexPassElement::SRenderData data;
@@ -3567,15 +3519,56 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
         data.ignoreAlpha           = EFFECTS.textureBlur.ignoreAlpha;
         data.blockBlurOptimization = EFFECTS.textureBlur.blockBlurOptimization;
 
-        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 
-NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription() {
-    if (!m_renderData.pMonitor)
+NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription(const CRenderingContext& context) {
+    if (!context.sceneMonitor)
         return LINEAR_IMAGE_DESCRIPTION;
 
-    return m_renderData.pMonitor->workBufferImageDescription();
+    return context.sceneMonitor->workBufferImageDescription();
+}
+
+bool IHyprRenderer::shouldBlur(const CRenderingContext& context, PHLLS ls) {
+    if (context.renderingSnapshot)
+        return false;
+
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    auto surface = ls->wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    return ls->m_ruleApplicator->blur().valueOrDefault();
+}
+
+bool IHyprRenderer::shouldBlur(const CRenderingContext& context, PHLWINDOW w) {
+    if (context.renderingSnapshot)
+        return false;
+
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    const bool DONT_BLUR = w->m_ruleApplicator->noBlur().valueOrDefault() || w->m_ruleApplicator->RGBX().valueOrDefault() || w->presentation().opaque();
+    if (DONT_BLUR)
+        return false;
+
+    auto surface = w->wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    return true;
+}
+
+bool IHyprRenderer::shouldBlur(const CRenderingContext&, WP<Desktop::View::CPopup> p) {
+    static CConfigValue PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
+    static CConfigValue PBLUR       = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+
+    return *PBLURPOPUPS && *PBLUR;
 }
 
 SP<ITexture> IHyprRenderer::renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth,
@@ -3669,8 +3662,8 @@ static auto            colorConversionCache = []() {
 }();
 
 //
-CHyprColor IHyprRenderer::getConvertedColor(const CHyprColor& color) {
-    const auto DESCR = m_renderData.currentFB ? m_renderData.currentFB->imageDescription() : workBufferImageDescription();
+CHyprColor IHyprRenderer::getConvertedColor(const CRenderingContext& context, const CHyprColor& color) {
+    const auto DESCR = context.currentFB ? context.currentFB->imageDescription() : workBufferImageDescription(context);
 
     if (!DESCR) {
         Log::logger->log(Log::ERR, "getConvertedColor: failed to get image description");
@@ -3685,7 +3678,7 @@ CHyprColor IHyprRenderer::getConvertedColor(const CHyprColor& color) {
     if (const auto IT = colorConversionCache.find(key); IT != colorConversionCache.end())
         return IT->second;
 
-    const auto converted = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);
+    const auto converted = convertColor(context, color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);
     colorConversionCache.emplace(key, converted);
 
     return converted;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1007,7 +1007,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pLayer->alpha()[LS_ALPHA_FADE]->value());
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     TRACY_GPU_ZONE("RenderLayer");
@@ -1044,7 +1044,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = s->m_current.texture;
                 renderdata.surface     = s;
                 renderdata.mainSurface = s == pLayer->wlSurface()->resource();
-                m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -1079,7 +1079,7 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
                 renderdata.texture     = SURF->m_current.texture;
                 renderdata.surface     = SURF;
                 renderdata.mainSurface = false;
-                m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                addPassElement(makeUnique<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
             &renderdata);
@@ -1120,7 +1120,7 @@ void IHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, con
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == SURF;
-            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
@@ -1150,7 +1150,7 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = s == pSurface->surface->surface();
-            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         &renderdata);
@@ -1177,11 +1177,11 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
     CScopeGuard x([&RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
@@ -1233,7 +1233,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
 
     // pre window pass
     if (preBlurQueued(pMonitor))
-        m_renderPass.add(makeUnique<CPreBlurElement>());
+        addPassElement(makeUnique<CPreBlurElement>());
 
     if UNLIKELY /* subjective? */ (Fullscreen::controller()->hasFullscreen(pWorkspace))
         renderWorkspaceWindowsFullscreen(pMonitor, pWorkspace, time);
@@ -1246,7 +1246,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
         data.color = CHyprColor(0, 0, 0, pMonitor->m_specialDim->value());
 
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     if UNLIKELY (pMonitor->m_specialBlur->value() != 0.F) {
@@ -1256,7 +1256,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         data.blur  = true;
         data.blurA = pMonitor->m_specialBlur->value();
 
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     std::vector<PHLWORKSPACE> specialWorkspaces;
@@ -1337,11 +1337,11 @@ void IHyprRenderer::renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, c
         RENDERMODIFDATA.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale);
 
     if UNLIKELY (!RENDERMODIFDATA.modifs.empty())
-        m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
+        addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
 
     CScopeGuard x([&RENDERMODIFDATA] {
         if (!RENDERMODIFDATA.modifs.empty()) {
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+            g_pHyprRenderer->addPassElement(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         }
     });
 
@@ -1437,7 +1437,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
     static auto PNOSPLASH        = CConfigValue<Config::INTEGER>("misc:disable_splash_rendering");
 
     if (*PRENDERTEX /* inverted cfg flag */ || pMonitor->m_backgroundOpacity->isBeingAnimated())
-        m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+        addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
     if (!*PRENDERTEX) {
         static auto PBACKGROUNDCOLOR = CConfigValue<Config::INTEGER>("misc:background_color");
@@ -1446,7 +1446,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             pMonitor->m_background = getBackground(pMonitor);
 
         if (!pMonitor->m_background)
-            m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+            addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
         else {
             CTexPassElement::SRenderData data;
             const double                 MONRATIO = m_renderData.pMonitor->m_transformedSize.x / m_renderData.pMonitor->m_transformedSize.y;
@@ -1463,12 +1463,12 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             }
 
             if (MONRATIO != WPRATIO)
-                m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
+                addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(*PBACKGROUNDCOLOR)}));
 
             data.box = {origin, pMonitor->m_background->m_size * scale};
             data.a   = m_renderData.pMonitor->m_backgroundOpacity->value();
             data.tex = pMonitor->m_background;
-            m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 
@@ -1482,7 +1482,7 @@ void IHyprRenderer::renderBackground(PHLMONITOR pMonitor) {
             CTexPassElement::SRenderData data;
             data.box = {{(monitorSize.x - pMonitor->m_splash->m_size.x) / 2.0, monitorSize.y * 0.98 - pMonitor->m_splash->m_size.y}, pMonitor->m_splash->m_size};
             data.tex = pMonitor->m_splash;
-            m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+            addPassElement(makeUnique<CTexPassElement>(std::move(data)));
         }
     }
 }
@@ -1778,7 +1778,7 @@ void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
     data.color = CHyprColor(0, 0, 0, 1.f);
     data.box   = CBox{{}, pMonitor->m_transformedSize};
 
-    m_renderPass.add(makeUnique<CRectPassElement>(data));
+    addPassElement(makeUnique<CRectPassElement>(data));
 }
 
 void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
@@ -1798,7 +1798,7 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
     data.box = monbox;
     data.a   = 1;
 
-    m_renderPass.add(makeUnique<CTexPassElement>(data));
+    addPassElement(makeUnique<CTexPassElement>(data));
 
     if (!ANY_PRESENT && m_lockTtyTextTexture) {
         // also render text for the tty number
@@ -1806,7 +1806,7 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
         data.tex    = m_lockTtyTextTexture;
         data.box    = texbox;
 
-        m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 
@@ -2133,13 +2133,13 @@ void IHyprRenderer::renderMirrored() {
 
     const auto MIRROR_TEX = mirrored->resources()->getMirrorTexture();
 
-    m_renderPass.add(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
 
     CTexPassElement::SRenderData data;
     data.tex = MIRROR_TEX;
     data.box = monbox;
 
-    m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+    addPassElement(makeUnique<CTexPassElement>(std::move(data)));
 }
 
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
@@ -2276,7 +2276,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     // if we have no tracking or full tracking, invalidate the entire monitor
     if (*PDAMAGETRACKINGMODE == DAMAGE_TRACKING_NONE || *PDAMAGETRACKINGMODE == DAMAGE_TRACKING_MONITOR || pMonitor->m_forceFullFrames > 0 || damageBlinkCleanup > 0 ||
-        ZOOM_DAMAGE_ENTIRE)
+        ZOOM_DAMAGE_ENTIRE || pMonitor->resources()->m_sceneStack.hasOverride())
         damage = {0, 0, sc<int>(pMonitor->m_transformedSize.x) * 10, sc<int>(pMonitor->m_transformedSize.y) * 10};
 
     finalDamage = damage;
@@ -2294,7 +2294,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     bool renderCursor = !pMonitor->isMirror();
 
-    if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
+    if (pMonitor->m_solitaryClient && !pMonitor->resources()->m_sceneStack.hasOverride() && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
         pMonitor->resources()->m_sceneStack.current()->draw(NOW);
@@ -2315,7 +2315,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             CRectPassElement::SRectData data;
             data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
             data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            addPassElement(makeUnique<CRectPassElement>(data));
             damageBlinkCleanup = 1;
         } else if (*PDAMAGEBLINK) {
             damageBlinkCleanup++;
@@ -2341,7 +2341,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         CRectPassElement::SRectData data;
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = Colors::BLACK.modifyA(pMonitor->m_dpmsBlackOpacity->value());
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        addPassElement(makeUnique<CRectPassElement>(data));
     }
 
     Event::bus()->m_events.render.stage.emit(RENDER_LAST_MOMENT);
@@ -2692,6 +2692,65 @@ bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuf
         renderWorkspaceWindowsFullscreen(MONITOR, workspace, Time::steadyNow());
     else
         renderWorkspaceWindows(MONITOR, workspace, Time::steadyNow());
+
+    m_currentPass = OLDPASS;
+    pass.render(damage);
+
+    return true;
+}
+
+bool IHyprRenderer::renderMonitorToBuffer(PHLMONITOR monitor, SP<IFramebuffer> framebuffer, const Time::steady_tp& time, bool sendFeedback) {
+    if (!monitor || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != monitor->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != monitor)
+        return false;
+    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+        return false;
+
+    if (!framebuffer->imageDescription())
+        framebuffer->setImageDescription(monitor->workBufferImageDescription());
+
+    CRenderPass pass;
+    const auto  OLDRENDERDATA        = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
+    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER  = monitor->m_blurFBShouldRender;
+    auto* const OLDPASS              = m_currentPass;
+
+    CScopeGuard restore([&] {
+        m_currentPass                 = OLDPASS;
+        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
+        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
+        monitor->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
+        m_renderData                  = OLDRENDERDATA;
+    });
+    auto        framebufferGuard = bindTempFB(framebuffer);
+
+    CRegion     damage{0, 0, sc<int>(monitor->m_transformedSize.x), sc<int>(monitor->m_transformedSize.y)};
+    m_currentPass = &pass;
+    m_isolatedWorkspace.reset();
+    m_bBlockSurfaceFeedback = !sendFeedback;
+    m_bRenderingSnapshot    = false;
+    m_renderData.pMonitor   = monitor;
+    m_renderData.mainFB     = framebuffer;
+    m_renderData.outFB.reset();
+    m_renderData.fbSize                     = monitor->m_transformedSize;
+    m_renderData.damage                     = damage;
+    m_renderData.finalDamage                = damage;
+    m_renderData.renderModif                = {};
+    m_renderData.mouseZoomFactor            = 1.F;
+    m_renderData.mouseZoomUseMouse          = false;
+    m_renderData.transformDamage            = false;
+    m_renderData.noSimplify                 = false;
+    m_renderData.renderingTransformedSource = false;
+    m_renderData.blockScreenShader          = true;
+    m_renderData.currentWindow.reset();
+    m_renderData.surface.reset();
+    m_renderData.clipBox = {};
+    setProjectionType(RPT_EXPORT);
+
+    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    CMonitorScene{monitor}.draw(time);
 
     m_currentPass = OLDPASS;
     pass.render(damage);
@@ -3408,7 +3467,7 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
             renderdata.texture     = s->m_current.texture;
             renderdata.surface     = s;
             renderdata.mainSurface = false;
-            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
             renderdata.surfaceCounter++;
         },
         nullptr);
@@ -3448,7 +3507,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             CRectPassElement::SRectData data;
             data.box   = {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y};
             data.color = CHyprColor(0, 0, 0, EFFECTS.dimAroundAlpha);
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            addPassElement(makeUnique<CRectPassElement>(data));
         }
 
         if (EFFECTS.preBlur) {
@@ -3460,7 +3519,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             data.round         = EFFECTS.preBlur->round;
             data.roundingPower = EFFECTS.preBlur->roundingPower;
             data.xray          = EFFECTS.preBlur->xray;
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            addPassElement(makeUnique<CRectPassElement>(data));
         }
 
         CTexPassElement::SRenderData data;
@@ -3475,7 +3534,7 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
         data.ignoreAlpha           = EFFECTS.textureBlur.ignoreAlpha;
         data.blockBlurOptimization = EFFECTS.textureBlur.blockBlurOptimization;
 
-        m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+        addPassElement(makeUnique<CTexPassElement>(std::move(data)));
     }
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -49,6 +49,7 @@
 #include "pass/RendererHintsPassElement.hpp"
 #include "pass/SurfacePassElement.hpp"
 #include "pass/BackdropScopePassElement.hpp"
+#include "scene/Scene.hpp"
 #include "../debug/log/Logger.hpp"
 #include "../protocols/ColorManagement.hpp"
 #include "../protocols/types/ContentType.hpp"
@@ -2206,48 +2207,35 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     Event::bus()->m_events.render.stage.emit(RENDER_BEGIN);
 
-    bool renderCursor = true;
+    bool renderCursor = !pMonitor->isMirror();
 
     if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
-        if (pMonitor->isMirror()) {
-            blend(false);
-            renderMirrored();
-            blend(true);
-            Event::bus()->m_events.render.stage.emit(RENDER_POST_MIRROR);
-            renderCursor = false;
-        } else {
-            CBox renderBox = {0, 0, sc<int>(pMonitor->m_transformedSize.x), sc<int>(pMonitor->m_transformedSize.y)};
-            renderWorkspace(pMonitor, pMonitor->m_activeWorkspace, NOW, renderBox);
-            renderLockscreen(pMonitor, NOW, renderBox);
+        pMonitor->resources()->m_sceneStack.current()->draw(NOW);
 
-            // render IME even above the lockscreen - allow the user to use it to potentially input stuff on it.
-            renderIME(pMonitor, NOW, renderBox);
+        if (pMonitor == Desktop::focusState()->monitor()) {
+            Notification::overlay()->draw(pMonitor);
+            ErrorOverlay::overlay()->draw();
+        }
 
-            if (pMonitor == Desktop::focusState()->monitor()) {
-                Notification::overlay()->draw(pMonitor);
-                ErrorOverlay::overlay()->draw();
-            }
+        // for drawing the debug overlay
+        if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
+            renderStartOverlay = std::chrono::high_resolution_clock::now();
+            Debug::overlay()->draw();
+            endRenderOverlay = std::chrono::high_resolution_clock::now();
+        }
 
-            // for drawing the debug overlay
-            if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
-                renderStartOverlay = std::chrono::high_resolution_clock::now();
-                Debug::overlay()->draw();
-                endRenderOverlay = std::chrono::high_resolution_clock::now();
-            }
-
-            if (*PDAMAGEBLINK && damageBlinkCleanup == 0) {
-                CRectPassElement::SRectData data;
-                data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
-                data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-                m_renderPass.add(makeUnique<CRectPassElement>(data));
-                damageBlinkCleanup = 1;
-            } else if (*PDAMAGEBLINK) {
-                damageBlinkCleanup++;
-                if (damageBlinkCleanup > 3)
-                    damageBlinkCleanup = 0;
-            }
+        if (*PDAMAGEBLINK && damageBlinkCleanup == 0) {
+            CRectPassElement::SRectData data;
+            data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
+            data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
+            m_renderPass.add(makeUnique<CRectPassElement>(data));
+            damageBlinkCleanup = 1;
+        } else if (*PDAMAGEBLINK) {
+            damageBlinkCleanup++;
+            if (damageBlinkCleanup > 3)
+                damageBlinkCleanup = 0;
         }
     } else if (!pMonitor->isMirror()) {
         if (pMonitor->m_activeWorkspace)

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2644,11 +2644,22 @@ bool IHyprRenderer::renderWorkspaceSceneToBuffer(CRenderingContext& context, PHL
     return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true);
 }
 
+bool IHyprRenderer::renderWorkspaceSceneToBufferScaled(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
+                                                       bool sendFeedback) {
+    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true, true);
+}
+
 bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
-                                                    bool sendFeedback, bool fullScene) {
+                                                    bool sendFeedback, bool fullScene, bool scaleToBuffer) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     auto&      parent  = context;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB)
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || !parent.currentFB)
+        return false;
+    if (framebuffer->m_size.x <= 0 || framebuffer->m_size.y <= 0 || MONITOR->m_transformedSize.x <= 0 || MONITOR->m_transformedSize.y <= 0)
+        return false;
+    if (!scaleToBuffer && framebuffer->m_size != MONITOR->m_transformedSize)
+        return false;
+    if (scaleToBuffer && !DELTALESSTHAN(framebuffer->m_size.x / framebuffer->m_size.y, MONITOR->m_transformedSize.x / MONITOR->m_transformedSize.y, 0.01))
         return false;
     if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
@@ -2658,7 +2669,7 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     CRenderPass       pass;
     CRenderingContext child{parent, pass, MONITOR};
-    CRegion           damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
+    CRegion           damage{0, 0, sc<int>(framebuffer->m_size.x), sc<int>(framebuffer->m_size.y)};
 
     child.isolatedWorkspace          = workspace;
     child.isolatedWorkspaceFullScene = fullScene;
@@ -2667,14 +2678,14 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
     child.precomputeBlur             = false;
     child.mainFB                     = framebuffer;
     child.outFB.reset();
-    child.fbSize                     = MONITOR->m_transformedSize;
+    child.fbSize                     = framebuffer->m_size;
     child.damage                     = damage;
     child.finalDamage                = damage;
     child.renderModif                = {};
     child.mouseZoomFactor            = 1.F;
     child.mouseZoomUseMouse          = false;
     child.transformDamage            = false;
-    child.noSimplify                 = false;
+    child.noSimplify                 = scaleToBuffer;
     child.renderingTransformedSource = false;
     child.blockScreenShader          = true;
     child.currentWindow.reset();
@@ -2686,9 +2697,17 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
     if (fullScene) {
-        renderAllClientsForWorkspace(child, MONITOR, workspace, time);
-        const CBox renderBox = {{}, MONITOR->m_transformedSize};
-        renderLockscreen(child, MONITOR, time, renderBox);
+        const float SCALE = scaleToBuffer ? framebuffer->m_size.x / MONITOR->m_transformedSize.x : 1.F;
+        renderAllClientsForWorkspace(child, MONITOR, workspace, time, {}, SCALE);
+        const CBox renderBox = {{}, MONITOR->m_transformedSize * SCALE};
+        if (scaleToBuffer) {
+            SRenderModifData renderModif;
+            renderModif.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, SCALE);
+            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{renderModif}));
+            renderLockscreen(child, MONITOR, time, renderBox);
+            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+        } else
+            renderLockscreen(child, MONITOR, time, renderBox);
         renderIME(child, MONITOR, time, renderBox);
     } else if (Fullscreen::controller()->hasFullscreen(workspace))
         renderWorkspaceWindowsFullscreen(child, MONITOR, workspace, time);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2644,22 +2644,11 @@ bool IHyprRenderer::renderWorkspaceSceneToBuffer(CRenderingContext& context, PHL
     return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true);
 }
 
-bool IHyprRenderer::renderWorkspaceSceneToBufferScaled(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
-                                                       bool sendFeedback) {
-    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true, true);
-}
-
 bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
-                                                    bool sendFeedback, bool fullScene, bool scaleToBuffer) {
+                                                    bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     auto&      parent  = context;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || !parent.currentFB)
-        return false;
-    if (framebuffer->m_size.x <= 0 || framebuffer->m_size.y <= 0 || MONITOR->m_transformedSize.x <= 0 || MONITOR->m_transformedSize.y <= 0)
-        return false;
-    if (!scaleToBuffer && framebuffer->m_size != MONITOR->m_transformedSize)
-        return false;
-    if (scaleToBuffer && !DELTALESSTHAN(framebuffer->m_size.x / framebuffer->m_size.y, MONITOR->m_transformedSize.x / MONITOR->m_transformedSize.y, 0.01))
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB)
         return false;
     if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
@@ -2669,7 +2658,7 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     CRenderPass       pass;
     CRenderingContext child{parent, pass, MONITOR};
-    CRegion           damage{0, 0, sc<int>(framebuffer->m_size.x), sc<int>(framebuffer->m_size.y)};
+    CRegion           damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
 
     child.isolatedWorkspace          = workspace;
     child.isolatedWorkspaceFullScene = fullScene;
@@ -2678,14 +2667,14 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
     child.precomputeBlur             = false;
     child.mainFB                     = framebuffer;
     child.outFB.reset();
-    child.fbSize                     = framebuffer->m_size;
+    child.fbSize                     = MONITOR->m_transformedSize;
     child.damage                     = damage;
     child.finalDamage                = damage;
     child.renderModif                = {};
     child.mouseZoomFactor            = 1.F;
     child.mouseZoomUseMouse          = false;
     child.transformDamage            = false;
-    child.noSimplify                 = scaleToBuffer;
+    child.noSimplify                 = false;
     child.renderingTransformedSource = false;
     child.blockScreenShader          = true;
     child.currentWindow.reset();
@@ -2697,17 +2686,9 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
     if (fullScene) {
-        const float SCALE = scaleToBuffer ? framebuffer->m_size.x / MONITOR->m_transformedSize.x : 1.F;
-        renderAllClientsForWorkspace(child, MONITOR, workspace, time, {}, SCALE);
-        const CBox renderBox = {{}, MONITOR->m_transformedSize * SCALE};
-        if (scaleToBuffer) {
-            SRenderModifData renderModif;
-            renderModif.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, SCALE);
-            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{renderModif}));
-            renderLockscreen(child, MONITOR, time, renderBox);
-            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
-        } else
-            renderLockscreen(child, MONITOR, time, renderBox);
+        renderAllClientsForWorkspace(child, MONITOR, workspace, time);
+        const CBox renderBox = {{}, MONITOR->m_transformedSize};
+        renderLockscreen(child, MONITOR, time, renderBox);
         renderIME(child, MONITOR, time, renderBox);
     } else if (Fullscreen::controller()->hasFullscreen(workspace))
         renderWorkspaceWindowsFullscreen(child, MONITOR, workspace, time);
@@ -2716,6 +2697,47 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     pass.render(child, damage);
 
+    return true;
+}
+
+bool IHyprRenderer::renderTextureToBuffer(CRenderingContext& context, SP<ITexture> texture, SP<IFramebuffer> framebuffer) {
+    if (!texture || !framebuffer || !framebuffer->isAllocated() || !context.currentFB || framebuffer == context.currentFB || framebuffer == context.mainFB ||
+        framebuffer == context.outFB || texture == framebuffer->getTexture())
+        return false;
+
+    if (texture->m_imageDescription)
+        framebuffer->setImageDescription(texture->m_imageDescription);
+
+    CRenderingContext child{context, context.renderPass()};
+    const CRegion     damage{0, 0, sc<int>(framebuffer->m_size.x), sc<int>(framebuffer->m_size.y)};
+    auto              framebufferGuard = bindTempFB(child, framebuffer);
+    child.fbSize                       = framebuffer->m_size;
+    child.damage                       = damage;
+    child.finalDamage                  = damage;
+    child.mainFB                       = framebuffer;
+    child.outFB.reset();
+    child.transformDamage             = false;
+    child.renderModif                 = {};
+    child.mouseZoomFactor             = 1.F;
+    child.mouseZoomUseMouse           = false;
+    child.useNearestNeighbor          = false;
+    child.blockScreenShader           = true;
+    child.primarySurfaceUVTopLeft     = {-1, -1};
+    child.primarySurfaceUVBottomRight = {-1, -1};
+    child.clipBox                     = {};
+    child.currentWindow.reset();
+    child.surface.reset();
+    child.isolatedWorkspace.reset();
+    child.isolatedWorkspaceFullScene = false;
+    child.blockSurfaceFeedback       = true;
+    child.renderingSnapshot          = false;
+    child.precomputeBlur             = false;
+    child.updatesMonitorBlurState    = false;
+    child.applyFinalScreenShader     = false;
+    setProjectionType(child, RPT_EXPORT);
+
+    draw(child, CClearPassElement::SClearData{CHyprColor(0.F, 0.F, 0.F, 0.F)}, damage);
+    draw(child, CTexPassElement::SRenderData{.tex = texture, .box = {{}, framebuffer->m_size}, .damage = damage}, damage);
     return true;
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -41,6 +41,7 @@
 #include "../helpers/MainLoopExecutor.hpp"
 #include "../output/Monitor.hpp"
 #include "../output/OutputCommitCoordinator.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "../state/MonitorState.hpp"
 #include "../state/WorkspaceState.hpp"
 #include "macros.hpp"
@@ -239,6 +240,9 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->m_workspace)
         return false;
 
+    if (m_isolatedWorkspace)
+        return !(pWindow->m_state & WINDOW_STATE_PINNED) && pWindow->m_workspace == m_isolatedWorkspace;
+
     if (pWindow->m_state & WINDOW_STATE_PINNED)
         return true;
 
@@ -249,7 +253,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
 
     const auto PWINDOWWORKSPACE = pWindow->m_workspace;
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_monitor == pMonitor) {
-        if (PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() || PWINDOWWORKSPACE->m_alpha->isBeingAnimated() || PWINDOWWORKSPACE->m_forceRendering)
+        if (pMonitor->m_workspaceTransition->participates(PWINDOWWORKSPACE))
             return true;
 
         // if hidden behind fullscreen
@@ -257,7 +261,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
             pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) == 0)
             return false;
 
-        if (!PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOWWORKSPACE->m_alpha->isBeingAnimated() && !PWINDOWWORKSPACE->isVisible())
+        if (!pMonitor->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE) && !PWINDOWWORKSPACE->isVisible())
             return false;
     }
 
@@ -279,13 +283,14 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
         return false;
 
     if (pWindow->positionAnimation()->isBeingAnimated()) {
-        if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated())
+        const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
+        if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
             return false;
         // render window if window and monitor intersect
         // (when moving out of or through a monitor)
         CBox windowBox = pWindow->getFullWindowBoundingBox();
-        if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated())
-            windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
+        if (PWINDOWWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE))
+            windowBox.translate(PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWINDOWWORKSPACE));
         windowBox.translate(pWindow->presentation().floatingOffset());
 
         const CBox monitorBox = {pMonitor->m_position, pMonitor->m_size};
@@ -306,14 +311,16 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (!pWindow->m_workspace)
         return false;
 
-    if ((pWindow->m_state & WINDOW_STATE_PINNED) || PWORKSPACE->m_forceRendering)
+    const auto PWORKSPACEMONITOR = PWORKSPACE->m_monitor.lock();
+
+    if ((pWindow->m_state & WINDOW_STATE_PINNED) || (PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->forceRendering(PWORKSPACE)))
         return true;
 
     if (PWORKSPACE && PWORKSPACE->isVisible())
         return true;
 
     for (auto const& m : State::monitorState()->monitors()) {
-        if (PWORKSPACE && PWORKSPACE->m_monitor == m && (PWORKSPACE->m_renderOffset->isBeingAnimated() || PWORKSPACE->m_alpha->isBeingAnimated()))
+        if (PWORKSPACE && PWORKSPACE->m_monitor == m && m->m_workspaceTransition->isAnimating(PWORKSPACE))
             return true;
 
         if (m->m_activeSpecialWorkspace && pWindow->onSpecialWorkspace())
@@ -321,6 +328,38 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     }
 
     return false;
+}
+
+float IHyprRenderer::workspaceRenderAlpha(PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+        return 1.F;
+
+    const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
+    return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->alphaValue(workspace) : 1.F;
+}
+
+Vector2D IHyprRenderer::workspaceRenderOffset(PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+        return {};
+
+    const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
+    return WORKSPACEMONITOR ? WORKSPACEMONITOR->m_workspaceTransition->offsetValue(workspace) : Vector2D{};
+}
+
+bool IHyprRenderer::workspaceRenderIsAnimating(PHLWORKSPACE workspace, PHLMONITOR) const {
+    if (!workspace || (m_isolatedWorkspace && workspace == m_isolatedWorkspace))
+        return false;
+
+    const auto WORKSPACEMONITOR = workspace->m_monitor.lock();
+    return WORKSPACEMONITOR && WORKSPACEMONITOR->m_workspaceTransition->isAnimating(workspace);
+}
+
+Vector2D IHyprRenderer::windowRenderFloatingOffset(PHLWINDOW window) const {
+    return window && !(m_isolatedWorkspace && window->m_workspace == m_isolatedWorkspace) ? window->presentation().floatingOffset() : Vector2D{};
+}
+
+bool IHyprRenderer::renderingWorkspaceToBuffer() const {
+    return !!m_isolatedWorkspace;
 }
 
 bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
@@ -336,7 +375,8 @@ bool IHyprRenderer::shouldRenderMonitor(PHLMONITOR monitor) {
 void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW pWorkspaceWindow = nullptr;
 
-    Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     // pre-filter renderable windows once for the tiled + floating passes
     std::vector<PHLWINDOW> windows;
@@ -364,7 +404,8 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
     for (auto const& w : windows) {
@@ -380,16 +421,21 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (w->isFadingOutUnderFullscreen())
             continue; // render these over fullscreen so the fade-out is visible
 
+        if (m_isolatedWorkspace && w->shouldRenderOverFullscreen())
+            continue;
+
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
     for (auto const& w : Desktop::windowState()->windows()) {
         const auto PWORKSPACE = w->m_workspace;
 
         if (w->m_workspace != pWorkspace || !Fullscreen::controller()->isFullscreen(w)) {
-            if (!(PWORKSPACE && (PWORKSPACE->m_renderOffset->isBeingAnimated() || PWORKSPACE->m_alpha->isBeingAnimated() || PWORKSPACE->m_forceRendering)))
+            const auto PWORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+            if (!(PWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->participates(PWORKSPACE)))
                 continue;
 
             if (w->m_monitor != pMonitor)
@@ -422,6 +468,9 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (shouldSkipWindow)
             continue;
 
+        if (!shouldRenderWindow(w, pMonitor))
+            continue;
+
         const bool mismatchedSpecialWorkspace = w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace();
 
         if (mismatchedSpecialWorkspace)
@@ -434,13 +483,15 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
 void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
     PHLWINDOW lastWindow;
 
-    Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
     std::vector<PHLWINDOWREF> windows;
     windows.reserve(Desktop::windowState()->windows().size());
@@ -484,7 +535,8 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     lastWindow.reset();
 
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
     for (auto& w : windows) {
@@ -525,7 +577,8 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         // render the bad boy
         renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
-    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
+    if (!m_isolatedWorkspace)
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
 void IHyprRenderer::bindOffMain() {
@@ -563,10 +616,11 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     TRACY_GPU_ZONE("RenderWindow");
 
-    const auto PWORKSPACE = pWindow->m_workspace;
-    const auto REALPOS =
-        pWindow->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + ((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
-    static auto                      PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
+    const auto  PWORKSPACE      = pWindow->m_workspace;
+    const auto  WORKSPACEOFFSET = workspaceRenderOffset(PWORKSPACE, pMonitor);
+    const auto  WINDOWOFFSET    = windowRenderFloatingOffset(pWindow);
+    const auto  REALPOS         = pWindow->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + ((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET);
+    static auto PDIMAROUND      = CConfigValue<Config::FLOAT>("decoration:dim_around");
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time};
     const auto                       REALSIZE   = pWindow->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
@@ -593,7 +647,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.surface   = pWindow->wlSurface()->resource();
     renderdata.dontRound = Fullscreen::controller()->getFullscreenModes(pWindow).internal == Fullscreen::FSMODE_FULLSCREEN;
     renderdata.fadeAlpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_FADE) * pWindow->presentation().alphaValue(WINDOW_ALPHA_FULLSCREEN) *
-        pWindow->presentation().alphaValue(WINDOW_ALPHA_LAYOUT) * ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
+        pWindow->presentation().alphaValue(WINDOW_ALPHA_LAYOUT) *
+        ((pWindow->m_state & WINDOW_STATE_PINNED) || USE_WORKSPACE_FADE_ALPHA ? 1.f : workspaceRenderAlpha(PWORKSPACE, pMonitor)) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_TO_WORKSPACE) : 1.F) *
         pWindow->presentation().alphaValue(WINDOW_ALPHA_MOVE_FROM_WORKSPACE);
     renderdata.alpha = pWindow->presentation().alphaValue(WINDOW_ALPHA_ACTIVE);
@@ -618,7 +673,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     // for plugins
     m_renderData.currentWindow = pWindow;
 
-    Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOW);
 
     const auto fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
 
@@ -630,15 +686,12 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         addPassElement(makeUnique<CRectPassElement>(data));
     }
 
-    renderdata.pos += pWindow->presentation().floatingOffset();
+    renderdata.pos += WINDOWOFFSET;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && PWORKSPACE->m_renderOffset->isBeingAnimated() &&
+    if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(PWORKSPACE, pMonitor) &&
         !(pWindow->m_state & WINDOW_STATE_PINNED)) {
-        CRegion rg         = pWindow->getFullWindowBoundingBox()
-                                 .translate(-pMonitor->m_position + PWORKSPACE->m_renderOffset->value() + pWindow->presentation().floatingOffset())
-                                 .scale(pMonitor->m_scale)
-                                 .round();
+        CRegion rg = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
         renderdata.clipBox = rg.getExtents();
     }
 
@@ -731,9 +784,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             passRedirect.reset();
 
             CBox currentBox = pWindow->getFullWindowBoundingBox();
-            currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : PWORKSPACE->m_renderOffset->value()) + pWindow->presentation().floatingOffset() -
-                                 pMonitor->m_position);
-            CBox            transformedBox = pWindow->effects().transformedExtents(currentBox);
+            currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET) + WINDOWOFFSET - pMonitor->m_position);
+            CBox transformedBox = pWindow->effects().transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
             if (!standalone && !m_bRenderingSnapshot) {
@@ -789,17 +841,18 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             if (pWindow->m_ruleApplicator->nearestNeighbor().valueOrDefault())
                 renderdata.useNearestNeighbor = true;
 
-            renderdata.surfaceCounter = 0;
+            renderdata.surfaceCounter  = 0;
+            const auto PARENTFADEALPHA = renderdata.fadeAlpha;
 
             pWindow->popupHead()->breadthfirst(
-                [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
+                [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
                     if (!popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();
                     const Vector2D oldPos = renderdata.pos;
                     renderdata.pos += pos;
-                    renderdata.fadeAlpha = popup->alpha()[POPUP_ALPHA_FADE]->value();
+                    renderdata.fadeAlpha = PARENTFADEALPHA * popup->alpha()[POPUP_ALPHA_FADE]->value();
 
                     popup->wlSurface()->resource()->breadthfirst(
                         [this, &renderdata](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
@@ -813,7 +866,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                             renderdata.texture     = s->m_current.texture;
                             renderdata.surface     = s;
                             renderdata.mainSurface = false;
-                            m_renderPass.add(makeUnique<CSurfacePassElement>(renderdata));
+                            addPassElement(makeUnique<CSurfacePassElement>(renderdata));
                             renderdata.surfaceCounter++;
                         },
                         data);
@@ -822,7 +875,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 },
                 &renderdata);
 
-            renderdata.alpha = 1.F;
+            renderdata.fadeAlpha = PARENTFADEALPHA;
+            renderdata.alpha     = 1.F;
         }
 
         if (decorate) {
@@ -835,7 +889,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         }
     }
 
-    Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOW);
+    if (!m_isolatedWorkspace)
+        Event::bus()->m_events.render.stage.emit(RENDER_POST_WINDOW);
 
     m_renderData.currentWindow.reset();
 }
@@ -1204,15 +1259,25 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         m_renderPass.add(makeUnique<CRectPassElement>(data));
     }
 
-    // special
-    for (auto const& ws : State::workspaceState()->workspaces()) {
-        if (ws->m_alpha->value() <= 0.F || !ws->m_isSpecialWorkspace)
+    std::vector<PHLWORKSPACE> specialWorkspaces;
+    for (const auto& monitor : State::monitorState()->monitors()) {
+        for (const auto& workspace : monitor->m_workspaceTransition->participants(true)) {
+            if (!std::ranges::contains(specialWorkspaces, workspace))
+                specialWorkspaces.emplace_back(workspace);
+        }
+
+        if (monitor->m_activeSpecialWorkspace && !std::ranges::contains(specialWorkspaces, monitor->m_activeSpecialWorkspace))
+            specialWorkspaces.emplace_back(monitor->m_activeSpecialWorkspace);
+    }
+
+    for (const auto& workspace : specialWorkspaces) {
+        if (workspaceRenderAlpha(workspace, pMonitor) <= 0.F)
             continue;
 
-        if (Fullscreen::controller()->hasFullscreen(ws.lock()))
-            renderWorkspaceWindowsFullscreen(pMonitor, ws.lock(), time);
+        if (Fullscreen::controller()->hasFullscreen(workspace))
+            renderWorkspaceWindowsFullscreen(pMonitor, workspace, time);
         else
-            renderWorkspaceWindows(pMonitor, ws.lock(), time);
+            renderWorkspaceWindows(pMonitor, workspace, time);
     }
 
     // pinned always above
@@ -2570,6 +2635,70 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
     renderAllClientsForWorkspace(pMonitor, pWorkspace, now, translate, scale);
 }
 
+bool IHyprRenderer::renderWorkspaceToBuffer(PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, bool sendFeedback) {
+    const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !m_renderData.currentFB || m_renderData.pMonitor != MONITOR)
+        return false;
+    if (framebuffer == m_renderData.currentFB || framebuffer == m_renderData.mainFB || framebuffer == m_renderData.outFB)
+        return false;
+
+    if (!framebuffer->imageDescription())
+        framebuffer->setImageDescription(MONITOR->workBufferImageDescription());
+
+    CRenderPass pass;
+    const auto  OLDRENDERDATA        = m_renderData;
+    const auto  OLDISOLATEDWORKSPACE = m_isolatedWorkspace;
+    const bool  OLDBLOCKFEEDBACK     = m_bBlockSurfaceFeedback;
+    const bool  OLDRENDERINGSNAPSHOT = m_bRenderingSnapshot;
+    const bool  OLDBLURSHOULDRENDER  = MONITOR->m_blurFBShouldRender;
+    auto* const OLDPASS              = m_currentPass;
+
+    CScopeGuard restore([&] {
+        m_currentPass                 = OLDPASS;
+        m_isolatedWorkspace           = OLDISOLATEDWORKSPACE;
+        m_bBlockSurfaceFeedback       = OLDBLOCKFEEDBACK;
+        m_bRenderingSnapshot          = OLDRENDERINGSNAPSHOT;
+        MONITOR->m_blurFBShouldRender = OLDBLURSHOULDRENDER;
+        m_renderData                  = OLDRENDERDATA;
+    });
+    auto        framebufferGuard = bindTempFB(framebuffer);
+
+    CRegion     damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
+    m_currentPass                 = &pass;
+    m_isolatedWorkspace           = workspace;
+    m_bBlockSurfaceFeedback       = !sendFeedback;
+    m_bRenderingSnapshot          = true;
+    MONITOR->m_blurFBShouldRender = false;
+    m_renderData.pMonitor         = MONITOR;
+    m_renderData.mainFB           = framebuffer;
+    m_renderData.outFB.reset();
+    m_renderData.fbSize                     = MONITOR->m_transformedSize;
+    m_renderData.damage                     = damage;
+    m_renderData.finalDamage                = damage;
+    m_renderData.renderModif                = {};
+    m_renderData.mouseZoomFactor            = 1.F;
+    m_renderData.mouseZoomUseMouse          = false;
+    m_renderData.transformDamage            = false;
+    m_renderData.noSimplify                 = false;
+    m_renderData.renderingTransformedSource = false;
+    m_renderData.blockScreenShader          = true;
+    m_renderData.currentWindow.reset();
+    m_renderData.surface.reset();
+    m_renderData.clipBox = {};
+    setProjectionType(RPT_EXPORT);
+
+    addPassElement(makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    if (Fullscreen::controller()->hasFullscreen(workspace))
+        renderWorkspaceWindowsFullscreen(MONITOR, workspace, Time::steadyNow());
+    else
+        renderWorkspaceWindows(MONITOR, workspace, Time::steadyNow());
+
+    m_currentPass = OLDPASS;
+    pass.render(damage);
+
+    return true;
+}
+
 void IHyprRenderer::sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now) {
     for (const auto& view : Desktop::View::getViewsForWorkspace(pWorkspace)) {
         if (!view->mapped() || !view->acceptsInput() || !view->resource())
@@ -2823,10 +2952,11 @@ void IHyprRenderer::damageSurface(SP<CWLSurfaceResource> pSurface, double x, dou
 }
 
 void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
-    CBox       windowBox        = pWindow->getFullWindowBoundingBox();
-    const auto PWINDOWWORKSPACE = pWindow->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !(pWindow->m_state & WINDOW_STATE_PINNED))
-        windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
+    CBox       windowBox         = pWindow->getFullWindowBoundingBox();
+    const auto PWINDOWWORKSPACE  = pWindow->m_workspace;
+    const auto PWORKSPACEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
+    if (PWINDOWWORKSPACE && PWORKSPACEMONITOR && PWORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWINDOWWORKSPACE) && !(pWindow->m_state & WINDOW_STATE_PINNED))
+        windowBox.translate(PWORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWINDOWWORKSPACE));
     windowBox.translate(pWindow->presentation().floatingOffset());
     windowBox = pWindow->effects().transformBoxForDamage(windowBox);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -690,7 +690,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     // if window is floating and we have a slide animation, clip it to its full bb
     if (!ignorePosition && pWindow->isFloating() && !Fullscreen::controller()->isFullscreen(pWindow) && workspaceRenderIsAnimating(PWORKSPACE, pMonitor) &&
         !(pWindow->m_state & WINDOW_STATE_PINNED)) {
-        CRegion rg = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
+        CRegion rg         = pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + WORKSPACEOFFSET + WINDOWOFFSET).scale(pMonitor->m_scale).round();
         renderdata.clipBox = rg.getExtents();
     }
 
@@ -784,7 +784,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             CBox currentBox = pWindow->getFullWindowBoundingBox();
             currentBox.translate(((pWindow->m_state & WINDOW_STATE_PINNED) ? Vector2D{} : WORKSPACEOFFSET) + WINDOWOFFSET - pMonitor->m_position);
-            CBox transformedBox = pWindow->effects().transformedExtents(currentBox);
+            CBox            transformedBox = pWindow->effects().transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
             if (!standalone && !m_bRenderingSnapshot) {
@@ -845,7 +845,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             pWindow->popupHead()->breadthfirst(
                 [this, &renderdata, PARENTFADEALPHA](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (!popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
+                    if (!popup->mapped() || !popup->resource() || (!m_isolatedWorkspace && (!popup->acceptsInput() || !popup->alphaNonZero())))
                         return;
 
                     const auto     pos    = popup->coordsRelativeToParent();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2631,22 +2631,11 @@ bool IHyprRenderer::renderWorkspaceSceneToBuffer(CRenderingContext& context, PHL
     return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true);
 }
 
-bool IHyprRenderer::renderWorkspaceSceneToBufferScaled(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
-                                                       bool sendFeedback) {
-    return renderWorkspaceToBufferInternal(context, workspace, framebuffer, time, sendFeedback, true, true);
-}
-
 bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, PHLWORKSPACE workspace, SP<IFramebuffer> framebuffer, const Time::steady_tp& time,
-                                                    bool sendFeedback, bool fullScene, bool scaleToBuffer) {
+                                                    bool sendFeedback, bool fullScene) {
     const auto MONITOR = workspace ? workspace->m_monitor.lock() : nullptr;
     auto&      parent  = context;
-    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || !parent.currentFB)
-        return false;
-    if (framebuffer->m_size.x <= 0 || framebuffer->m_size.y <= 0 || MONITOR->m_transformedSize.x <= 0 || MONITOR->m_transformedSize.y <= 0)
-        return false;
-    if (!scaleToBuffer && framebuffer->m_size != MONITOR->m_transformedSize)
-        return false;
-    if (scaleToBuffer && !DELTALESSTHAN(framebuffer->m_size.x / framebuffer->m_size.y, MONITOR->m_transformedSize.x / MONITOR->m_transformedSize.y, 0.01))
+    if (!MONITOR || !framebuffer || !framebuffer->isAllocated() || framebuffer->m_size != MONITOR->m_transformedSize || !parent.currentFB)
         return false;
     if (framebuffer == parent.currentFB || framebuffer == parent.mainFB || framebuffer == parent.outFB)
         return false;
@@ -2656,7 +2645,7 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     CRenderPass       pass;
     CRenderingContext child{parent, pass, MONITOR};
-    CRegion           damage{0, 0, sc<int>(framebuffer->m_size.x), sc<int>(framebuffer->m_size.y)};
+    CRegion           damage{0, 0, sc<int>(MONITOR->m_transformedSize.x), sc<int>(MONITOR->m_transformedSize.y)};
 
     child.isolatedWorkspace          = workspace;
     child.isolatedWorkspaceFullScene = fullScene;
@@ -2665,14 +2654,14 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
     child.precomputeBlur             = false;
     child.mainFB                     = framebuffer;
     child.outFB.reset();
-    child.fbSize                     = framebuffer->m_size;
+    child.fbSize                     = MONITOR->m_transformedSize;
     child.damage                     = damage;
     child.finalDamage                = damage;
     child.renderModif                = {};
     child.mouseZoomFactor            = 1.F;
     child.mouseZoomUseMouse          = false;
     child.transformDamage            = false;
-    child.noSimplify                 = scaleToBuffer;
+    child.noSimplify                 = false;
     child.renderingTransformedSource = false;
     child.blockScreenShader          = true;
     child.currentWindow.reset();
@@ -2684,17 +2673,9 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     addPassElement(child, makeUnique<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
     if (fullScene) {
-        const float SCALE = scaleToBuffer ? framebuffer->m_size.x / MONITOR->m_transformedSize.x : 1.F;
-        renderAllClientsForWorkspace(child, MONITOR, workspace, time, {}, SCALE);
-        const CBox renderBox = {{}, MONITOR->m_transformedSize * SCALE};
-        if (scaleToBuffer) {
-            SRenderModifData renderModif;
-            renderModif.modifs.emplace_back(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, SCALE);
-            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{renderModif}));
-            renderLockscreen(child, MONITOR, time, renderBox);
-            addPassElement(child, makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
-        } else
-            renderLockscreen(child, MONITOR, time, renderBox);
+        renderAllClientsForWorkspace(child, MONITOR, workspace, time);
+        const CBox renderBox = {{}, MONITOR->m_transformedSize};
+        renderLockscreen(child, MONITOR, time, renderBox);
         renderIME(child, MONITOR, time, renderBox);
     } else if (Fullscreen::controller()->hasFullscreen(workspace))
         renderWorkspaceWindowsFullscreen(child, MONITOR, workspace, time);
@@ -2703,6 +2684,47 @@ bool IHyprRenderer::renderWorkspaceToBufferInternal(CRenderingContext& context, 
 
     pass.render(child, damage);
 
+    return true;
+}
+
+bool IHyprRenderer::renderTextureToBuffer(CRenderingContext& context, SP<ITexture> texture, SP<IFramebuffer> framebuffer) {
+    if (!texture || !framebuffer || !framebuffer->isAllocated() || !context.currentFB || framebuffer == context.currentFB || framebuffer == context.mainFB ||
+        framebuffer == context.outFB || texture == framebuffer->getTexture())
+        return false;
+
+    if (texture->m_imageDescription)
+        framebuffer->setImageDescription(texture->m_imageDescription);
+
+    CRenderingContext child{context, context.renderPass()};
+    const CRegion     damage{0, 0, sc<int>(framebuffer->m_size.x), sc<int>(framebuffer->m_size.y)};
+    auto              framebufferGuard = bindTempFB(child, framebuffer);
+    child.fbSize                       = framebuffer->m_size;
+    child.damage                       = damage;
+    child.finalDamage                  = damage;
+    child.mainFB                       = framebuffer;
+    child.outFB.reset();
+    child.transformDamage             = false;
+    child.renderModif                 = {};
+    child.mouseZoomFactor             = 1.F;
+    child.mouseZoomUseMouse           = false;
+    child.useNearestNeighbor          = false;
+    child.blockScreenShader           = true;
+    child.primarySurfaceUVTopLeft     = {-1, -1};
+    child.primarySurfaceUVBottomRight = {-1, -1};
+    child.clipBox                     = {};
+    child.currentWindow.reset();
+    child.surface.reset();
+    child.isolatedWorkspace.reset();
+    child.isolatedWorkspaceFullScene = false;
+    child.blockSurfaceFeedback       = true;
+    child.renderingSnapshot          = false;
+    child.precomputeBlur             = false;
+    child.updatesMonitorBlurState    = false;
+    child.applyFinalScreenShader     = false;
+    setProjectionType(child, RPT_EXPORT);
+
+    draw(child, CClearPassElement::SClearData{CHyprColor(0.F, 0.F, 0.F, 0.F)}, damage);
+    draw(child, CTexPassElement::SRenderData{.tex = texture, .box = {{}, framebuffer->m_size}, .damage = damage}, damage);
     return true;
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1197,12 +1197,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHL
     if UNLIKELY (!pWorkspace) {
         // allow rendering without a workspace. In this case, just render layers.
 
-        renderBackground(context, pMonitor);
-
-        for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(context, ls.lock(), pMonitor, time);
-        }
-        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderMonitorBackground(context, pMonitor, time);
 
         if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
@@ -1226,12 +1221,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHL
     }
 
     if LIKELY (!*PXPMODE) {
-        renderBackground(context, pMonitor);
-
-        for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
-            renderLayer(context, ls.lock(), pMonitor, time);
-        }
-        renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
+        renderMonitorBackground(context, pMonitor, time);
 
         if (!context.isolatedWorkspace)
             Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
@@ -1328,6 +1318,18 @@ void IHyprRenderer::renderAllClientsForWorkspace(CRenderingContext& context, PHL
     renderFadeouts(context, pMonitor, Desktop::FADEOUT_PLANE_POPUP);
 
     renderDragIcon(context, pMonitor, time);
+}
+
+void IHyprRenderer::renderMonitorBackground(CRenderingContext& context, PHLMONITOR monitor, const Time::steady_tp& time) {
+    if (!monitor)
+        return;
+
+    renderBackground(context, monitor);
+
+    for (const auto& layer : monitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
+        renderLayer(context, layer.lock(), monitor, time);
+    }
+    renderFadeouts(context, monitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 }
 
 void IHyprRenderer::renderIME(CRenderingContext& context, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry) {

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -96,7 +96,9 @@ namespace Render {
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
         bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
-        bool                                renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        // Renders the compositor background and layer-shell background plane.
+        void                                renderMonitorBackground(CRenderingContext&, PHLMONITOR, const Time::steady_tp&);
         bool                                shouldRenderMonitor(PHLMONITOR);
         void                                ensureCursorRenderingMode();
         bool                                shouldRenderCursor();

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -95,8 +95,7 @@ namespace Render {
         bool renderWorkspaceToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
         bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
-        // Renders and scales the target workspace to an aspect-ratio-matched framebuffer.
-        bool renderWorkspaceSceneToBufferScaled(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool renderTextureToBuffer(CRenderingContext&, SP<ITexture>, SP<IFramebuffer>);
         // Renders the target monitor's regular scene during its active render.
         bool renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the compositor background and layer-shell background plane.
@@ -259,8 +258,7 @@ namespace Render {
         SP<ITexture>         m_lockDead3Texture;
         SP<ITexture>         m_lockTtyTextTexture;
         void                 handleFullscreenSettings(PHLMONITOR pMonitor);
-        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene,
-                                                             bool scaleToBuffer = false);
+        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
 
         // old private:
         void         arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -95,8 +95,7 @@ namespace Render {
         bool renderWorkspaceToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
         bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
-        // Renders and scales the target workspace to an aspect-ratio-matched framebuffer.
-        bool renderWorkspaceSceneToBufferScaled(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool renderTextureToBuffer(CRenderingContext&, SP<ITexture>, SP<IFramebuffer>);
         // Renders the target monitor's regular scene during its active render.
         bool renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the compositor background and layer-shell background plane.
@@ -257,8 +256,7 @@ namespace Render {
         SP<ITexture>         m_lockDead3Texture;
         SP<ITexture>         m_lockTtyTextTexture;
         void                 handleFullscreenSettings(PHLMONITOR pMonitor);
-        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene,
-                                                             bool scaleToBuffer = false);
+        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
 
         // old private:
         void         arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -83,19 +83,20 @@ namespace Render {
         void                            damageRegion(const CRegion&);
         void                            damageMonitor(PHLMONITOR);
         void                            damageMirrorsWith(PHLMONITOR, const CRegion&);
+        bool                            shouldRenderWindow(const CRenderingContext&, PHLWINDOW, PHLMONITOR);
         bool                            shouldRenderWindow(PHLWINDOW, PHLMONITOR);
         bool                            shouldRenderWindow(PHLWINDOW);
-        float                           workspaceRenderAlpha(PHLWORKSPACE, PHLMONITOR = nullptr) const;
-        Vector2D                        workspaceRenderOffset(PHLWORKSPACE, PHLMONITOR = nullptr) const;
-        bool                            workspaceRenderIsAnimating(PHLWORKSPACE, PHLMONITOR = nullptr) const;
-        Vector2D                        windowRenderFloatingOffset(PHLWINDOW) const;
-        bool                            renderingWorkspaceToBuffer() const;
+        float                           workspaceRenderAlpha(const CRenderingContext&, PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        workspaceRenderOffset(const CRenderingContext&, PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        bool                            workspaceRenderIsAnimating(const CRenderingContext&, PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        windowRenderFloatingOffset(const CRenderingContext&, PHLWINDOW) const;
+        bool                            renderingWorkspaceToBuffer(const CRenderingContext&) const;
         // Renders only the target workspace's windows and popups during the target monitor's active render.
-        bool renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
+        bool renderWorkspaceToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
-        bool renderWorkspaceSceneToBuffer(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
-        bool                                renderMonitorToBuffer(PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool                                renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
         void                                ensureCursorRenderingMode();
         bool                                shouldRenderCursor();
@@ -103,7 +104,7 @@ namespace Render {
 
         std::tuple<float, float, float>     getRenderTimes(PHLMONITOR pMonitor); // avg max min
         void                                ensureLockTexturesRendered(bool load);
-        void                                renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
+        void                                renderLockscreen(CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
         void                                setCursorSurface(SP<Desktop::View::CWLSurface> surf, int hotspotX, int hotspotY, bool force = false);
         void                                setCursorFromName(const std::string& name, bool force = false);
         void                                onRenderbufferDestroy(IRenderbuffer* rb);
@@ -115,23 +116,19 @@ namespace Render {
         SP<IFramebuffer>                    makeSnapshotFB(PHLWINDOW);
         SP<IFramebuffer>                    makeSnapshotFB(PHLLS);
         SP<IFramebuffer>                    makeSnapshotFB(WP<Desktop::View::CPopup>);
-        void                                renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace = nullptr);
-        bool                                beginFullFakeRender(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb);
-        bool                                beginRenderToBuffer(PHLMONITOR pMonitor, CRegion& damage, SP<IHLBuffer> buffer, bool simple = false);
-        virtual void                        startRenderPass() {};
-        virtual void                        endRender(const std::function<void()>& renderingDoneCallback = {}) = 0;
+        void                                renderFadeouts(CRenderingContext&, PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace = nullptr);
+        bool                                beginFullFakeRender(CRenderingContext&, CRegion& damage, SP<IFramebuffer> fb);
+        bool                                beginRenderToBuffer(CRenderingContext&, CRegion& damage, SP<IHLBuffer> buffer, bool simple = false);
+        virtual void                        startRenderPass(CRenderingContext&) {};
+        virtual void                        endRender(CRenderingContext&, const std::function<void()>& renderingDoneCallback = {}) = 0;
 
-        NColorManagement::PImageDescription workBufferImageDescription();
-        bool                                m_bBlockSurfaceFeedback = false;
-        bool                                m_bRenderingSnapshot    = false;
+        NColorManagement::PImageDescription workBufferImageDescription(const CRenderingContext&);
         PHLMONITORREF                       m_mostHzMonitor;
         bool                                m_directScanoutBlocked = false;
 
         void                                setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
 
         void                                initiateManualCrash();
-        const SRenderData&                  renderData();
-
         bool                                m_crashingInProgress = false;
         float                               m_crashingDistort    = 0.5f;
         wl_event_source*                    m_crashingLoop       = nullptr;
@@ -147,37 +144,32 @@ namespace Render {
             std::string                                  name;
         } m_lastCursorData;
 
-        CRenderPass     m_renderPass;
+        void         addPassElement(CRenderingContext&, UP<IPassElement>&& element);
 
-        void            addPassElement(UP<IPassElement>&& element);
-        CRenderPass&    currentPass();
-        UP<CScopeGuard> redirectPass(CRenderPass* pass);
-
-        SP<ITexture>    renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth = 1024,
-                                     const int maxHeight = 1024);
-        CHyprColor      getConvertedColor(const CHyprColor& color);
+        SP<ITexture> renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth = 1024,
+                                  const int maxHeight = 1024);
+        CHyprColor   getConvertedColor(const CRenderingContext&, const CHyprColor& color);
 
         virtual SP<IRenderbuffer>    getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer,
                                                              uint32_t                fmt); // TODO? move to protected and fix CPointerManager::renderHWCursorBuffer
         bool                         commitPendingAndDoExplicitSync(PHLMONITOR pMonitor);  // TODO? move to protected and fix CMonitorFrameScheduler::onPresented
-        SRenderData                  m_renderData;                                         // TODO? move to protected and fix CRenderPass
         SP<ITexture>                 m_screencopyDeniedTexture;                            // TODO? make readonly
         uint                         m_failedAssetsNo     = 0;                             // TODO? make readonly
         bool                         m_reloadScreenShader = true;                          // at launch it can be set
         CTimer                       m_globalTimer;
 
-        void                         draw(WP<IPassElement> element, const CRegion& damage = {});
-        void                         draw(const CBorderPassElement::SBorderData& data, const CRegion& damage = {});
-        void                         draw(const CClearPassElement::SClearData& data, const CRegion& damage = {});
-        void                         draw(const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage = {});
-        void                         draw(const CRectPassElement::SRectData& data, const CRegion& damage = {});
-        void                         draw(const CRendererHintsPassElement::SData& data, const CRegion& damage = {});
-        void                         draw(const CShadowPassElement::SShadowData& data, const CRegion& damage = {});
-        void                         draw(const CSurfacePassElement::SRenderData& data, const CRegion& damage = {});
-        void                         draw(const CTexPassElement::SRenderData& data, const CRegion& damage = {});
-        void                         draw(const CTextureMatteElement::STextureMatteData& data, const CRegion& damage = {});
-        virtual void                 bindFB(SP<IFramebuffer> fb);
-        UP<CScopeGuard>              bindTempFB(SP<IFramebuffer> fb);
+        void                         draw(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CBorderPassElement::SBorderData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CClearPassElement::SClearData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CRectPassElement::SRectData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CRendererHintsPassElement::SData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CShadowPassElement::SShadowData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CSurfacePassElement::SRenderData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CTexPassElement::SRenderData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CTextureMatteElement::STextureMatteData& data, const CRegion& damage = {});
+        virtual void                 bindFB(CRenderingContext&, SP<IFramebuffer> fb);
+        UP<CScopeGuard>              bindTempFB(CRenderingContext&, SP<IFramebuffer> fb);
         virtual UP<ISyncFDManager>   createSyncFDManager()                                                                                                                     = 0;
         virtual WP<IElementRenderer> elementRenderer()                                                                                                                         = 0;
         virtual SP<ITexture>         createStencilTexture(const int width, const int height)                                                                                   = 0;
@@ -192,120 +184,108 @@ namespace Render {
                                                 int weight = 400);
         virtual SP<ITexture>         renderText(Hyprgraphics::CTextResource::STextResourceData&& data);
         SP<ITexture>                 loadAsset(const std::string& filename);
-        virtual bool                 shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow);
-        virtual bool                 explicitSyncSupported()                                                                                                     = 0;
-        virtual bool                 fp16Supported()                                                                                                             = 0;
-        virtual std::vector<SDRMFormat> getDRMFormats()                                                                                                          = 0;
-        virtual std::vector<uint64_t>   getDRMFormatModifiers(DRMFormat format)                                                                                  = 0;
-        virtual SP<IFramebuffer>        createFB(const std::string& name = "")                                                                                   = 0;
-        virtual void                    disableScissor()                                                                                                         = 0;
-        virtual void                    blend(bool enabled)                                                                                                      = 0;
-        virtual void                    drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) = 0;
-        virtual void     drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                    float lerp, float a)                                                                                                         = 0;
-        virtual void     drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a)                  = 0;
-        virtual void     drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                  float lerp, float a)                                                                                                           = 0;
-        virtual void     setViewport(int x, int y, int width, int height)                                                                                        = 0;
+        virtual bool                 shouldUseNewBlurOptimizations(const CRenderingContext&, PHLLS pLayer, PHLWINDOW pWindow);
+        virtual bool                 explicitSyncSupported()                                                                                                                  = 0;
+        virtual bool                 fp16Supported()                                                                                                                          = 0;
+        virtual std::vector<SDRMFormat> getDRMFormats()                                                                                                                       = 0;
+        virtual std::vector<uint64_t>   getDRMFormatModifiers(DRMFormat format)                                                                                               = 0;
+        virtual SP<IFramebuffer>        createFB(const std::string& name = "")                                                                                                = 0;
+        virtual void                    disableScissor(CRenderingContext&)                                                                                                    = 0;
+        virtual void                    blend(bool enabled)                                                                                                                   = 0;
+        virtual void             drawShadow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) = 0;
+        virtual void             drawShadow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                            const Config::CGradientValueData& grad2, float lerp, float a)                                                                     = 0;
+        virtual void             drawGlow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a)   = 0;
+        virtual void             drawGlow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                          const Config::CGradientValueData& grad2, float lerp, float a)                                                                       = 0;
+        virtual void             setViewport(int x, int y, int width, int height)                                                                                             = 0;
 
-        bool             preBlurQueued(PHLMONITORREF pMonitor);
-        void             sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now);
+        bool                     preBlurQueued(const CRenderingContext&);
+        void                     sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now);
 
-        void             setProjectionType(const Vector2D& fbSize);
-        void             setProjectionType(eRenderProjectionType projectionType);
-        Mat3x3           getBoxProjection(const CBox& box, std::optional<eTransform> transform = std::nullopt);
-        Mat3x3           projectBoxToTarget(const CBox& box, std::optional<eTransform> transform = std::nullopt);
+        void                     setProjectionType(CRenderingContext&, const Vector2D& fbSize);
+        void                     setProjectionType(CRenderingContext&, eRenderProjectionType projectionType);
+        Mat3x3                   getBoxProjection(const CRenderingContext&, const CBox& box, std::optional<eTransform> transform = std::nullopt);
+        Mat3x3                   projectBoxToTarget(const CRenderingContext&, const CBox& box, std::optional<eTransform> transform = std::nullopt);
 
-        SP<IFramebuffer> blurMainFramebuffer(float strength, const CRegion& originalDamage, const Render::SBlurContext& context = {});
-        void             beginBackdropScope(SP<SBackdropScope> scope);
-        void             endBackdropScope(SP<SBackdropScope> scope);
-        virtual SP<IFramebuffer> blurFramebuffer(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const Render::SBlurContext& context = {}) = 0;
-        virtual void             refreshBlurProvider()                                                                                                             = 0;
-        virtual void             expandBlurDamage(CRegion& damage, float multiplier = 1.F) const                                                                   = 0;
-        virtual bool             blurProviderIsAnimated() const                                                                                                    = 0;
-        virtual bool             blurProviderRequiresLiveBlur() const                                                                                              = 0;
-        void                     scheduleFrameForAnimatedBlur(const CRegion& damage, bool usesPrecomputedBlur);
-        void                     preBlurForCurrentMonitor(const CRegion& fakeDamage);
+        SP<IFramebuffer>         blurMainFramebuffer(CRenderingContext&, float strength, const CRegion& originalDamage, const Render::SBlurContext& blurContext = {});
+        void                     beginBackdropScope(CRenderingContext&, SP<SBackdropScope> scope);
+        void                     endBackdropScope(CRenderingContext&, SP<SBackdropScope> scope);
+        virtual SP<IFramebuffer> blurFramebuffer(CRenderingContext&, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                                 const Render::SBlurContext& blurContext = {})   = 0;
+        virtual void             refreshBlurProvider()                                           = 0;
+        virtual void             expandBlurDamage(CRegion& damage, float multiplier = 1.F) const = 0;
+        virtual bool             blurProviderIsAnimated(const CRenderingContext&) const          = 0;
+        virtual bool             blurProviderRequiresLiveBlur() const                            = 0;
+        void                     scheduleFrameForAnimatedBlur(const CRenderingContext&, const CRegion& damage, bool usesPrecomputedBlur);
+        void                     preBlurForCurrentMonitor(CRenderingContext&, const CRegion& fakeDamage);
 
-        SCMSettings              getCMSettings(const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
-                                               SP<CWLSurfaceResource> surface = nullptr, bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1,
-                                               bool shouldUseSurface = false);
-        void                     clearCMSettingsCache();
+        SCMSettings              getCMSettings(const CRenderingContext&, const NColorManagement::PImageDescription imageDescription,
+                                               const NColorManagement::PImageDescription targetImageDescription, SP<CWLSurfaceResource> surface = nullptr, bool modifySDR = false,
+                                               float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1, bool shouldUseSurface = false);
         virtual bool             reloadShaders(const std::string& path = "") = 0;
 
       protected:
-        virtual void              renderOffToMain(SP<IFramebuffer> off)                                         = 0;
+        virtual void              renderOffToMain(CRenderingContext&, SP<IFramebuffer> off)                     = 0;
         virtual SP<IRenderbuffer> getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) = 0;
-        void                      renderMirrored();
-        void                      setDamage(const CRegion& damage_, std::optional<CRegion> finalDamage);
+        void                      renderMirrored(CRenderingContext&);
+        void                      setDamage(CRenderingContext&, const CRegion& damage_, std::optional<CRegion> finalDamage);
         // if RENDER_MODE_NORMAL, provided damage will be written to.
         // otherwise, it will be the one used.
-        bool         beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, SP<IFramebuffer> fb = nullptr,
-                                 bool simple = false);
+        bool beginRender(CRenderingContext&, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, SP<IFramebuffer> fb = nullptr, bool simple = false);
 
-        virtual bool beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple = false) {
+        virtual bool beginRenderInternal(CRenderingContext&, CRegion& damage, bool simple = false) {
             return false;
         };
-        virtual bool beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) {
+        virtual bool beginFullFakeRenderInternal(CRenderingContext&, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) {
             return false;
         };
         virtual void initRender() {};
-        virtual bool initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
+        virtual bool initRenderBuffer(CRenderingContext&, SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
             return false;
         };
 
-        SP<ITexture>         getBackground(PHLMONITOR pMonitor);
-        virtual SP<ITexture> getBlurTexture(PHLMONITORREF pMonitor);
+        SP<ITexture>         getBackground(CRenderingContext&, PHLMONITOR pMonitor);
+        virtual SP<ITexture> getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor);
 
-        struct SCMSettingsCacheEntry {
-            uint64_t    srcDescId = 0, dstDescId = 0;
-            void*       surfacePtr      = nullptr; // read-only!!
-            bool        modifySDR       = false;
-            float       sdrMinLuminance = -1.F;
-            int         sdrMaxLuminance = -1;
-            SCMSettings settings;
-        };
-        std::vector<SCMSettingsCacheEntry> m_cmSettingsCache;
-
-        SP<ITexture>                       m_lockDeadTexture;
-        SP<ITexture>                       m_lockDead2Texture;
-        SP<ITexture>                       m_lockDead3Texture;
-        SP<ITexture>                       m_lockTtyTextTexture;
-        CRenderPass*                       m_currentPass = nullptr;
-        PHLWORKSPACEREF                    m_isolatedWorkspace;
-        bool                               m_isolatedWorkspaceFullScene = false;
-
-        void                               handleFullscreenSettings(PHLMONITOR pMonitor);
-        bool                               renderWorkspaceToBufferInternal(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
+        SP<ITexture>         m_lockDeadTexture;
+        SP<ITexture>         m_lockDead2Texture;
+        SP<ITexture>         m_lockDead3Texture;
+        SP<ITexture>         m_lockTtyTextTexture;
+        void                 handleFullscreenSettings(PHLMONITOR pMonitor);
+        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
 
         // old private:
-        void arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
-        void renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry);
-        void renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
-        void renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
-        void renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&); // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
-        void renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
-        void renderWindow(PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
-        void renderLayer(PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false, bool lockscreen = false);
-        void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
-        void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
-        void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);
-        void renderSessionLockPrimer(PHLMONITOR pMonitor);
-        void renderSessionLockMissing(PHLMONITOR pMonitor);
-        void renderBackground(PHLMONITOR pMonitor);
-        void requestBackgroundResource();
-        std::string                       resolveAssetPath(const std::string& file);
-        void                              initMissingAssetTexture();
-        void                              initAssets();
-        SP<ITexture>                      m_missingAssetTexture;
+        void         arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
+        void         renderWorkspace(CRenderingContext&, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry);
+        void         renderIME(CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
+        void         renderWorkspaceWindowsFullscreen(CRenderingContext&, PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);
+        void         renderWorkspaceWindows(CRenderingContext&, PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);
+        void         renderAllClientsForWorkspace(CRenderingContext&, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const Vector2D& translate = {0, 0},
+                                                  const float& scale = 1.f);
+        void         renderWindow(CRenderingContext&, PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
+        void         renderLayer(CRenderingContext&, PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false, bool lockscreen = false);
+        void         renderSessionLockSurface(CRenderingContext&, WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
+        void         renderDragIcon(CRenderingContext&, PHLMONITOR, const Time::steady_tp&);
+        void         renderIMEPopup(CRenderingContext&, CInputPopup*, PHLMONITOR, const Time::steady_tp&);
+        void         renderSessionLockPrimer(CRenderingContext&, PHLMONITOR pMonitor);
+        void         renderSessionLockMissing(CRenderingContext&, PHLMONITOR pMonitor);
+        void         renderBackground(CRenderingContext&, PHLMONITOR pMonitor);
+        void         requestBackgroundResource();
+        std::string  resolveAssetPath(const std::string& file);
+        void         initMissingAssetTexture();
+        void         initAssets();
+        SP<ITexture> m_missingAssetTexture;
         ASP<Hyprgraphics::CImageResource> m_backgroundResource;
         bool                              m_backgroundResourceFailed = false;
+
+        bool                              shouldBlur(const CRenderingContext&, PHLLS ls);
+        bool                              shouldBlur(const CRenderingContext&, PHLWINDOW w);
+        bool                              shouldBlur(const CRenderingContext&, WP<Desktop::View::CPopup> p);
 
         bool                              m_cursorHidden            = false;
         bool                              m_cursorHiddenByCondition = false;
         bool                              m_cursorHasSurface        = false;
-        SP<Aquamarine::IBuffer>           m_currentBuffer           = nullptr;
-        eRenderMode                       m_renderMode              = RENDER_MODE_NORMAL;
         bool                              m_nvidia                  = false;
         bool                              m_intel                   = false;
         bool                              m_software                = false;
@@ -322,13 +302,6 @@ namespace Render {
         std::vector<PHLWINDOWREF>      m_renderUnfocused;
         SP<CEventLoopTimer>            m_renderUnfocusedTimer;
 
-        struct SBackdropCapture {
-            SP<SBackdropScope> scope;
-            SP<IFramebuffer>   framebuffer;
-        };
-
-        std::vector<SBackdropCapture> m_backdropCaptures;
-
         friend class CRenderPass;
         friend class Render::GL::CHyprOpenGLImpl;
         friend class CToplevelExportFrame;
@@ -340,8 +313,8 @@ namespace Render {
         friend class CMonitorScene;
 
       private:
-        void bindOffMain();
-        void bindBackOnMain();
+        void bindOffMain(CRenderingContext&);
+        void bindBackOnMain(CRenderingContext&);
     };
 
 }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -23,6 +23,7 @@
 #include "./pass/TexPassElement.hpp"
 #include "./pass/TextureMatteElement.hpp"
 #include "./pass/TransformedWindowPassElement.hpp"
+#include "render/scene/MonitorScene.hpp"
 #include "types.hpp"
 #include "../output/Monitor.hpp"
 #include "../desktop/state/Fadeout.hpp"
@@ -323,6 +324,7 @@ namespace Render {
         friend class Pointer::CPointerManager;
         friend class Monitor::CMonitor;
         friend class CMonitorFrameScheduler;
+        friend class CMonitorScene;
 
       private:
         void bindOffMain();

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -71,20 +71,27 @@ namespace Render {
             RT_VK = 2,
         };
 
-        virtual eType                       type() = 0;
-        WP<Render::GL::CHyprOpenGLImpl>     glBackend();
+        virtual eType                   type() = 0;
+        WP<Render::GL::CHyprOpenGLImpl> glBackend();
 
-        void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
-        void                                arrangeLayersForMonitor(const MONITORID&);
-        void                                damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
-        void                                damageWindow(PHLWINDOW, bool forceFull = false);
-        void                                damageBox(const CBox&, bool skipFrameSchedule = false);
-        void                                damageBox(const int& x, const int& y, const int& w, const int& h);
-        void                                damageRegion(const CRegion&);
-        void                                damageMonitor(PHLMONITOR);
-        void                                damageMirrorsWith(PHLMONITOR, const CRegion&);
-        bool                                shouldRenderWindow(PHLWINDOW, PHLMONITOR);
-        bool                                shouldRenderWindow(PHLWINDOW);
+        void                            renderMonitor(PHLMONITOR pMonitor, bool commit = true);
+        void                            arrangeLayersForMonitor(const MONITORID&);
+        void                            damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
+        void                            damageWindow(PHLWINDOW, bool forceFull = false);
+        void                            damageBox(const CBox&, bool skipFrameSchedule = false);
+        void                            damageBox(const int& x, const int& y, const int& w, const int& h);
+        void                            damageRegion(const CRegion&);
+        void                            damageMonitor(PHLMONITOR);
+        void                            damageMirrorsWith(PHLMONITOR, const CRegion&);
+        bool                            shouldRenderWindow(PHLWINDOW, PHLMONITOR);
+        bool                            shouldRenderWindow(PHLWINDOW);
+        float                           workspaceRenderAlpha(PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        workspaceRenderOffset(PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        bool                            workspaceRenderIsAnimating(PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        windowRenderFloatingOffset(PHLWINDOW) const;
+        bool                            renderingWorkspaceToBuffer() const;
+        // Renders only the target workspace's windows and popups during the target monitor's active render.
+        bool                                renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
         void                                ensureCursorRenderingMode();
         bool                                shouldRenderCursor();
@@ -262,6 +269,7 @@ namespace Render {
         SP<ITexture>                       m_lockDead3Texture;
         SP<ITexture>                       m_lockTtyTextTexture;
         CRenderPass*                       m_currentPass = nullptr;
+        PHLWORKSPACEREF                    m_isolatedWorkspace;
 
         void                               handleFullscreenSettings(PHLMONITOR pMonitor);
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -95,6 +95,8 @@ namespace Render {
         bool renderWorkspaceToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
         bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        // Renders and scales the target workspace to an aspect-ratio-matched framebuffer.
+        bool renderWorkspaceSceneToBufferScaled(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
         bool renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the compositor background and layer-shell background plane.
@@ -257,7 +259,8 @@ namespace Render {
         SP<ITexture>         m_lockDead3Texture;
         SP<ITexture>         m_lockTtyTextTexture;
         void                 handleFullscreenSettings(PHLMONITOR pMonitor);
-        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
+        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene,
+                                                             bool scaleToBuffer = false);
 
         // old private:
         void         arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -92,6 +92,8 @@ namespace Render {
         bool                            renderingWorkspaceToBuffer() const;
         // Renders only the target workspace's windows and popups during the target monitor's active render.
         bool renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
+        // Renders the target workspace as a complete monitor scene during the target monitor's active render.
+        bool renderWorkspaceSceneToBuffer(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
         bool                                renderMonitorToBuffer(PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
@@ -271,8 +273,10 @@ namespace Render {
         SP<ITexture>                       m_lockTtyTextTexture;
         CRenderPass*                       m_currentPass = nullptr;
         PHLWORKSPACEREF                    m_isolatedWorkspace;
+        bool                               m_isolatedWorkspaceFullScene = false;
 
         void                               handleFullscreenSettings(PHLMONITOR pMonitor);
+        bool                               renderWorkspaceToBufferInternal(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
 
         // old private:
         void arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -71,20 +71,27 @@ namespace Render {
             RT_VK = 2,
         };
 
-        virtual eType                       type() = 0;
-        WP<Render::GL::CHyprOpenGLImpl>     glBackend();
+        virtual eType                   type() = 0;
+        WP<Render::GL::CHyprOpenGLImpl> glBackend();
 
-        void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
-        void                                arrangeLayersForMonitor(const MONITORID&);
-        void                                damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
-        void                                damageWindow(PHLWINDOW, bool forceFull = false);
-        void                                damageBox(const CBox&, bool skipFrameSchedule = false);
-        void                                damageBox(const int& x, const int& y, const int& w, const int& h);
-        void                                damageRegion(const CRegion&);
-        void                                damageMonitor(PHLMONITOR);
-        void                                damageMirrorsWith(PHLMONITOR, const CRegion&);
-        bool                                shouldRenderWindow(PHLWINDOW, PHLMONITOR);
-        bool                                shouldRenderWindow(PHLWINDOW);
+        void                            renderMonitor(PHLMONITOR pMonitor, bool commit = true);
+        void                            arrangeLayersForMonitor(const MONITORID&);
+        void                            damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
+        void                            damageWindow(PHLWINDOW, bool forceFull = false);
+        void                            damageBox(const CBox&, bool skipFrameSchedule = false);
+        void                            damageBox(const int& x, const int& y, const int& w, const int& h);
+        void                            damageRegion(const CRegion&);
+        void                            damageMonitor(PHLMONITOR);
+        void                            damageMirrorsWith(PHLMONITOR, const CRegion&);
+        bool                            shouldRenderWindow(PHLWINDOW, PHLMONITOR);
+        bool                            shouldRenderWindow(PHLWINDOW);
+        float                           workspaceRenderAlpha(PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        workspaceRenderOffset(PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        bool                            workspaceRenderIsAnimating(PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        windowRenderFloatingOffset(PHLWINDOW) const;
+        bool                            renderingWorkspaceToBuffer() const;
+        // Renders only the target workspace's windows and popups during the target monitor's active render.
+        bool                                renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
         void                                ensureCursorRenderingMode();
         bool                                shouldRenderCursor();
@@ -261,6 +268,7 @@ namespace Render {
         SP<ITexture>                       m_lockDead3Texture;
         SP<ITexture>                       m_lockTtyTextTexture;
         CRenderPass*                       m_currentPass = nullptr;
+        PHLWORKSPACEREF                    m_isolatedWorkspace;
 
         void                               handleFullscreenSettings(PHLMONITOR pMonitor);
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -83,19 +83,20 @@ namespace Render {
         void                            damageRegion(const CRegion&);
         void                            damageMonitor(PHLMONITOR);
         void                            damageMirrorsWith(PHLMONITOR, const CRegion&);
+        bool                            shouldRenderWindow(const CRenderingContext&, PHLWINDOW, PHLMONITOR);
         bool                            shouldRenderWindow(PHLWINDOW, PHLMONITOR);
         bool                            shouldRenderWindow(PHLWINDOW);
-        float                           workspaceRenderAlpha(PHLWORKSPACE, PHLMONITOR = nullptr) const;
-        Vector2D                        workspaceRenderOffset(PHLWORKSPACE, PHLMONITOR = nullptr) const;
-        bool                            workspaceRenderIsAnimating(PHLWORKSPACE, PHLMONITOR = nullptr) const;
-        Vector2D                        windowRenderFloatingOffset(PHLWINDOW) const;
-        bool                            renderingWorkspaceToBuffer() const;
+        float                           workspaceRenderAlpha(const CRenderingContext&, PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        workspaceRenderOffset(const CRenderingContext&, PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        bool                            workspaceRenderIsAnimating(const CRenderingContext&, PHLWORKSPACE, PHLMONITOR = nullptr) const;
+        Vector2D                        windowRenderFloatingOffset(const CRenderingContext&, PHLWINDOW) const;
+        bool                            renderingWorkspaceToBuffer(const CRenderingContext&) const;
         // Renders only the target workspace's windows and popups during the target monitor's active render.
-        bool renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
+        bool renderWorkspaceToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
-        bool renderWorkspaceSceneToBuffer(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
-        bool                                renderMonitorToBuffer(PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        bool                                renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
         void                                ensureCursorRenderingMode();
         bool                                shouldRenderCursor();
@@ -103,7 +104,7 @@ namespace Render {
 
         std::tuple<float, float, float>     getRenderTimes(PHLMONITOR pMonitor); // avg max min
         void                                ensureLockTexturesRendered(bool load);
-        void                                renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
+        void                                renderLockscreen(CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
         void                                setCursorSurface(SP<Desktop::View::CWLSurface> surf, int hotspotX, int hotspotY, bool force = false);
         void                                setCursorFromName(const std::string& name, bool force = false);
         void                                onRenderbufferDestroy(IRenderbuffer* rb);
@@ -115,23 +116,19 @@ namespace Render {
         SP<IFramebuffer>                    makeSnapshotFB(PHLWINDOW);
         SP<IFramebuffer>                    makeSnapshotFB(PHLLS);
         SP<IFramebuffer>                    makeSnapshotFB(WP<Desktop::View::CPopup>);
-        void                                renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace = nullptr);
-        bool                                beginFullFakeRender(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb);
-        bool                                beginRenderToBuffer(PHLMONITOR pMonitor, CRegion& damage, SP<IHLBuffer> buffer, bool simple = false);
-        virtual void                        startRenderPass() {};
-        virtual void                        endRender(const std::function<void()>& renderingDoneCallback = {}) = 0;
+        void                                renderFadeouts(CRenderingContext&, PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace = nullptr);
+        bool                                beginFullFakeRender(CRenderingContext&, CRegion& damage, SP<IFramebuffer> fb);
+        bool                                beginRenderToBuffer(CRenderingContext&, CRegion& damage, SP<IHLBuffer> buffer, bool simple = false);
+        virtual void                        startRenderPass(CRenderingContext&) {};
+        virtual void                        endRender(CRenderingContext&, const std::function<void()>& renderingDoneCallback = {}) = 0;
 
-        NColorManagement::PImageDescription workBufferImageDescription();
-        bool                                m_bBlockSurfaceFeedback = false;
-        bool                                m_bRenderingSnapshot    = false;
+        NColorManagement::PImageDescription workBufferImageDescription(const CRenderingContext&);
         PHLMONITORREF                       m_mostHzMonitor;
         bool                                m_directScanoutBlocked = false;
 
         void                                setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
 
         void                                initiateManualCrash();
-        const SRenderData&                  renderData();
-
         bool                                m_crashingInProgress = false;
         float                               m_crashingDistort    = 0.5f;
         wl_event_source*                    m_crashingLoop       = nullptr;
@@ -147,38 +144,33 @@ namespace Render {
             std::string                                  name;
         } m_lastCursorData;
 
-        CRenderPass     m_renderPass;
+        void         addPassElement(CRenderingContext&, UP<IPassElement>&& element);
 
-        void            addPassElement(UP<IPassElement>&& element);
-        CRenderPass&    currentPass();
-        UP<CScopeGuard> redirectPass(CRenderPass* pass);
-
-        SP<ITexture>    renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth = 1024,
-                                     const int maxHeight = 1024);
-        CHyprColor      getConvertedColor(const CHyprColor& color);
+        SP<ITexture> renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth = 1024,
+                                  const int maxHeight = 1024);
+        CHyprColor   getConvertedColor(const CRenderingContext&, const CHyprColor& color);
 
         virtual SP<IRenderbuffer>    getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer,
                                                              uint32_t                fmt); // TODO? move to protected and fix CPointerManager::renderHWCursorBuffer
         bool                         commitPendingAndDoExplicitSync(PHLMONITOR pMonitor, std::optional<Monitor::CDamageRing::CTransaction> damage = std::nullopt,
                                                                     const CRegion& renderedDamage = {}); // TODO? move to protected and fix CMonitorFrameScheduler::onPresented
-        SRenderData                  m_renderData;                                                       // TODO? move to protected and fix CRenderPass
         SP<ITexture>                 m_screencopyDeniedTexture;                                          // TODO? make readonly
         uint                         m_failedAssetsNo     = 0;                                           // TODO? make readonly
         bool                         m_reloadScreenShader = true;                                        // at launch it can be set
         CTimer                       m_globalTimer;
 
-        void                         draw(WP<IPassElement> element, const CRegion& damage = {});
-        void                         draw(const CBorderPassElement::SBorderData& data, const CRegion& damage = {});
-        void                         draw(const CClearPassElement::SClearData& data, const CRegion& damage = {});
-        void                         draw(const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage = {});
-        void                         draw(const CRectPassElement::SRectData& data, const CRegion& damage = {});
-        void                         draw(const CRendererHintsPassElement::SData& data, const CRegion& damage = {});
-        void                         draw(const CShadowPassElement::SShadowData& data, const CRegion& damage = {});
-        void                         draw(const CSurfacePassElement::SRenderData& data, const CRegion& damage = {});
-        void                         draw(const CTexPassElement::SRenderData& data, const CRegion& damage = {});
-        void                         draw(const CTextureMatteElement::STextureMatteData& data, const CRegion& damage = {});
-        virtual void                 bindFB(SP<IFramebuffer> fb);
-        UP<CScopeGuard>              bindTempFB(SP<IFramebuffer> fb);
+        void                         draw(CRenderingContext& context, WP<IPassElement> element, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CBorderPassElement::SBorderData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CClearPassElement::SClearData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CRectPassElement::SRectData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CRendererHintsPassElement::SData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CShadowPassElement::SShadowData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CSurfacePassElement::SRenderData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CTexPassElement::SRenderData& data, const CRegion& damage = {});
+        void                         draw(CRenderingContext&, const CTextureMatteElement::STextureMatteData& data, const CRegion& damage = {});
+        virtual void                 bindFB(CRenderingContext&, SP<IFramebuffer> fb);
+        UP<CScopeGuard>              bindTempFB(CRenderingContext&, SP<IFramebuffer> fb);
         virtual UP<ISyncFDManager>   createSyncFDManager()                                                                                                                     = 0;
         virtual WP<IElementRenderer> elementRenderer()                                                                                                                         = 0;
         virtual SP<ITexture>         createStencilTexture(const int width, const int height)                                                                                   = 0;
@@ -193,120 +185,109 @@ namespace Render {
                                                 int weight = 400);
         virtual SP<ITexture>         renderText(Hyprgraphics::CTextResource::STextResourceData&& data);
         SP<ITexture>                 loadAsset(const std::string& filename);
-        virtual bool                 shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow);
-        virtual bool                 explicitSyncSupported()                                                                                                     = 0;
-        virtual bool                 fp16Supported()                                                                                                             = 0;
-        virtual std::vector<SDRMFormat> getDRMFormats()                                                                                                          = 0;
-        virtual std::vector<uint64_t>   getDRMFormatModifiers(DRMFormat format)                                                                                  = 0;
-        virtual SP<IFramebuffer>        createFB(const std::string& name = "")                                                                                   = 0;
-        virtual void                    disableScissor()                                                                                                         = 0;
-        virtual void                    blend(bool enabled)                                                                                                      = 0;
-        virtual void                    drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) = 0;
-        virtual void     drawShadow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                    float lerp, float a)                                                                                                         = 0;
-        virtual void     drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a)                  = 0;
-        virtual void     drawGlow(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                                  float lerp, float a)                                                                                                           = 0;
-        virtual void     setViewport(int x, int y, int width, int height)                                                                                        = 0;
+        virtual bool                 shouldUseNewBlurOptimizations(const CRenderingContext&, PHLLS pLayer, PHLWINDOW pWindow);
+        virtual bool                 explicitSyncSupported()                                                                                                                  = 0;
+        virtual bool                 fp16Supported()                                                                                                                          = 0;
+        virtual std::vector<SDRMFormat> getDRMFormats()                                                                                                                       = 0;
+        virtual std::vector<uint64_t>   getDRMFormatModifiers(DRMFormat format)                                                                                               = 0;
+        virtual SP<IFramebuffer>        createFB(const std::string& name = "")                                                                                                = 0;
+        virtual void                    disableScissor(CRenderingContext&)                                                                                                    = 0;
+        virtual void                    blend(bool enabled)                                                                                                                   = 0;
+        virtual void             drawShadow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a) = 0;
+        virtual void             drawShadow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                            const Config::CGradientValueData& grad2, float lerp, float a)                                                                     = 0;
+        virtual void             drawGlow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a)   = 0;
+        virtual void             drawGlow(CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                          const Config::CGradientValueData& grad2, float lerp, float a)                                                                       = 0;
+        virtual void             setViewport(int x, int y, int width, int height)                                                                                             = 0;
 
-        bool             preBlurQueued(PHLMONITORREF pMonitor);
-        void             sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now);
+        bool                     preBlurQueued(const CRenderingContext&);
+        void                     sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now);
 
-        void             setProjectionType(const Vector2D& fbSize);
-        void             setProjectionType(eRenderProjectionType projectionType);
-        Mat3x3           getBoxProjection(const CBox& box, std::optional<eTransform> transform = std::nullopt);
-        Mat3x3           projectBoxToTarget(const CBox& box, std::optional<eTransform> transform = std::nullopt);
+        void                     setProjectionType(CRenderingContext&, const Vector2D& fbSize);
+        void                     setProjectionType(CRenderingContext&, eRenderProjectionType projectionType);
+        Mat3x3                   getBoxProjection(const CRenderingContext&, const CBox& box, std::optional<eTransform> transform = std::nullopt);
+        Mat3x3                   projectBoxToTarget(const CRenderingContext&, const CBox& box, std::optional<eTransform> transform = std::nullopt);
 
-        SP<IFramebuffer> blurMainFramebuffer(float strength, const CRegion& originalDamage, const Render::SBlurContext& context = {});
-        void             beginBackdropScope(SP<SBackdropScope> scope);
-        void             endBackdropScope(SP<SBackdropScope> scope);
-        virtual SP<IFramebuffer> blurFramebuffer(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const Render::SBlurContext& context = {}) = 0;
-        virtual void             refreshBlurProvider()                                                                                                             = 0;
-        virtual void             expandBlurDamage(CRegion& damage, float multiplier = 1.F) const                                                                   = 0;
-        virtual bool             blurProviderIsAnimated() const                                                                                                    = 0;
-        virtual bool             blurProviderRequiresLiveBlur() const                                                                                              = 0;
-        void                     scheduleFrameForAnimatedBlur(const CRegion& damage, bool usesPrecomputedBlur);
-        void                     preBlurForCurrentMonitor(const CRegion& fakeDamage);
+        SP<IFramebuffer>         blurMainFramebuffer(CRenderingContext&, float strength, const CRegion& originalDamage, const Render::SBlurContext& blurContext = {});
+        void                     beginBackdropScope(CRenderingContext&, SP<SBackdropScope> scope);
+        void                     endBackdropScope(CRenderingContext&, SP<SBackdropScope> scope);
+        virtual SP<IFramebuffer> blurFramebuffer(CRenderingContext&, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                                 const Render::SBlurContext& blurContext = {})   = 0;
+        virtual void             refreshBlurProvider()                                           = 0;
+        virtual void             expandBlurDamage(CRegion& damage, float multiplier = 1.F) const = 0;
+        virtual bool             blurProviderIsAnimated(const CRenderingContext&) const          = 0;
+        virtual bool             blurProviderRequiresLiveBlur() const                            = 0;
+        void                     scheduleFrameForAnimatedBlur(const CRenderingContext&, const CRegion& damage, bool usesPrecomputedBlur);
+        void                     preBlurForCurrentMonitor(CRenderingContext&, const CRegion& fakeDamage);
 
-        SCMSettings              getCMSettings(const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
-                                               SP<CWLSurfaceResource> surface = nullptr, bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1,
-                                               bool shouldUseSurface = false);
-        void                     clearCMSettingsCache();
+        SCMSettings              getCMSettings(const CRenderingContext&, const NColorManagement::PImageDescription imageDescription,
+                                               const NColorManagement::PImageDescription targetImageDescription, SP<CWLSurfaceResource> surface = nullptr, bool modifySDR = false,
+                                               float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1, bool shouldUseSurface = false);
         virtual bool             reloadShaders(const std::string& path = "") = 0;
 
       protected:
-        virtual void              renderOffToMain(SP<IFramebuffer> off)                                         = 0;
+        virtual void              renderOffToMain(CRenderingContext&, SP<IFramebuffer> off)                     = 0;
         virtual SP<IRenderbuffer> getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) = 0;
-        void                      renderMirrored();
-        void                      setDamage(const CRegion& damage_, std::optional<CRegion> finalDamage);
+        void                      renderMirrored(CRenderingContext&);
+        void                      setDamage(CRenderingContext&, const CRegion& damage_, std::optional<CRegion> finalDamage);
         // if RENDER_MODE_NORMAL, provided damage will be written to.
         // otherwise, it will be the one used.
-        bool beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, SP<IFramebuffer> fb = nullptr, bool simple = false,
+        bool beginRender(CRenderingContext&, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, SP<IFramebuffer> fb = nullptr, bool simple = false,
                          std::optional<Monitor::CDamageRing::CTransaction>* damageTransaction = nullptr);
 
-        virtual bool beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple = false) {
+        virtual bool beginRenderInternal(CRenderingContext&, CRegion& damage, bool simple = false) {
             return false;
         };
-        virtual bool beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) {
+        virtual bool beginFullFakeRenderInternal(CRenderingContext&, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) {
             return false;
         };
         virtual void initRender() {};
-        virtual bool initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
+        virtual bool initRenderBuffer(CRenderingContext&, SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
             return false;
         };
 
-        SP<ITexture>         getBackground(PHLMONITOR pMonitor);
-        virtual SP<ITexture> getBlurTexture(PHLMONITORREF pMonitor);
+        SP<ITexture>         getBackground(CRenderingContext&, PHLMONITOR pMonitor);
+        virtual SP<ITexture> getBlurTexture(const CRenderingContext&, PHLMONITORREF pMonitor);
 
-        struct SCMSettingsCacheEntry {
-            uint64_t    srcDescId = 0, dstDescId = 0;
-            void*       surfacePtr      = nullptr; // read-only!!
-            bool        modifySDR       = false;
-            float       sdrMinLuminance = -1.F;
-            int         sdrMaxLuminance = -1;
-            SCMSettings settings;
-        };
-        std::vector<SCMSettingsCacheEntry> m_cmSettingsCache;
-
-        SP<ITexture>                       m_lockDeadTexture;
-        SP<ITexture>                       m_lockDead2Texture;
-        SP<ITexture>                       m_lockDead3Texture;
-        SP<ITexture>                       m_lockTtyTextTexture;
-        CRenderPass*                       m_currentPass = nullptr;
-        PHLWORKSPACEREF                    m_isolatedWorkspace;
-        bool                               m_isolatedWorkspaceFullScene = false;
-
-        void                               handleFullscreenSettings(PHLMONITOR pMonitor);
-        bool                               renderWorkspaceToBufferInternal(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
+        SP<ITexture>         m_lockDeadTexture;
+        SP<ITexture>         m_lockDead2Texture;
+        SP<ITexture>         m_lockDead3Texture;
+        SP<ITexture>         m_lockTtyTextTexture;
+        void                 handleFullscreenSettings(PHLMONITOR pMonitor);
+        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
 
         // old private:
-        void arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
-        void renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry);
-        void renderIME(PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
-        void renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
-        void renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&); // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
-        void renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
-        void renderWindow(PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
-        void renderLayer(PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false, bool lockscreen = false);
-        void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
-        void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
-        void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);
-        void renderSessionLockPrimer(PHLMONITOR pMonitor);
-        void renderSessionLockMissing(PHLMONITOR pMonitor);
-        void renderBackground(PHLMONITOR pMonitor);
-        void requestBackgroundResource();
-        std::string                       resolveAssetPath(const std::string& file);
-        void                              initMissingAssetTexture();
-        void                              initAssets();
-        SP<ITexture>                      m_missingAssetTexture;
+        void         arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
+        void         renderWorkspace(CRenderingContext&, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry);
+        void         renderIME(CRenderingContext&, PHLMONITOR pMonitor, const Time::steady_tp& now, const CBox& geometry);
+        void         renderWorkspaceWindowsFullscreen(CRenderingContext&, PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);
+        void         renderWorkspaceWindows(CRenderingContext&, PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);
+        void         renderAllClientsForWorkspace(CRenderingContext&, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const Vector2D& translate = {0, 0},
+                                                  const float& scale = 1.f);
+        void         renderWindow(CRenderingContext&, PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
+        void         renderLayer(CRenderingContext&, PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false, bool lockscreen = false);
+        void         renderSessionLockSurface(CRenderingContext&, WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
+        void         renderDragIcon(CRenderingContext&, PHLMONITOR, const Time::steady_tp&);
+        void         renderIMEPopup(CRenderingContext&, CInputPopup*, PHLMONITOR, const Time::steady_tp&);
+        void         renderSessionLockPrimer(CRenderingContext&, PHLMONITOR pMonitor);
+        void         renderSessionLockMissing(CRenderingContext&, PHLMONITOR pMonitor);
+        void         renderBackground(CRenderingContext&, PHLMONITOR pMonitor);
+        void         requestBackgroundResource();
+        std::string  resolveAssetPath(const std::string& file);
+        void         initMissingAssetTexture();
+        void         initAssets();
+        SP<ITexture> m_missingAssetTexture;
         ASP<Hyprgraphics::CImageResource> m_backgroundResource;
         bool                              m_backgroundResourceFailed = false;
+
+        bool                              shouldBlur(const CRenderingContext&, PHLLS ls);
+        bool                              shouldBlur(const CRenderingContext&, PHLWINDOW w);
+        bool                              shouldBlur(const CRenderingContext&, WP<Desktop::View::CPopup> p);
 
         bool                              m_cursorHidden            = false;
         bool                              m_cursorHiddenByCondition = false;
         bool                              m_cursorHasSurface        = false;
-        SP<Aquamarine::IBuffer>           m_currentBuffer           = nullptr;
-        eRenderMode                       m_renderMode              = RENDER_MODE_NORMAL;
         bool                              m_nvidia                  = false;
         bool                              m_intel                   = false;
         bool                              m_software                = false;
@@ -323,13 +304,6 @@ namespace Render {
         std::vector<PHLWINDOWREF>      m_renderUnfocused;
         SP<CEventLoopTimer>            m_renderUnfocusedTimer;
 
-        struct SBackdropCapture {
-            SP<SBackdropScope> scope;
-            SP<IFramebuffer>   framebuffer;
-        };
-
-        std::vector<SBackdropCapture> m_backdropCaptures;
-
         friend class CRenderPass;
         friend class Render::GL::CHyprOpenGLImpl;
         friend class CToplevelExportFrame;
@@ -341,8 +315,8 @@ namespace Render {
         friend class CMonitorScene;
 
       private:
-        void bindOffMain();
-        void bindBackOnMain();
+        void bindOffMain(CRenderingContext&);
+        void bindBackOnMain(CRenderingContext&);
     };
 
 }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -91,7 +91,9 @@ namespace Render {
         Vector2D                        windowRenderFloatingOffset(PHLWINDOW) const;
         bool                            renderingWorkspaceToBuffer() const;
         // Renders only the target workspace's windows and popups during the target monitor's active render.
-        bool                                renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
+        bool renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
+        // Renders the target monitor's regular scene during its active render.
+        bool                                renderMonitorToBuffer(PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
         void                                ensureCursorRenderingMode();
         bool                                shouldRenderCursor();

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -95,6 +95,8 @@ namespace Render {
         bool renderWorkspaceToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
         // Renders the target workspace as a complete monitor scene during the target monitor's active render.
         bool renderWorkspaceSceneToBuffer(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
+        // Renders and scales the target workspace to an aspect-ratio-matched framebuffer.
+        bool renderWorkspaceSceneToBufferScaled(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
         bool renderMonitorToBuffer(CRenderingContext&, PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the compositor background and layer-shell background plane.
@@ -255,7 +257,8 @@ namespace Render {
         SP<ITexture>         m_lockDead3Texture;
         SP<ITexture>         m_lockTtyTextTexture;
         void                 handleFullscreenSettings(PHLMONITOR pMonitor);
-        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
+        bool                 renderWorkspaceToBufferInternal(CRenderingContext&, PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene,
+                                                             bool scaleToBuffer = false);
 
         // old private:
         void         arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -92,6 +92,8 @@ namespace Render {
         bool                            renderingWorkspaceToBuffer() const;
         // Renders only the target workspace's windows and popups during the target monitor's active render.
         bool renderWorkspaceToBuffer(PHLWORKSPACE, SP<IFramebuffer>, bool sendFeedback = true);
+        // Renders the target workspace as a complete monitor scene during the target monitor's active render.
+        bool renderWorkspaceSceneToBuffer(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         // Renders the target monitor's regular scene during its active render.
         bool                                renderMonitorToBuffer(PHLMONITOR, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback = true);
         bool                                shouldRenderMonitor(PHLMONITOR);
@@ -272,8 +274,10 @@ namespace Render {
         SP<ITexture>                       m_lockTtyTextTexture;
         CRenderPass*                       m_currentPass = nullptr;
         PHLWORKSPACEREF                    m_isolatedWorkspace;
+        bool                               m_isolatedWorkspaceFullScene = false;
 
         void                               handleFullscreenSettings(PHLMONITOR pMonitor);
+        bool                               renderWorkspaceToBufferInternal(PHLWORKSPACE, SP<IFramebuffer>, const Time::steady_tp&, bool sendFeedback, bool fullScene);
 
         // old private:
         void arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -23,6 +23,7 @@
 #include "./pass/TexPassElement.hpp"
 #include "./pass/TextureMatteElement.hpp"
 #include "./pass/TransformedWindowPassElement.hpp"
+#include "render/scene/MonitorScene.hpp"
 #include "types.hpp"
 #include "../output/Monitor.hpp"
 #include "../desktop/state/Fadeout.hpp"
@@ -322,6 +323,7 @@ namespace Render {
         friend class Pointer::CPointerManager;
         friend class Monitor::CMonitor;
         friend class CMonitorFrameScheduler;
+        friend class CMonitorScene;
 
       private:
         void bindOffMain();

--- a/src/render/RenderingContext.cpp
+++ b/src/render/RenderingContext.cpp
@@ -1,0 +1,33 @@
+#include "types.hpp"
+
+#include "../output/Monitor.hpp"
+#include "pass/Pass.hpp"
+
+using namespace Render;
+
+CRenderingContext::CRenderingContext(PHLMONITORREF sceneMonitor_, CRenderPass& pass, PHLMONITORREF outputMonitor_) :
+    sceneMonitor(sceneMonitor_), outputMonitor(outputMonitor_ ? outputMonitor_ : sceneMonitor_), precomputeBlur(sceneMonitor_ && sceneMonitor_->m_blurFBShouldRender),
+    cmSettingsCache(makeShared<SCMSettingsCache>()), m_pass(pass) {
+    ;
+}
+
+CRenderingContext::CRenderingContext(const CRenderingContext& parent, CRenderPass& pass) : CRenderingContext(parent, pass, parent.sceneMonitor) {
+    ;
+}
+
+CRenderingContext::CRenderingContext(const CRenderingContext& parent, CRenderPass& pass, PHLMONITORREF sceneMonitor_) : CRenderingContext(parent) {
+    m_pass                  = pass;
+    updatesMonitorBlurState = false;
+
+    if (sceneMonitor == sceneMonitor_)
+        return;
+
+    sceneMonitor    = sceneMonitor_;
+    precomputeBlur  = false;
+    cmSettingsCache = makeShared<SCMSettingsCache>();
+    backdropCaptures.clear();
+}
+
+CRenderPass& CRenderingContext::renderPass() const {
+    return m_pass.get();
+}

--- a/src/render/blur/Provider.hpp
+++ b/src/render/blur/Provider.hpp
@@ -7,6 +7,8 @@
 #include <optional>
 
 namespace Render {
+    class CRenderingContext;
+
     struct SBlurShape {
         CBox  box;
         float radius        = 0.F;
@@ -38,12 +40,13 @@ namespace Render {
       public:
         virtual ~IBlurProvider() = default;
 
-        virtual eBlurType        type() const noexcept             = 0;
-        virtual bool             isAnimated() const noexcept       = 0;
-        virtual bool             requiresLiveBlur() const noexcept = 0;
+        virtual eBlurType        type() const noexcept                                       = 0;
+        virtual bool             isAnimated(const CRenderingContext& context) const noexcept = 0;
+        virtual bool             requiresLiveBlur() const noexcept                           = 0;
 
-        virtual void             expandDamage(CRegion& damage, float multiplier = 1.F) const                                                    = 0;
-        virtual SP<IFramebuffer> blur(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context = {}) = 0;
+        virtual void             expandDamage(CRegion& damage, float multiplier = 1.F) const = 0;
+        virtual SP<IFramebuffer> blur(CRenderingContext& renderingContext, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                      const SBlurContext& blurContext = {})                  = 0;
 
       protected:
         IBlurProvider() = default;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -49,20 +49,30 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE) : Vector2D{};
+    const auto WORKSPACEOFFSET =
+        !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED) && PWORKSPACE->m_monitor ? PWORKSPACE->m_monitor->m_workspaceTransition->offsetValue(PWORKSPACE) : Vector2D{};
     return box.translate(WORKSPACEOFFSET);
 }
 
-void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
+CBox CHyprBorderDecoration::assignedBoxGlobalForRender(const Render::CRenderingContext& context) {
+    CBox box = m_assignedGeometry;
+    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_BOTTOM | DECORATION_EDGE_LEFT | DECORATION_EDGE_RIGHT | DECORATION_EDGE_TOP, m_window));
+
+    if (!m_window->m_workspace || m_window->m_state & Desktop::View::WINDOW_STATE_PINNED)
+        return box;
+
+    return box.translate(g_pHyprRenderer->workspaceRenderOffset(context, m_window->m_workspace));
+}
+
+void CHyprBorderDecoration::draw(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
     if (doesntWantBorders())
         return;
 
     if (m_assignedGeometry.width < m_extents.topLeft.x + 1 || m_assignedGeometry.height < m_extents.topLeft.y + 1)
         return;
 
-
-    CBox windowBox = assignedBoxGlobal()
-                         .translate(-pMonitor->m_position + g_pHyprRenderer->windowRenderFloatingOffset(m_window.lock()))
+    CBox windowBox = assignedBoxGlobalForRender(context)
+                         .translate(-pMonitor->m_position + g_pHyprRenderer->windowRenderFloatingOffset(context, m_window.lock()))
                          .expand(-borderSize())
                          .scale(pMonitor->m_scale)
                          .round();
@@ -95,7 +105,7 @@ void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
         data.lerp     = GRADIENT.progress;
     }
 
-    g_pHyprRenderer->addPassElement(makeUnique<CBorderPassElement>(data));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CBorderPassElement>(data));
 }
 
 eDecorationType CHyprBorderDecoration::getDecorationType() {

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -8,6 +8,7 @@
 #include "../../desktop/view/Group.hpp"
 #include "../../managers/eventLoop/EventLoopManager.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include "../pass/BorderPassElement.hpp"
 #include "../Renderer.hpp"
 #include "../../state/MonitorState.hpp"
@@ -48,7 +49,7 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto WORKSPACEOFFSET = !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE) : Vector2D{};
     return box.translate(WORKSPACEOFFSET);
 }
 
@@ -59,7 +60,12 @@ void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     if (m_assignedGeometry.width < m_extents.topLeft.x + 1 || m_assignedGeometry.height < m_extents.topLeft.y + 1)
         return;
 
-    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->m_position + m_window->presentation().floatingOffset()).expand(-borderSize()).scale(pMonitor->m_scale).round();
+
+    CBox windowBox = assignedBoxGlobal()
+                         .translate(-pMonitor->m_position + g_pHyprRenderer->windowRenderFloatingOffset(m_window.lock()))
+                         .expand(-borderSize())
+                         .scale(pMonitor->m_scale)
+                         .round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;

--- a/src/render/decorations/CHyprBorderDecoration.hpp
+++ b/src/render/decorations/CHyprBorderDecoration.hpp
@@ -12,7 +12,7 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float const& a);
+    virtual void                       draw(Render::CRenderingContext&, PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 
@@ -49,5 +49,6 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
     mutable bool                m_borderSizeCacheDirty = true;
 
     CBox                        assignedBoxGlobal();
+    CBox                        assignedBoxGlobalForRender(const Render::CRenderingContext&);
     bool                        doesntWantBorders();
 };

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -6,6 +6,7 @@
 #include "../../config/ConfigManager.hpp"
 #include "../../config/ConfigValue.hpp"
 #include "../../desktop/state/FocusState.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include "../pass/ShadowPassElement.hpp"
 #include "../Renderer.hpp"
 #include "../pass/RectPassElement.hpp"
@@ -93,9 +94,9 @@ void CHyprDropShadowDecoration::damageEntire() {
 
     const auto PWORKSPACE  = PWINDOW->m_workspace;
     const auto applyOffset = [&](CBox& b) {
-        if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
-            b.translate(PWORKSPACE->m_renderOffset->value());
-        b.translate(PWINDOW->presentation().floatingOffset());
+        if (g_pHyprRenderer->workspaceRenderIsAnimating(PWORKSPACE) && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
+            b.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE));
+        b.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
     };
 
     applyOffset(shadowBox);
@@ -179,7 +180,7 @@ SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, 
     const auto  CORRECTIONOFFSET = (BORDERSIZE * (M_SQRT2 - 1) * std::max(2.0 - ROUNDINGPOWER, 0.0));
     const auto  ROUNDING         = ROUNDINGBASE > 0 ? (ROUNDINGBASE + BORDERSIZE) - CORRECTIONOFFSET : 0;
     const auto  PWORKSPACE       = PWINDOW->m_workspace;
-    const auto  WORKSPACEOFFSET  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto  WORKSPACEOFFSET  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE) : Vector2D{};
 
     // draw the shadow
     CBox fullBox = m_lastWindowBoxWithDecos;
@@ -209,7 +210,7 @@ SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, 
             },
     };
 
-    fullBox.translate(PWINDOW->presentation().floatingOffset());
+    fullBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
 
     if (fullBox.width < 1 || fullBox.height < 1)
         return {}; // don't draw invisible shadows

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -94,9 +94,10 @@ void CHyprDropShadowDecoration::damageEntire() {
 
     const auto PWORKSPACE  = PWINDOW->m_workspace;
     const auto applyOffset = [&](CBox& b) {
-        if (g_pHyprRenderer->workspaceRenderIsAnimating(PWORKSPACE) && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
-            b.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE));
-        b.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
+        const auto WORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+        if (WORKSPACEMONITOR && WORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWORKSPACE) && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
+            b.translate(WORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWORKSPACE));
+        b.translate(PWINDOW->presentation().floatingOffset());
     };
 
     applyOffset(shadowBox);
@@ -123,7 +124,7 @@ void CHyprDropShadowDecoration::updateWindow(PHLWINDOW pWindow) {
     m_lastWindowBoxWithDecos = g_pDecorationPositioner->getBoxWithIncludedDecos(pWindow);
 }
 
-void CHyprDropShadowDecoration::draw(PHLMONITOR pMonitor, float const& a) {
+void CHyprDropShadowDecoration::draw(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
     const auto SELF = dynamicPointerCast<CHyprDropShadowDecoration>(self());
     if (!SELF)
         return;
@@ -131,7 +132,7 @@ void CHyprDropShadowDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     CShadowPassElement::SShadowData data;
     data.deco = SELF;
     data.a    = a;
-    g_pHyprRenderer->addPassElement(makeUnique<CShadowPassElement>(data));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CShadowPassElement>(data));
 }
 
 bool CHyprDropShadowDecoration::canRender(PHLMONITOR pMonitor) {
@@ -164,7 +165,7 @@ bool CHyprDropShadowDecoration::canRender(PHLMONITOR pMonitor) {
     return true;
 }
 
-SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, float const& a) {
+SShadowRenderData CHyprDropShadowDecoration::getRenderData(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
     if (!canRender(pMonitor))
         return {};
 
@@ -180,7 +181,7 @@ SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, 
     const auto  CORRECTIONOFFSET = (BORDERSIZE * (M_SQRT2 - 1) * std::max(2.0 - ROUNDINGPOWER, 0.0));
     const auto  ROUNDING         = ROUNDINGBASE > 0 ? (ROUNDINGBASE + BORDERSIZE) - CORRECTIONOFFSET : 0;
     const auto  PWORKSPACE       = PWINDOW->m_workspace;
-    const auto  WORKSPACEOFFSET  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE) : Vector2D{};
+    const auto  WORKSPACEOFFSET = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(context, PWORKSPACE) : Vector2D{};
 
     // draw the shadow
     CBox fullBox = m_lastWindowBoxWithDecos;
@@ -210,12 +211,12 @@ SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, 
             },
     };
 
-    fullBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
+    fullBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(context, PWINDOW));
 
     if (fullBox.width < 1 || fullBox.height < 1)
         return {}; // don't draw invisible shadows
 
-    g_pHyprRenderer->m_renderData.currentWindow = m_window;
+    context.currentWindow = m_window;
 
     fullBox.scale(pMonitor->m_scale).round();
 
@@ -231,27 +232,26 @@ SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, 
 void CHyprDropShadowDecoration::reposition() {
     if (m_extents != m_reportedExtents)
         g_pDecorationPositioner->repositionDeco(this);
-
-    g_pHyprRenderer->m_renderData.currentWindow.reset();
 }
 
 // TODO remove
-void CHyprDropShadowDecoration::render(PHLMONITOR pMonitor, float const& a) {
-    auto data = getRenderData(pMonitor, a);
+void CHyprDropShadowDecoration::render(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
+    Render::CRenderingContext child{context, context.renderPass()};
+    auto                      data = getRenderData(child, pMonitor, a);
     if (!data.valid)
         return;
 
     const auto PWINDOW = m_window.lock();
 
-    g_pHyprRenderer->disableScissor();
+    g_pHyprRenderer->disableScissor(child);
 
     const auto GRADIENT = m_gradient.renderState();
 
     if (GRADIENT.transitioning)
-        drawShadowInternal(data.fullBox, data.rounding * pMonitor->m_scale, data.roundingPower, data.size * pMonitor->m_scale, GRADIENT.previous, GRADIENT.current,
+        drawShadowInternal(child, data.fullBox, data.rounding * pMonitor->m_scale, data.roundingPower, data.size * pMonitor->m_scale, GRADIENT.previous, GRADIENT.current,
                            GRADIENT.progress, a);
     else
-        drawShadowInternal(data.fullBox, data.rounding * pMonitor->m_scale, data.roundingPower, data.size * pMonitor->m_scale, GRADIENT.current, a);
+        drawShadowInternal(child, data.fullBox, data.rounding * pMonitor->m_scale, data.roundingPower, data.size * pMonitor->m_scale, GRADIENT.current, a);
 
     reposition();
 }
@@ -260,7 +260,8 @@ eDecorationLayer CHyprDropShadowDecoration::getDecorationLayer() {
     return DECORATION_LAYER_BOTTOM;
 }
 
-void CHyprDropShadowDecoration::drawShadowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
+void CHyprDropShadowDecoration::drawShadowInternal(Render::CRenderingContext& context, const CBox& box, int round, float roundingPower, int range,
+                                                   const Config::CGradientValueData& grad, float a) {
     static auto PSHADOWSHARP = CConfigValue<Config::INTEGER>("decoration:shadow:sharp");
 
     if (box.w < 1 || box.h < 1)
@@ -271,20 +272,20 @@ void CHyprDropShadowDecoration::drawShadowInternal(const CBox& box, int round, f
     if (*PSHADOWSHARP) {
         CHyprColor flatColor = grad.m_colors.empty() ? CHyprColor(0, 0, 0, 0) : grad.m_colors[0];
         flatColor.a *= a;
-        g_pHyprRenderer->draw(
-            CRectPassElement::SRectData{
-                .box           = box,
-                .color         = flatColor,
-                .round         = round,
-                .roundingPower = roundingPower,
-            },
-            box);
+        g_pHyprRenderer->draw(context,
+                              CRectPassElement::SRectData{
+                                  .box           = box,
+                                  .color         = flatColor,
+                                  .round         = round,
+                                  .roundingPower = roundingPower,
+                              },
+                              box);
     } else
-        g_pHyprRenderer->drawShadow(box, round, roundingPower, range, grad, a);
+        g_pHyprRenderer->drawShadow(context, box, round, roundingPower, range, grad, a);
 }
 
-void CHyprDropShadowDecoration::drawShadowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
-                                                   const Config::CGradientValueData& grad2, float lerp, float a) {
+void CHyprDropShadowDecoration::drawShadowInternal(Render::CRenderingContext& context, const CBox& box, int round, float roundingPower, int range,
+                                                   const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp, float a) {
     static auto PSHADOWSHARP = CConfigValue<Config::INTEGER>("decoration:shadow:sharp");
 
     if (box.w < 1 || box.h < 1)
@@ -298,14 +299,14 @@ void CHyprDropShadowDecoration::drawShadowInternal(const CBox& box, int round, f
         CHyprColor flatColor =
             CHyprColor(col1.r + (col2.r - col1.r) * lerp, col1.g + (col2.g - col1.g) * lerp, col1.b + (col2.b - col1.b) * lerp, col1.a + (col2.a - col1.a) * lerp);
         flatColor.a *= a;
-        g_pHyprRenderer->draw(
-            CRectPassElement::SRectData{
-                .box           = box,
-                .color         = flatColor,
-                .round         = round,
-                .roundingPower = roundingPower,
-            },
-            box);
+        g_pHyprRenderer->draw(context,
+                              CRectPassElement::SRectData{
+                                  .box           = box,
+                                  .color         = flatColor,
+                                  .round         = round,
+                                  .roundingPower = roundingPower,
+                              },
+                              box);
     } else
-        g_pHyprRenderer->drawShadow(box, round, roundingPower, range, grad1, grad2, lerp, a);
+        g_pHyprRenderer->drawShadow(context, box, round, roundingPower, range, grad1, grad2, lerp, a);
 }

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -20,7 +20,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float const& a);
+    virtual void                       draw(Render::CRenderingContext&, PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 
@@ -40,11 +40,11 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
     virtual void                       onWindowFocus() override;
 
     bool                               canRender(PHLMONITOR);
-    SShadowRenderData                  getRenderData(PHLMONITOR, float const& a);
+    SShadowRenderData                  getRenderData(Render::CRenderingContext&, PHLMONITOR, float const& a);
     void                               reposition();
 
     // TODO remove
-    void render(PHLMONITOR, float const& a);
+    void render(Render::CRenderingContext&, PHLMONITOR, float const& a);
 
   private:
     SBoxExtents                 m_extents;
@@ -57,9 +57,9 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
     Vector2D                    m_lastWindowPos;
     Vector2D                    m_lastWindowSize;
 
-    void                        drawShadowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a);
-    void drawShadowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
-                            float lerp, float a);
+    void drawShadowInternal(Render::CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a);
+    void drawShadowInternal(Render::CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                            const Config::CGradientValueData& grad2, float lerp, float a);
 
     CBox m_lastWindowBox          = {0};
     CBox m_lastWindowBoxWithDecos = {0};

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -7,6 +7,7 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../desktop/state/WindowState.hpp"
 #include "../../desktop/view/Group.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include <ranges>
 #include <pango/pangocairo.h>
 #include "../pass/TexPassElement.hpp"
@@ -140,7 +141,8 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     auto* const GROUPCOLACTIVELOCKED       = sc<Config::CGradientValueData*>((PGROUPCOLACTIVELOCKED.ptr()));
     auto* const GROUPCOLINACTIVELOCKED     = sc<Config::CGradientValueData*>((PGROUPCOLINACTIVELOCKED.ptr()));
 
-    const auto  ASSIGNEDBOX = assignedBoxGlobal();
+    const auto  ASSIGNEDBOX  = assignedBoxGlobal();
+    const auto  WINDOWOFFSET = g_pHyprRenderer->windowRenderFloatingOffset(m_window.lock());
 
     const auto  ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + *PINDICATORGAP + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
     m_barWidth               = *PSTACKED ? ASSIGNEDBOX.w : (ASSIGNEDBOX.w - *PINNERGAP * (barsToDraw - 1)) / barsToDraw;
@@ -153,14 +155,13 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     float xoff = 0;
     float yoff = 0;
 
-    bool  blur = *PBLUR != 0;
+    bool  blur = *PBLUR != 0 && !g_pHyprRenderer->renderingWorkspaceToBuffer();
 
     for (int i = 0; i < barsToDraw; ++i) {
         const auto WINDOWINDEX = *PSTACKED ? m_dwGroupMembers.size() - i - 1 : i;
 
-        const auto FLOATING_OFFSET = m_window->presentation().floatingOffset();
-        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + FLOATING_OFFSET.x,
-                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - *PINDICATORHEIGHT - *POUTERGAP - pMonitor->m_position.y + FLOATING_OFFSET.y, m_barWidth, *PINDICATORHEIGHT};
+        CBox       rect = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + WINDOWOFFSET.x,
+                           ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - *PINDICATORHEIGHT - *POUTERGAP - pMonitor->m_position.y + WINDOWOFFSET.y, m_barWidth, *PINDICATORHEIGHT};
 
         rect.scale(pMonitor->m_scale).round();
 
@@ -196,9 +197,8 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             g_pHyprRenderer->addPassElement(makeUnique<CRectPassElement>(rectdata));
         }
 
-        rect = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + FLOATING_OFFSET.x,
-                ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->m_position.y + FLOATING_OFFSET.y, m_barWidth,
-                (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)};
+        rect = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + WINDOWOFFSET.x,
+                ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->m_position.y + WINDOWOFFSET.y, m_barWidth, (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)};
         rect.scale(pMonitor->m_scale);
 
         if (!rect.empty()) {
@@ -546,7 +546,7 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
     const auto PWORKSPACE = m_window->m_workspace;
 
     if (PWORKSPACE && !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED))
-        box.translate(PWORKSPACE->m_renderOffset->value());
+        box.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE));
 
     return box.round();
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -99,7 +99,7 @@ void CHyprGroupBarDecoration::damageEntire() {
     g_pHyprRenderer->damageBox(box);
 }
 
-void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
+void CHyprGroupBarDecoration::draw(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
     // get how many bars we will draw
     int        barsToDraw = m_dwGroupMembers.size();
 
@@ -141,8 +141,8 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     auto* const GROUPCOLACTIVELOCKED       = sc<Config::CGradientValueData*>((PGROUPCOLACTIVELOCKED.ptr()));
     auto* const GROUPCOLINACTIVELOCKED     = sc<Config::CGradientValueData*>((PGROUPCOLINACTIVELOCKED.ptr()));
 
-    const auto  ASSIGNEDBOX  = assignedBoxGlobal();
-    const auto  WINDOWOFFSET = g_pHyprRenderer->windowRenderFloatingOffset(m_window.lock());
+    const auto  ASSIGNEDBOX  = assignedBoxGlobalForRender(context);
+    const auto  WINDOWOFFSET = g_pHyprRenderer->windowRenderFloatingOffset(context, m_window.lock());
 
     const auto  ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + *PINDICATORGAP + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
     m_barWidth               = *PSTACKED ? ASSIGNEDBOX.w : (ASSIGNEDBOX.w - *PINNERGAP * (barsToDraw - 1)) / barsToDraw;
@@ -155,7 +155,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     float xoff = 0;
     float yoff = 0;
 
-    bool  blur = *PBLUR != 0 && !g_pHyprRenderer->renderingWorkspaceToBuffer();
+    bool  blur = *PBLUR != 0 && !g_pHyprRenderer->renderingWorkspaceToBuffer(context);
 
     for (int i = 0; i < barsToDraw; ++i) {
         const auto WINDOWINDEX = *PSTACKED ? m_dwGroupMembers.size() - i - 1 : i;
@@ -194,7 +194,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                     }
                 }
             }
-            g_pHyprRenderer->addPassElement(makeUnique<CRectPassElement>(rectdata));
+            g_pHyprRenderer->addPassElement(context, makeUnique<CRectPassElement>(rectdata));
         }
 
         rect = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + WINDOWOFFSET.x,
@@ -228,7 +228,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                             }
                         }
                     }
-                    g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(data));
+                    g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(data));
                 }
             }
 
@@ -259,7 +259,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                 data.tex = titleTex;
                 data.box = rect;
                 data.a   = a;
-                g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(std::move(data)));
+                g_pHyprRenderer->addPassElement(context, makeUnique<CTexPassElement>(std::move(data)));
             }
         }
 
@@ -545,8 +545,19 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
 
     const auto PWORKSPACE = m_window->m_workspace;
 
-    if (PWORKSPACE && !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED))
-        box.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE));
+    const auto WORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+    if (WORKSPACEMONITOR && !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED))
+        box.translate(WORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWORKSPACE));
+
+    return box.round();
+}
+
+CBox CHyprGroupBarDecoration::assignedBoxGlobalForRender(const Render::CRenderingContext& context) {
+    CBox box = m_assignedBox;
+    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_window));
+
+    if (m_window->m_workspace && !(m_window->m_state & Desktop::View::WINDOW_STATE_PINNED))
+        box.translate(g_pHyprRenderer->workspaceRenderOffset(context, m_window->m_workspace));
 
     return box.round();
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -32,7 +32,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float const& a);
+    virtual void                       draw(Render::CRenderingContext&, PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 
@@ -64,6 +64,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     void                      invalidateTextures();
 
     CBox                      assignedBoxGlobal();
+    CBox                      assignedBoxGlobalForRender(const Render::CRenderingContext&);
     bool                      visible();
 
     bool                      onBeginWindowDragOnDeco(const Vector2D&);

--- a/src/render/decorations/CHyprInnerGlowDecoration.cpp
+++ b/src/render/decorations/CHyprInnerGlowDecoration.cpp
@@ -85,9 +85,10 @@ void CHyprInnerGlowDecoration::damageEntire() {
 
     const auto PWORKSPACE = PWINDOW->m_workspace;
 
-    if (g_pHyprRenderer->workspaceRenderIsAnimating(PWORKSPACE) && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
-        windowBox.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE));
-    windowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
+    const auto WORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+    if (WORKSPACEMONITOR && WORKSPACEMONITOR->m_workspaceTransition->isAnimating(PWORKSPACE) && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
+        windowBox.translate(WORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWORKSPACE));
+    windowBox.translate(PWINDOW->presentation().floatingOffset());
 
     g_pHyprRenderer->damageRegion(CRegion(windowBox));
 }
@@ -98,7 +99,7 @@ void CHyprInnerGlowDecoration::updateWindow(PHLWINDOW pWindow) {
     m_lastWindowSize   = PWINDOW->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
 }
 
-void CHyprInnerGlowDecoration::draw(PHLMONITOR pMonitor, float const& a) {
+void CHyprInnerGlowDecoration::draw(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
     const auto SELF = dynamicPointerCast<CHyprInnerGlowDecoration>(self());
     if (!SELF)
         return;
@@ -106,10 +107,10 @@ void CHyprInnerGlowDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     CInnerGlowPassElement::SInnerGlowData data;
     data.deco = SELF;
     data.a    = a;
-    g_pHyprRenderer->addPassElement(makeUnique<CInnerGlowPassElement>(data));
+    g_pHyprRenderer->addPassElement(context, makeUnique<CInnerGlowPassElement>(data));
 }
 
-void CHyprInnerGlowDecoration::render(PHLMONITOR pMonitor, float const& a) {
+void CHyprInnerGlowDecoration::render(Render::CRenderingContext& context, PHLMONITOR pMonitor, float const& a) {
     static auto PGLOW = CConfigValue<Config::INTEGER>("decoration:glow:enabled");
     if (!*PGLOW || !visible())
         return;
@@ -122,49 +123,45 @@ void CHyprInnerGlowDecoration::render(PHLMONITOR pMonitor, float const& a) {
     const auto ROUNDING      = PWINDOW->presentation().rounding() > 0 ? PWINDOW->presentation().rounding() - 1 : PWINDOW->presentation().rounding();
     const auto ROUNDINGPOWER = PWINDOW->presentation().roundingPower();
     const auto PWORKSPACE    = PWINDOW->m_workspace;
-    const auto WORKSPACEOFF  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE) : Vector2D{};
+    const auto WORKSPACEOFF  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(context, PWORKSPACE) : Vector2D{};
 
     CBox       windowBox = {m_lastWindowPos.x, m_lastWindowPos.y, m_lastWindowSize.x, m_lastWindowSize.y};
-    windowBox.translate(-pMonitor->m_position + WORKSPACEOFF + g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
+    windowBox.translate(-pMonitor->m_position + WORKSPACEOFF + g_pHyprRenderer->windowRenderFloatingOffset(context, PWINDOW));
     windowBox.scale(pMonitor->m_scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;
 
-    static auto PGLOWSIZE = CConfigValue<Config::INTEGER>("decoration:glow:range");
-    const auto  GLOWSIZE  = sc<int>(*PGLOWSIZE);
+    static auto         PGLOWSIZE = CConfigValue<Config::INTEGER>("decoration:glow:range");
+    const auto          GLOWSIZE  = sc<int>(*PGLOWSIZE);
 
-    const auto  GRADIENT = m_gradient.renderState();
+    const auto          GRADIENT = m_gradient.renderState();
 
-    g_pHyprRenderer->m_renderData.currentWindow = m_window;
+    Render::CRenderingContext child{context, context.renderPass()};
+    child.currentWindow = m_window;
 
     g_pHyprRenderer->blend(true);
 
     if (GRADIENT.transitioning)
-        drawGlowInternal(windowBox, ROUNDING * pMonitor->m_scale, ROUNDINGPOWER, GLOWSIZE * pMonitor->m_scale, GRADIENT.previous, GRADIENT.current, GRADIENT.progress, a);
+        drawGlowInternal(child, windowBox, ROUNDING * pMonitor->m_scale, ROUNDINGPOWER, GLOWSIZE * pMonitor->m_scale, GRADIENT.previous, GRADIENT.current, GRADIENT.progress, a);
     else
-        drawGlowInternal(windowBox, ROUNDING * pMonitor->m_scale, ROUNDINGPOWER, GLOWSIZE * pMonitor->m_scale, GRADIENT.current, a);
-
-    g_pHyprRenderer->m_renderData.currentWindow.reset();
+        drawGlowInternal(child, windowBox, ROUNDING * pMonitor->m_scale, ROUNDINGPOWER, GLOWSIZE * pMonitor->m_scale, GRADIENT.current, a);
 }
 
-void CHyprInnerGlowDecoration::drawGlowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a) {
+void CHyprInnerGlowDecoration::drawGlowInternal(Render::CRenderingContext& context, const CBox& box, int round, float roundingPower, int range,
+                                                const Config::CGradientValueData& grad, float a) {
     if (box.w < 1 || box.h < 1)
         return;
     g_pHyprRenderer->blend(true);
-    g_pHyprRenderer->m_renderData.currentWindow = m_window;
-    g_pHyprRenderer->drawGlow(box, round, roundingPower, range, grad, a);
-    g_pHyprRenderer->m_renderData.currentWindow.reset();
+    g_pHyprRenderer->drawGlow(context, box, round, roundingPower, range, grad, a);
 }
 
-void CHyprInnerGlowDecoration::drawGlowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
-                                                const Config::CGradientValueData& grad2, float lerp, float a) {
+void CHyprInnerGlowDecoration::drawGlowInternal(Render::CRenderingContext& context, const CBox& box, int round, float roundingPower, int range,
+                                                const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp, float a) {
     if (box.w < 1 || box.h < 1)
         return;
     g_pHyprRenderer->blend(true);
-    g_pHyprRenderer->m_renderData.currentWindow = m_window;
-    g_pHyprRenderer->drawGlow(box, round, roundingPower, range, grad1, grad2, lerp, a);
-    g_pHyprRenderer->m_renderData.currentWindow.reset();
+    g_pHyprRenderer->drawGlow(context, box, round, roundingPower, range, grad1, grad2, lerp, a);
 }
 
 eDecorationLayer CHyprInnerGlowDecoration::getDecorationLayer() {

--- a/src/render/decorations/CHyprInnerGlowDecoration.cpp
+++ b/src/render/decorations/CHyprInnerGlowDecoration.cpp
@@ -7,6 +7,7 @@
 #include "../../config/ConfigValue.hpp"
 #include "../../Compositor.hpp"
 #include "../../desktop/state/FocusState.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include "../pass/InnerGlowPassElement.hpp"
 #include "../Renderer.hpp"
 #include "../OpenGL.hpp"
@@ -83,9 +84,10 @@ void CHyprInnerGlowDecoration::damageEntire() {
     CBox       windowBox = PWINDOW->getWindowMainSurfaceBox();
 
     const auto PWORKSPACE = PWINDOW->m_workspace;
-    if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
-        windowBox.translate(PWORKSPACE->m_renderOffset->value());
-    windowBox.translate(PWINDOW->presentation().floatingOffset());
+
+    if (g_pHyprRenderer->workspaceRenderIsAnimating(PWORKSPACE) && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED))
+        windowBox.translate(g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE));
+    windowBox.translate(g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
 
     g_pHyprRenderer->damageRegion(CRegion(windowBox));
 }
@@ -120,10 +122,10 @@ void CHyprInnerGlowDecoration::render(PHLMONITOR pMonitor, float const& a) {
     const auto ROUNDING      = PWINDOW->presentation().rounding() > 0 ? PWINDOW->presentation().rounding() - 1 : PWINDOW->presentation().rounding();
     const auto ROUNDINGPOWER = PWINDOW->presentation().roundingPower();
     const auto PWORKSPACE    = PWINDOW->m_workspace;
-    const auto WORKSPACEOFF  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto WORKSPACEOFF  = PWORKSPACE && !(PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE) : Vector2D{};
 
     CBox       windowBox = {m_lastWindowPos.x, m_lastWindowPos.y, m_lastWindowSize.x, m_lastWindowSize.y};
-    windowBox.translate(-pMonitor->m_position + WORKSPACEOFF + PWINDOW->presentation().floatingOffset());
+    windowBox.translate(-pMonitor->m_position + WORKSPACEOFF + g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW));
     windowBox.scale(pMonitor->m_scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)

--- a/src/render/decorations/CHyprInnerGlowDecoration.cpp
+++ b/src/render/decorations/CHyprInnerGlowDecoration.cpp
@@ -132,10 +132,10 @@ void CHyprInnerGlowDecoration::render(Render::CRenderingContext& context, PHLMON
     if (windowBox.width < 1 || windowBox.height < 1)
         return;
 
-    static auto         PGLOWSIZE = CConfigValue<Config::INTEGER>("decoration:glow:range");
-    const auto          GLOWSIZE  = sc<int>(*PGLOWSIZE);
+    static auto               PGLOWSIZE = CConfigValue<Config::INTEGER>("decoration:glow:range");
+    const auto                GLOWSIZE  = sc<int>(*PGLOWSIZE);
 
-    const auto          GRADIENT = m_gradient.renderState();
+    const auto                GRADIENT = m_gradient.renderState();
 
     Render::CRenderingContext child{context, context.renderPass()};
     child.currentWindow = m_window;

--- a/src/render/decorations/CHyprInnerGlowDecoration.hpp
+++ b/src/render/decorations/CHyprInnerGlowDecoration.hpp
@@ -12,7 +12,7 @@ class CHyprInnerGlowDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float const& a);
+    virtual void                       draw(Render::CRenderingContext&, PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 
@@ -31,15 +31,15 @@ class CHyprInnerGlowDecoration : public IHyprWindowDecoration {
     virtual void                       onWindowMap() override;
     virtual void                       onWindowFocus() override;
 
-    void                               render(PHLMONITOR, float const& a);
+    void                               render(Render::CRenderingContext&, PHLMONITOR, float const& a);
 
   private:
-    bool visible();
-    void drawGlowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a);
-    void drawGlowInternal(const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2, float lerp,
-                          float a);
+    bool         visible();
+    void         drawGlowInternal(Render::CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad, float a);
+    void         drawGlowInternal(Render::CRenderingContext&, const CBox& box, int round, float roundingPower, int range, const Config::CGradientValueData& grad1,
+                                  const Config::CGradientValueData& grad2, float lerp, float a);
 
-    PHLWINDOWREF                m_window;
+    PHLWINDOWREF m_window;
 
     CAnimatedDecorationGradient m_gradient;
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -32,6 +32,9 @@ class CDecorationPositioner;
 namespace Desktop::View {
     class CWindowPresentation;
 }
+namespace Render {
+    class CRenderingContext;
+}
 
 class IHyprWindowDecoration {
   public:
@@ -42,7 +45,7 @@ class IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply) = 0;
 
-    virtual void                       draw(PHLMONITOR, float const& a) = 0;
+    virtual void                       draw(Render::CRenderingContext&, PHLMONITOR, float const& a) = 0;
 
     virtual eDecorationType            getDecorationType() = 0;
 

--- a/src/render/gl/GLElementRenderer.cpp
+++ b/src/render/gl/GLElementRenderer.cpp
@@ -1,4 +1,5 @@
 #include "GLElementRenderer.hpp"
+#include "../pass/BoxShadowPassElement.hpp"
 #include "../Renderer.hpp"
 #include "../decorations/CHyprDropShadowDecoration.hpp"
 #include "../OpenGL.hpp"
@@ -97,6 +98,17 @@ void CGLElementRenderer::draw(CRenderingContext& context, WP<CRectPassElement> e
 };
 
 void CGLElementRenderer::draw(CRenderingContext& context, WP<CShadowPassElement> element, const CRegion& damage) {
+    if (const auto BOX_SHADOW = dynamicPointerCast<CBoxShadowPassElement>(element)) {
+        const auto&       DATA = BOX_SHADOW->m_boxData;
+        CRenderingContext child{context, context.renderPass()};
+        child.clipBox = DATA.clipBox;
+        child.currentWindow.reset();
+        child.damage = damage;
+
+        g_pHyprOpenGL->renderRoundedShadow(child, DATA.box, DATA.round, DATA.roundingPower, DATA.range, Config::CGradientValueData{DATA.color}, DATA.a, DATA.cutoutBox, DATA.round);
+        return;
+    }
+
     const auto& m_data = element->m_data;
     const auto  DECO   = m_data.deco.lock();
     if (!DECO)

--- a/src/render/gl/GLElementRenderer.cpp
+++ b/src/render/gl/GLElementRenderer.cpp
@@ -7,46 +7,46 @@
 
 using namespace Render::GL;
 
-void CGLElementRenderer::draw(WP<CBorderPassElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CBorderPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
     if (m_data.hasGrad2)
         g_pHyprOpenGL->renderBorder(
-            m_data.box, m_data.grad1, m_data.grad2, m_data.lerp,
+            context, m_data.box, m_data.grad1, m_data.grad2, m_data.lerp,
             {.round = m_data.round, .roundingPower = m_data.roundingPower, .borderSize = m_data.borderSize, .a = m_data.a, .outerRound = m_data.outerRound});
     else
         g_pHyprOpenGL->renderBorder(
-            m_data.box, m_data.grad1,
+            context, m_data.box, m_data.grad1,
             {.round = m_data.round, .roundingPower = m_data.roundingPower, .borderSize = m_data.borderSize, .a = m_data.a, .outerRound = m_data.outerRound});
 };
 
-void CGLElementRenderer::draw(WP<CClearPassElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CClearPassElement> element, const CRegion& damage) {
     const auto& color = element->m_data.color;
-    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render without begin()!");
+    RASSERT(context.sceneMonitor, "Tried to render without begin()!");
 
     TRACY_GPU_ZONE("RenderClear");
     const std::array<GLfloat, 4> c = {sc<GLfloat>(color.r), sc<GLfloat>(color.g), sc<GLfloat>(color.b), sc<GLfloat>(color.a)};
 
-    if (!g_pHyprRenderer->m_renderData.damage.empty()) {
-        g_pHyprRenderer->m_renderData.damage.forEachRect([&c](const auto& RECT) {
-            g_pHyprOpenGL->scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+    if (!context.damage.empty()) {
+        context.damage.forEachRect([&c, &context](const auto& RECT) {
+            g_pHyprOpenGL->scissor(context, &RECT, context.transformDamage);
             glClearBufferfv(GL_COLOR, 0, c.data());
         });
 
-        g_pHyprOpenGL->scissor(nullptr);
+        g_pHyprOpenGL->scissor(context, nullptr);
     } else
         glClearBufferfv(GL_COLOR, 0, c.data());
 };
 
-void CGLElementRenderer::draw(WP<CFramebufferElement> element, const CRegion& damage) {
-    Log::logger->log(Log::ERR, "Deprecated CFramebufferElement. Use g_pHyprRenderer->m_renderData and CTexPassElement instead");
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CFramebufferElement> element, const CRegion& damage) {
+    Log::logger->log(Log::ERR, "Deprecated CFramebufferElement. Use context and CTexPassElement instead");
     // const auto       m_data = element->m_data;
     // SP<IFramebuffer> fb     = nullptr;
 
     // if (m_data.main) {
     //     switch (m_data.framebufferID) {
-    //         case FB_MONITOR_RENDER_MAIN: fb = g_pHyprRenderer->m_renderData.mainFB; break;
-    //         case FB_MONITOR_RENDER_CURRENT: fb = g_pHyprRenderer->m_renderData.currentFB; break;
-    //         case FB_MONITOR_RENDER_OUT: fb = g_pHyprRenderer->m_renderData.outFB; break;
+    //         case FB_MONITOR_RENDER_MAIN: fb = context.mainFB; break;
+    //         case FB_MONITOR_RENDER_CURRENT: fb = context.currentFB; break;
+    //         case FB_MONITOR_RENDER_OUT: fb = context.outFB; break;
     //         default: fb = nullptr;
     //     }
 
@@ -57,12 +57,12 @@ void CGLElementRenderer::draw(WP<CFramebufferElement> element, const CRegion& da
 
     // } else {
     //     switch (m_data.framebufferID) {
-    //         case FB_MONITOR_RENDER_EXTRA_OFFLOAD: fb = g_pHyprRenderer->m_renderData.pMonitor->m_offloadFB; break;
-    //         case FB_MONITOR_RENDER_EXTRA_MIRROR: fb = g_pHyprRenderer->m_renderData.pMonitor->m_mirrorFB; break;
-    //         case FB_MONITOR_RENDER_EXTRA_MIRROR_SWAP: fb = g_pHyprRenderer->m_renderData.pMonitor->m_mirrorSwapFB; break;
-    //         case FB_MONITOR_RENDER_EXTRA_OFF_MAIN: fb = g_pHyprRenderer->m_renderData.pMonitor->m_offMainFB; break;
-    //         case FB_MONITOR_RENDER_EXTRA_MONITOR_MIRROR: fb = g_pHyprRenderer->m_renderData.pMonitor->m_monitorMirrorFB; break;
-    //         case FB_MONITOR_RENDER_EXTRA_BLUR: fb = g_pHyprRenderer->m_renderData.pMonitor->m_blurFB; break;
+    //         case FB_MONITOR_RENDER_EXTRA_OFFLOAD: fb = context.sceneMonitor->m_offloadFB; break;
+    //         case FB_MONITOR_RENDER_EXTRA_MIRROR: fb = context.sceneMonitor->m_mirrorFB; break;
+    //         case FB_MONITOR_RENDER_EXTRA_MIRROR_SWAP: fb = context.sceneMonitor->m_mirrorSwapFB; break;
+    //         case FB_MONITOR_RENDER_EXTRA_OFF_MAIN: fb = context.sceneMonitor->m_offMainFB; break;
+    //         case FB_MONITOR_RENDER_EXTRA_MONITOR_MIRROR: fb = context.sceneMonitor->m_monitorMirrorFB; break;
+    //         case FB_MONITOR_RENDER_EXTRA_BLUR: fb = context.sceneMonitor->m_blurFB; break;
     //         default: fb = nullptr;
     //     }
 
@@ -75,18 +75,18 @@ void CGLElementRenderer::draw(WP<CFramebufferElement> element, const CRegion& da
     // g_pHyprRenderer->bindFB(fb);
 };
 
-void CGLElementRenderer::draw(WP<CPreBlurElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CPreBlurElement> element, const CRegion& damage) {
     auto dmg = damage;
-    g_pHyprRenderer->preBlurForCurrentMonitor(dmg);
+    g_pHyprRenderer->preBlurForCurrentMonitor(context, dmg);
 };
 
-void CGLElementRenderer::draw(WP<CRectPassElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CRectPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
 
     if (m_data.color.a == 1.F || !m_data.blur)
-        g_pHyprOpenGL->renderRect(m_data.box, m_data.color, {.damage = &damage, .round = m_data.round, .roundingPower = m_data.roundingPower});
+        g_pHyprOpenGL->renderRect(context, m_data.box, m_data.color, {.damage = &damage, .round = m_data.round, .roundingPower = m_data.roundingPower});
     else
-        g_pHyprOpenGL->renderRect(m_data.box, m_data.color,
+        g_pHyprOpenGL->renderRect(context, m_data.box, m_data.color,
                                   {.round          = m_data.round,
                                    .roundingPower  = m_data.roundingPower,
                                    .blur           = true,
@@ -96,27 +96,27 @@ void CGLElementRenderer::draw(WP<CRectPassElement> element, const CRegion& damag
                                    .blurOwner      = m_data.blurOwner});
 };
 
-void CGLElementRenderer::draw(WP<CShadowPassElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CShadowPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
     const auto  DECO   = m_data.deco.lock();
     if (!DECO)
         return;
-    DECO->render(g_pHyprRenderer->m_renderData.pMonitor.lock(), m_data.a);
+    DECO->render(context, context.sceneMonitor.lock(), m_data.a);
 };
 
-void CGLElementRenderer::draw(WP<CInnerGlowPassElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CInnerGlowPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
     const auto  DECO   = m_data.deco.lock();
     if (!DECO)
         return;
-    DECO->render(g_pHyprRenderer->m_renderData.pMonitor.lock(), m_data.a);
+    DECO->render(context, context.sceneMonitor.lock(), m_data.a);
 };
 
-void CGLElementRenderer::draw(WP<CTexPassElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CTexPassElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
 
     g_pHyprOpenGL->renderTexture( //
-        m_data.tex, m_data.box,
+        context, m_data.tex, m_data.box,
         {
             // blur settings for m_data.blur == true
             .blur                  = m_data.blur,
@@ -143,14 +143,14 @@ void CGLElementRenderer::draw(WP<CTexPassElement> element, const CRegion& damage
             .clipRegion     = m_data.clipRegion,
             .currentLS      = m_data.currentLS,
 
-            .primarySurfaceUVTopLeft     = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft,
-            .primarySurfaceUVBottomRight = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight,
+            .primarySurfaceUVTopLeft     = context.primarySurfaceUVTopLeft,
+            .primarySurfaceUVBottomRight = context.primarySurfaceUVBottomRight,
             .motionBlur                  = m_data.motionBlur,
         });
 };
 
-void CGLElementRenderer::draw(WP<CTextureMatteElement> element, const CRegion& damage) {
+void CGLElementRenderer::draw(CRenderingContext& context, WP<CTextureMatteElement> element, const CRegion& damage) {
     const auto& m_data = element->m_data;
 
-    g_pHyprOpenGL->renderTextureMatte(m_data.tex, m_data.box, m_data.fb);
+    g_pHyprOpenGL->renderTextureMatte(context, m_data.tex, m_data.box, m_data.fb);
 };

--- a/src/render/gl/GLElementRenderer.hpp
+++ b/src/render/gl/GLElementRenderer.hpp
@@ -9,14 +9,14 @@ namespace Render::GL {
         ~CGLElementRenderer() = default;
 
       private:
-        void draw(WP<CBorderPassElement> element, const Hyprutils::Math::CRegion& damage) override;
-        void draw(WP<CClearPassElement> element, const CRegion& damage) override;
-        void draw(WP<CFramebufferElement> element, const CRegion& damage) override;
-        void draw(WP<CPreBlurElement> element, const CRegion& damage) override;
-        void draw(WP<CRectPassElement> element, const CRegion& damage) override;
-        void draw(WP<CShadowPassElement> element, const CRegion& damage) override;
-        void draw(WP<CInnerGlowPassElement> element, const CRegion& damage) override;
-        void draw(WP<CTexPassElement> element, const CRegion& damage) override;
-        void draw(WP<CTextureMatteElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CBorderPassElement> element, const Hyprutils::Math::CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CClearPassElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CFramebufferElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CPreBlurElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CRectPassElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CShadowPassElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CInnerGlowPassElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CTexPassElement> element, const CRegion& damage) override;
+        void draw(CRenderingContext& context, WP<CTextureMatteElement> element, const CRegion& damage) override;
     };
 }

--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -15,7 +15,8 @@ CGLFramebuffer::CGLFramebuffer(const std::string& name) : IFramebuffer(name), m_
 
 bool CGLFramebuffer::internalAlloc(int w, int h, uint32_t drmFormat) {
     g_pHyprOpenGL->makeEGLCurrent();
-    m_tempBuf = false;
+    const auto previousDrawFB = g_pHyprOpenGL->boundDrawFramebuffer();
+    m_tempBuf                 = false;
 
     if (!m_tex) {
         m_tex = g_pHyprRenderer->createTexture();
@@ -74,10 +75,7 @@ bool CGLFramebuffer::internalAlloc(int w, int h, uint32_t drmFormat) {
     g_pHyprOpenGL->bindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 
     // this can run mid frame in enableMirror() in begin() restore the draw fb the renderer had bound
-    if (g_pHyprRenderer && g_pHyprRenderer->m_renderData.currentFB)
-        g_pHyprRenderer->m_renderData.currentFB->bind();
-    else
-        g_pHyprOpenGL->bindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    g_pHyprOpenGL->bindFramebuffer(GL_DRAW_FRAMEBUFFER, previousDrawFB);
 
     return true;
 }
@@ -121,6 +119,7 @@ void CGLFramebuffer::unbind() {
 
 void CGLFramebuffer::release() {
     if (m_fbAllocated) {
+        const auto previousDrawFB = g_pHyprOpenGL ? g_pHyprOpenGL->boundDrawFramebuffer() : 0;
         if (g_pHyprOpenGL)
             g_pHyprOpenGL->bindFramebuffer(GL_FRAMEBUFFER, m_fb);
         else
@@ -136,8 +135,8 @@ void CGLFramebuffer::release() {
 
         // releasing can happen mid frame from a temp fb, rebind the fb the renderer
         // had previously bound, otherwise draws continue into fb 0 and raise GL_INVALID_FRAMEBUFFER_OPERATION
-        if (g_pHyprRenderer && g_pHyprRenderer->m_renderData.currentFB && g_pHyprRenderer->m_renderData.currentFB.get() != this)
-            g_pHyprRenderer->m_renderData.currentFB->bind();
+        if (g_pHyprOpenGL)
+            g_pHyprOpenGL->bindFramebuffer(GL_DRAW_FRAMEBUFFER, previousDrawFB == m_fb ? 0 : previousDrawFB);
 
         m_fbAllocated = false;
         m_fb          = 0;
@@ -287,6 +286,6 @@ void CGLFramebuffer::clearAfterInvalidation() {
 
     m_cleared = true;
     glClearColor(0, 0, 0, 0);
-    g_pHyprOpenGL->scissor(nullptr);
+    g_pHyprOpenGL->disableScissorState();
     glClear(GL_COLOR_BUFFER_BIT);
 }

--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -15,7 +15,8 @@ CGLFramebuffer::CGLFramebuffer(const std::string& name) : IFramebuffer(name), m_
 
 bool CGLFramebuffer::internalAlloc(int w, int h, uint32_t drmFormat) {
     g_pHyprOpenGL->makeEGLCurrent();
-    m_tempBuf = false;
+    const auto previousDrawFB = g_pHyprOpenGL->boundDrawFramebuffer();
+    m_tempBuf                 = false;
 
     if (!m_tex) {
         m_tex = g_pHyprRenderer->createTexture();
@@ -73,10 +74,7 @@ bool CGLFramebuffer::internalAlloc(int w, int h, uint32_t drmFormat) {
     g_pHyprOpenGL->bindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 
     // this can run mid frame in enableMirror() in begin() restore the draw fb the renderer had bound
-    if (g_pHyprRenderer && g_pHyprRenderer->m_renderData.currentFB)
-        g_pHyprRenderer->m_renderData.currentFB->bind();
-    else
-        g_pHyprOpenGL->bindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    g_pHyprOpenGL->bindFramebuffer(GL_DRAW_FRAMEBUFFER, previousDrawFB);
 
     return true;
 }
@@ -119,6 +117,7 @@ void CGLFramebuffer::unbind() {
 
 void CGLFramebuffer::release() {
     if (m_fbAllocated) {
+        const auto previousDrawFB = g_pHyprOpenGL ? g_pHyprOpenGL->boundDrawFramebuffer() : 0;
         if (g_pHyprOpenGL)
             g_pHyprOpenGL->bindFramebuffer(GL_FRAMEBUFFER, m_fb);
         else
@@ -134,8 +133,8 @@ void CGLFramebuffer::release() {
 
         // releasing can happen mid frame from a temp fb, rebind the fb the renderer
         // had previously bound, otherwise draws continue into fb 0 and raise GL_INVALID_FRAMEBUFFER_OPERATION
-        if (g_pHyprRenderer && g_pHyprRenderer->m_renderData.currentFB && g_pHyprRenderer->m_renderData.currentFB.get() != this)
-            g_pHyprRenderer->m_renderData.currentFB->bind();
+        if (g_pHyprOpenGL)
+            g_pHyprOpenGL->bindFramebuffer(GL_DRAW_FRAMEBUFFER, previousDrawFB == m_fb ? 0 : previousDrawFB);
 
         m_fbAllocated = false;
         m_fb          = 0;
@@ -285,6 +284,6 @@ void CGLFramebuffer::clearAfterInvalidation() {
 
     m_cleared = true;
     glClearColor(0, 0, 0, 0);
-    g_pHyprOpenGL->scissor(nullptr);
+    g_pHyprOpenGL->disableScissorState();
     glClear(GL_COLOR_BUFFER_BIT);
 }

--- a/src/render/gl/GLRenderbuffer.cpp
+++ b/src/render/gl/GLRenderbuffer.cpp
@@ -67,7 +67,7 @@ CGLRenderbuffer::CGLRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format
 
 void CGLRenderbuffer::bind() {
     g_pHyprOpenGL->makeEGLCurrent();
-    g_pHyprRenderer->bindFB(m_framebuffer);
+    GLFB(m_framebuffer)->bind();
 }
 
 void CGLRenderbuffer::unbind() {

--- a/src/render/gl/blur/Acrylic.cpp
+++ b/src/render/gl/blur/Acrylic.cpp
@@ -27,9 +27,9 @@ static float srgbToLinear(float value) {
     return value <= 0.04045F ? value / 12.92F : std::pow((value + 0.055F) / 1.055F, 2.4F);
 }
 
-static float acrylicLuminanceScale() {
+static float acrylicLuminanceScale(const CRenderingContext& context) {
     const auto INTERMEDIATE = getDefaultImageDescription();
-    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription();
+    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription(context);
     if (!WORKBUFFER)
         return 1.F;
 
@@ -79,7 +79,7 @@ void CAcrylicBlurMaterial::bindFinish(WP<CShader> shader, const SBlurMaterialCon
     const auto  TINT            = CHyprColor(*PACRYLICTINT);
     const auto  TINT_ALPHA      = std::clamp(sc<float>(TINT.a), 0.F, 1.F);
     const auto  TINT_DEPTH      = -std::log(std::max(1.F - TINT_ALPHA, 0.0001F));
-    const auto  LUMINANCE_SCALE = acrylicLuminanceScale();
+    const auto  LUMINANCE_SCALE = acrylicLuminanceScale(context.renderingContext);
 
     shader->setUniformInt(SHADER_ACRYLIC_ENABLED, 1);
     shader->setUniformFloat4(SHADER_ACRYLIC_EXTENT, sc<float>(extent.x), sc<float>(extent.y), sc<float>(extent.width), sc<float>(extent.height));

--- a/src/render/gl/blur/Aurora.cpp
+++ b/src/render/gl/blur/Aurora.cpp
@@ -29,9 +29,9 @@ static float srgbToLinear(float value) {
     return value <= 0.04045F ? value / 12.92F : std::pow((value + 0.055F) / 1.055F, 2.4F);
 }
 
-static float auroraLuminanceScale() {
+static float auroraLuminanceScale(const CRenderingContext& context) {
     const auto INTERMEDIATE = getDefaultImageDescription();
-    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription();
+    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription(context);
     if (!WORKBUFFER)
         return 1.F;
 
@@ -49,7 +49,7 @@ CAuroraBlurProvider::CAuroraBlurProvider(CHyprOpenGLImpl& impl) : CGlassBlurProv
     ;
 }
 
-bool CAuroraBlurMaterial::isAnimated() const noexcept {
+bool CAuroraBlurMaterial::isAnimated(const CRenderingContext&) const noexcept {
     static auto PBLURENABLED     = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
     static auto PGLASSREFRACTION = CConfigValue<Config::FLOAT>("decoration:blur:glass:refraction");
     static auto PGLASSROUGHNESS  = CConfigValue<Config::FLOAT>("decoration:blur:glass:roughness");
@@ -75,7 +75,7 @@ void CAuroraBlurMaterial::bindFinish(WP<CShader> shader, const SBlurMaterialCont
 
     const auto COLOR1 = CHyprColor(*PAURORACOLOR1);
     const auto COLOR2 = CHyprColor(*PAURORACOLOR2);
-    const auto SCALE  = auroraLuminanceScale();
+    const auto SCALE  = auroraLuminanceScale(context.renderingContext);
 
     const auto bindColor = [&](eShaderUniform uniform, const CHyprColor& color) {
         const auto ALPHA = sc<float>(color.a);

--- a/src/render/gl/blur/Aurora.hpp
+++ b/src/render/gl/blur/Aurora.hpp
@@ -10,7 +10,7 @@ namespace Render::GL {
       public:
         CAuroraBlurMaterial();
 
-        bool isAnimated() const noexcept override;
+        bool isAnimated(const CRenderingContext&) const noexcept override;
         void bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const override;
 
       private:

--- a/src/render/gl/blur/Drops.cpp
+++ b/src/render/gl/blur/Drops.cpp
@@ -30,7 +30,7 @@ CDropsBlurProvider::CDropsBlurProvider(CHyprOpenGLImpl& impl) : CGlassBlurProvid
     ;
 }
 
-bool CDropsBlurMaterial::isAnimated() const noexcept {
+bool CDropsBlurMaterial::isAnimated(const CRenderingContext&) const noexcept {
     static auto PBLURENABLED     = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
     static auto PGLASSREFRACTION = CConfigValue<Config::FLOAT>("decoration:blur:glass:refraction");
     static auto PGLASSROUGHNESS  = CConfigValue<Config::FLOAT>("decoration:blur:glass:roughness");

--- a/src/render/gl/blur/Drops.hpp
+++ b/src/render/gl/blur/Drops.hpp
@@ -10,7 +10,7 @@ namespace Render::GL {
       public:
         CDropsBlurMaterial();
 
-        bool isAnimated() const noexcept override;
+        bool isAnimated(const CRenderingContext&) const noexcept override;
 
         void bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const override;
 

--- a/src/render/gl/blur/FluidJar.cpp
+++ b/src/render/gl/blur/FluidJar.cpp
@@ -70,13 +70,13 @@ static bool geometryDiscontinuous(const CBox& oldExtent, const CBox& newExtent, 
     return horizontalDelta > width * 0.75 || verticalDelta > height * 0.75;
 }
 
-static CBox renderedWindowBox(PHLWINDOW window) {
+static CBox renderedWindowBox(const CRenderingContext& context, PHLWINDOW window) {
     if (!window)
         return {};
 
-    auto position = window->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + window->presentation().floatingOffset();
+    auto position = window->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT) + g_pHyprRenderer->windowRenderFloatingOffset(context, window);
     if (!(window->m_state & Desktop::View::WINDOW_STATE_PINNED) && window->m_workspace)
-        position += window->m_workspace->m_renderOffset->value();
+        position += g_pHyprRenderer->workspaceRenderOffset(context, window->m_workspace);
 
     const auto size = window->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
     return {position.x, position.y, size.x, size.y};
@@ -118,13 +118,13 @@ void CFluidJarBlurMaterial::prepare(const SBlurMaterialContext& context) {
     pruneStates();
 
     const auto state         = stateForContext(context.blurContext, true);
-    const auto renderExtent  = transformedPatternBox(context.blurContext);
+    const auto renderExtent  = transformedPatternBox(context.renderingContext, context.blurContext);
     const auto window        = context.blurContext.owner.lock();
-    const auto physicsExtent = renderedWindowBox(window);
-    if (!state || physicsExtent.width <= 0 || physicsExtent.height <= 0 || renderExtent.width <= 0 || renderExtent.height <= 0 || !g_pHyprRenderer->m_renderData.pMonitor)
+    const auto physicsExtent = renderedWindowBox(context.renderingContext, window);
+    if (!state || physicsExtent.width <= 0 || physicsExtent.height <= 0 || renderExtent.width <= 0 || renderExtent.height <= 0 || !context.renderingContext.sceneMonitor)
         return;
 
-    updateState(*state, physicsExtent);
+    updateState(context.renderingContext, *state, physicsExtent);
 }
 
 void CFluidJarBlurMaterial::bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const {
@@ -134,13 +134,13 @@ void CFluidJarBlurMaterial::bindFinish(WP<CShader> shader, const SBlurMaterialCo
         return;
     }
 
-    const auto extent = transformedPatternBox(context.blurContext);
+    const auto extent = transformedPatternBox(context.renderingContext, context.blurContext);
     if (extent.width <= 0 || extent.height <= 0) {
         shader->setUniformInt(SHADER_FLUIDJAR_ENABLED, 0);
         return;
     }
 
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
+    const auto monitor = context.renderingContext.sceneMonitor;
     if (!monitor) {
         shader->setUniformInt(SHADER_FLUIDJAR_ENABLED, 0);
         return;
@@ -208,7 +208,7 @@ const CFluidJarBlurMaterial::SState* CFluidJarBlurMaterial::stateForContext(cons
     return state != m_states.end() ? &*state : nullptr;
 }
 
-void CFluidJarBlurMaterial::updateState(SState& state, const CBox& extent) {
+void CFluidJarBlurMaterial::updateState(CRenderingContext& renderingContext, SState& state, const CBox& extent) {
     if (state.lastFrame == m_frame)
         return;
 
@@ -227,7 +227,7 @@ void CFluidJarBlurMaterial::updateState(SState& state, const CBox& extent) {
     const auto speed   = std::clamp(*PFLUIDSPEED, 0.F, 10.F);
 
     if (!state.particles[0] || state.fillAmount != fillAmount || state.precision != precision) {
-        initializeState(state, simulationSize, fillAmount, precision);
+        initializeState(renderingContext, state, simulationSize, fillAmount, precision);
         state.extent    = extent;
         state.hasExtent = true;
     } else if (!state.hasExtent) {
@@ -237,7 +237,7 @@ void CFluidJarBlurMaterial::updateState(SState& state, const CBox& extent) {
         const auto discontinuous = geometryDiscontinuous(state.extent, extent, elapsed);
         const auto transform     = fluidJarGeometryTransform(state.extent, extent, state.simulationSize, simulationSize, !discontinuous);
         state.wallVelocities     = discontinuous ? std::array<float, 4>{} : fluidJarWallVelocities(state.extent, extent, simulationSize, elapsed, speed);
-        transformState(state, simulationSize, transform, state.wallVelocities);
+        transformState(renderingContext, state, simulationSize, transform, state.wallVelocities);
         state.extent = extent;
     } else
         state.wallVelocities = {};
@@ -248,16 +248,16 @@ void CFluidJarBlurMaterial::updateState(SState& state, const CBox& extent) {
 
         int substeps = 0;
         while (state.accumulator >= FIXED_TIMESTEP && substeps < MAX_SUBSTEPS) {
-            drawParticleStep(state, SOLVER_TIMESTEP);
-            drawGraphStep(state);
-            drawTrackingStep(state);
+            drawParticleStep(renderingContext, state, SOLVER_TIMESTEP);
+            drawGraphStep(renderingContext, state);
+            drawTrackingStep(renderingContext, state);
             state.accumulator -= FIXED_TIMESTEP;
             ++state.simulationFrame;
             ++substeps;
         }
 
         if (substeps > 0)
-            drawVisualStep(state, substeps);
+            drawVisualStep(renderingContext, state, substeps);
 
         if (substeps == MAX_SUBSTEPS)
             state.accumulator = std::min(state.accumulator, sc<double>(FIXED_TIMESTEP));
@@ -269,7 +269,7 @@ void CFluidJarBlurMaterial::updateState(SState& state, const CBox& extent) {
     state.lastFrame  = m_frame;
 }
 
-void CFluidJarBlurMaterial::initializeState(SState& state, const Vector2D& simulationSize, float fillAmount, float precision) {
+void CFluidJarBlurMaterial::initializeState(CRenderingContext& renderingContext, SState& state, const Vector2D& simulationSize, float fillAmount, float precision) {
     state.simulationSize      = simulationSize;
     state.gridSize            = fluidJarGridSize(simulationSize);
     state.particleTextureSize = {state.gridSize.x * 4.0, state.gridSize.y};
@@ -294,27 +294,28 @@ void CFluidJarBlurMaterial::initializeState(SState& state, const Vector2D& simul
     state.wallVelocities   = {};
 
     for (const auto& buffer : state.particles)
-        drawInitialize(state, buffer);
+        drawInitialize(renderingContext, state, buffer);
 
-    clearIntegerBuffers(state.graph);
+    clearIntegerBuffers(renderingContext, state.graph);
     for (int i = 0; i < INITIAL_GRAPH_STEPS; ++i) {
-        drawGraphStep(state);
+        drawGraphStep(renderingContext, state);
         ++state.simulationFrame;
     }
 
-    clearIntegerBuffers(state.tracking);
-    clearBuffers(state.visual, {0.F, 0.F, 0.F, 0.F});
+    clearIntegerBuffers(renderingContext, state.tracking);
+    clearBuffers(renderingContext, state.visual, {0.F, 0.F, 0.F, 0.F});
     if (state.particleCount > 0) {
         for (int i = 0; i < INITIAL_TRACK_STEPS; ++i) {
-            drawTrackingStep(state);
+            drawTrackingStep(renderingContext, state);
             ++state.simulationFrame;
         }
         for (int i = 0; i < INITIAL_VISUAL_STEPS; ++i)
-            drawVisualStep(state);
+            drawVisualStep(renderingContext, state);
     }
 }
 
-void CFluidJarBlurMaterial::transformState(SState& state, const Vector2D& simulationSize, const SFluidJarGeometryTransform& transform, const std::array<float, 4>& wallVelocities) {
+void CFluidJarBlurMaterial::transformState(CRenderingContext& renderingContext, SState& state, const Vector2D& simulationSize, const SFluidJarGeometryTransform& transform,
+                                           const std::array<float, 4>& wallVelocities) {
     const auto oldSize          = state.simulationSize;
     const auto oldGridSize      = state.gridSize;
     const auto oldParticleCount = state.particleCount;
@@ -327,34 +328,34 @@ void CFluidJarBlurMaterial::transformState(SState& state, const Vector2D& simula
     state.particleCount  = fluidJarResizedParticleCount(oldParticleCount, simulationSize);
 
     const auto particleTarget = state.particles[1 - state.currentParticles];
-    drawResample(state, oldParticles, particleTarget, oldGridSize, oldParticleCount, transform, wallVelocities);
+    drawResample(renderingContext, state, oldParticles, particleTarget, oldGridSize, oldParticleCount, transform, wallVelocities);
     state.currentParticles = 1 - state.currentParticles;
-    drawGraphStep(state);
+    drawGraphStep(renderingContext, state);
 
     if (resized) {
         std::array<SP<CGLFramebuffer>, 2> tracking;
         std::array<SP<CGLFramebuffer>, 2> visual;
         allocateBuffers(tracking, simulationSize, "Fluid jar resized tracking", DRM_FORMAT_ABGR16161616);
         allocateBuffers(visual, simulationSize, "Fluid jar resized visual");
-        clearIntegerBuffers(tracking);
-        clearBuffers(visual, {0.F, 0.F, 0.F, 0.F});
-        drawTrackingResample(oldTracking, tracking[0], oldSize, transform);
-        drawHistoryResample(oldVisual, visual[0], oldSize, transform, {0.F, 0.F, 0.F, 0.F}, true);
+        clearIntegerBuffers(renderingContext, tracking);
+        clearBuffers(renderingContext, visual, {0.F, 0.F, 0.F, 0.F});
+        drawTrackingResample(renderingContext, oldTracking, tracking[0], oldSize, transform);
+        drawHistoryResample(renderingContext, oldVisual, visual[0], oldSize, transform, {0.F, 0.F, 0.F, 0.F}, true);
         state.tracking        = std::move(tracking);
         state.visual          = std::move(visual);
         state.currentTracking = 0;
         state.currentVisual   = 0;
     } else {
-        drawTrackingResample(oldTracking, state.tracking[1 - state.currentTracking], oldSize, transform);
-        drawHistoryResample(oldVisual, state.visual[1 - state.currentVisual], oldSize, transform, {0.F, 0.F, 0.F, 0.F}, true);
+        drawTrackingResample(renderingContext, oldTracking, state.tracking[1 - state.currentTracking], oldSize, transform);
+        drawHistoryResample(renderingContext, oldVisual, state.visual[1 - state.currentVisual], oldSize, transform, {0.F, 0.F, 0.F, 0.F}, true);
         state.currentTracking = 1 - state.currentTracking;
         state.currentVisual   = 1 - state.currentVisual;
     }
 
     if (state.particleCount > 0) {
-        drawTrackingStep(state);
+        drawTrackingStep(renderingContext, state);
         const bool velocityScaleChanged = std::abs(transform.velocityScale.x - 1.0) > 0.001 || std::abs(transform.velocityScale.y - 1.0) > 0.001;
-        drawVisualStep(state, resized || velocityScaleChanged ? INITIAL_VISUAL_STEPS : 1);
+        drawVisualStep(renderingContext, state, resized || velocityScaleChanged ? INITIAL_VISUAL_STEPS : 1);
     }
 }
 
@@ -366,29 +367,29 @@ void CFluidJarBlurMaterial::allocateBuffers(std::array<SP<CGLFramebuffer>, 2>& b
     }
 }
 
-void CFluidJarBlurMaterial::clearIntegerBuffers(const std::array<SP<CGLFramebuffer>, 2>& buffers) const {
+void CFluidJarBlurMaterial::clearIntegerBuffers(CRenderingContext& renderingContext, const std::array<SP<CGLFramebuffer>, 2>& buffers) const {
     constexpr std::array<GLuint, 4> CLEAR_VALUE = {};
     for (const auto& buffer : buffers) {
         buffer->bind();
-        g_pHyprRenderer->disableScissor();
+        g_pHyprRenderer->disableScissor(renderingContext);
         g_pHyprRenderer->blend(false);
         glClearBufferuiv(GL_COLOR, 0, CLEAR_VALUE.data());
     }
 }
 
-void CFluidJarBlurMaterial::clearBuffers(const std::array<SP<CGLFramebuffer>, 2>& buffers, const std::array<float, 4>& color) const {
+void CFluidJarBlurMaterial::clearBuffers(CRenderingContext& renderingContext, const std::array<SP<CGLFramebuffer>, 2>& buffers, const std::array<float, 4>& color) const {
     for (const auto& buffer : buffers) {
         buffer->bind();
         g_pHyprRenderer->setViewport(0, 0, sc<int>(buffer->m_size.x), sc<int>(buffer->m_size.y));
-        g_pHyprRenderer->disableScissor();
+        g_pHyprRenderer->disableScissor(renderingContext);
         glClearColor(color[0], color[1], color[2], color[3]);
         glClear(GL_COLOR_BUFFER_BIT);
     }
 }
 
-void CFluidJarBlurMaterial::drawInitialize(const SState& state, SP<CGLFramebuffer> target) const {
+void CFluidJarBlurMaterial::drawInitialize(CRenderingContext& renderingContext, const SState& state, SP<CGLFramebuffer> target) const {
     const auto shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARINIT));
-    preparePass(target, state.particleTextureSize, shader);
+    preparePass(renderingContext, target, state.particleTextureSize, shader);
     shader->setUniformFloat2(SHADER_FLUIDJAR_RESOLUTION, state.simulationSize.x, state.simulationSize.y);
     shader->setUniformFloat2(SHADER_FLUIDJAR_GRID_SIZE, state.gridSize.x, state.gridSize.y);
     shader->setUniformInt(SHADER_FLUIDJAR_PARTICLE_COUNT, state.particleCount);
@@ -397,13 +398,14 @@ void CFluidJarBlurMaterial::drawInitialize(const SState& state, SP<CGLFramebuffe
     glBindVertexArray(0);
 }
 
-void CFluidJarBlurMaterial::drawResample(const SState& state, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldGridSize, int oldParticleCount,
-                                         const SFluidJarGeometryTransform& transform, const std::array<float, 4>& wallVelocities) const {
+void CFluidJarBlurMaterial::drawResample(CRenderingContext& renderingContext, const SState& state, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target,
+                                         const Vector2D& oldGridSize, int oldParticleCount, const SFluidJarGeometryTransform& transform,
+                                         const std::array<float, 4>& wallVelocities) const {
     static auto PFLUIDMASS = CConfigValue<Config::FLOAT>("decoration:blur:fluid_jar:mass");
 
     bindNearestTexture(source, GL_TEXTURE0);
     const auto shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARRESAMPLE));
-    preparePass(target, state.particleTextureSize, shader);
+    preparePass(renderingContext, target, state.particleTextureSize, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_PARTICLE_TEX, 0);
     shader->setUniformFloat2(SHADER_FLUIDJAR_RESOLUTION, state.simulationSize.x, state.simulationSize.y);
     shader->setUniformFloat2(SHADER_FLUIDJAR_GRID_SIZE, state.gridSize.x, state.gridSize.y);
@@ -419,8 +421,8 @@ void CFluidJarBlurMaterial::drawResample(const SState& state, SP<CGLFramebuffer>
     glBindVertexArray(0);
 }
 
-void CFluidJarBlurMaterial::drawHistoryResample(SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize, const SFluidJarGeometryTransform& transform,
-                                                const std::array<float, 4>& fallback, bool linear) const {
+void CFluidJarBlurMaterial::drawHistoryResample(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize,
+                                                const SFluidJarGeometryTransform& transform, const std::array<float, 4>& fallback, bool linear) const {
     glActiveTexture(GL_TEXTURE0);
     const auto texture = source->getTexture();
     texture->bind();
@@ -430,7 +432,7 @@ void CFluidJarBlurMaterial::drawHistoryResample(SP<CGLFramebuffer> source, SP<CG
     const Vector2D inverseScale  = {1.0 / transform.positionScale.x, 1.0 / transform.positionScale.y};
     const Vector2D inverseOffset = {-transform.positionOffset.x * inverseScale.x, -transform.positionOffset.y * inverseScale.y};
     const auto     shader        = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARHISTORYRESAMPLE));
-    preparePass(target, target->m_size, shader);
+    preparePass(renderingContext, target, target->m_size, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_HISTORY_TEX, 0);
     shader->setUniformFloat2(SHADER_FLUIDJAR_OLD_RESOLUTION, oldSize.x, oldSize.y);
     shader->setUniformFloat4(SHADER_FLUIDJAR_HISTORY_TRANSFORM, inverseScale.x, inverseScale.y, inverseOffset.x, inverseOffset.y);
@@ -440,7 +442,7 @@ void CFluidJarBlurMaterial::drawHistoryResample(SP<CGLFramebuffer> source, SP<CG
     glBindVertexArray(0);
 }
 
-void CFluidJarBlurMaterial::drawParticleStep(SState& state, float dt) const {
+void CFluidJarBlurMaterial::drawParticleStep(CRenderingContext& renderingContext, SState& state, float dt) const {
     static auto PFLUIDMASS = CConfigValue<Config::FLOAT>("decoration:blur:fluid_jar:mass");
 
     const auto  source = state.particles[state.currentParticles];
@@ -448,7 +450,7 @@ void CFluidJarBlurMaterial::drawParticleStep(SState& state, float dt) const {
     bindNearestTexture(source, GL_TEXTURE0);
     bindNearestTexture(state.graph[state.currentGraph], GL_TEXTURE1);
     const auto shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARSTEP));
-    preparePass(target, state.particleTextureSize, shader);
+    preparePass(renderingContext, target, state.particleTextureSize, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_PARTICLE_TEX, 0);
     shader->setUniformInt(SHADER_FLUIDJAR_GRAPH_TEX, 1);
     shader->setUniformFloat2(SHADER_FLUIDJAR_RESOLUTION, state.simulationSize.x, state.simulationSize.y);
@@ -463,12 +465,12 @@ void CFluidJarBlurMaterial::drawParticleStep(SState& state, float dt) const {
     state.currentParticles = 1 - state.currentParticles;
 }
 
-void CFluidJarBlurMaterial::drawGraphStep(SState& state) const {
+void CFluidJarBlurMaterial::drawGraphStep(CRenderingContext& renderingContext, SState& state) const {
     const auto target = state.graph[1 - state.currentGraph];
     bindNearestTexture(state.particles[state.currentParticles], GL_TEXTURE0);
     bindNearestTexture(state.graph[state.currentGraph], GL_TEXTURE1);
     const auto shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARGRAPH));
-    preparePass(target, state.graphTextureSize, shader);
+    preparePass(renderingContext, target, state.graphTextureSize, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_PARTICLE_TEX, 0);
     shader->setUniformInt(SHADER_FLUIDJAR_GRAPH_TEX, 1);
     shader->setUniformFloat2(SHADER_FLUIDJAR_RESOLUTION, state.simulationSize.x, state.simulationSize.y);
@@ -481,13 +483,13 @@ void CFluidJarBlurMaterial::drawGraphStep(SState& state) const {
     state.currentGraph = 1 - state.currentGraph;
 }
 
-void CFluidJarBlurMaterial::drawTrackingStep(SState& state) const {
+void CFluidJarBlurMaterial::drawTrackingStep(CRenderingContext& renderingContext, SState& state) const {
     const auto target = state.tracking[1 - state.currentTracking];
     bindNearestTexture(state.particles[state.currentParticles], GL_TEXTURE0);
     bindNearestTexture(state.graph[state.currentGraph], GL_TEXTURE1);
     bindNearestTexture(state.tracking[state.currentTracking], GL_TEXTURE2);
     const auto shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARTRACK));
-    preparePass(target, state.simulationSize, shader);
+    preparePass(renderingContext, target, state.simulationSize, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_PARTICLE_TEX, 0);
     shader->setUniformInt(SHADER_FLUIDJAR_GRAPH_TEX, 1);
     shader->setUniformInt(SHADER_FLUIDJAR_TRACKING_TEX, 2);
@@ -501,13 +503,14 @@ void CFluidJarBlurMaterial::drawTrackingStep(SState& state) const {
     state.currentTracking = 1 - state.currentTracking;
 }
 
-void CFluidJarBlurMaterial::drawTrackingResample(SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize, const SFluidJarGeometryTransform& transform) const {
+void CFluidJarBlurMaterial::drawTrackingResample(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize,
+                                                 const SFluidJarGeometryTransform& transform) const {
     bindNearestTexture(source, GL_TEXTURE0);
 
     const Vector2D inverseScale  = {1.0 / transform.positionScale.x, 1.0 / transform.positionScale.y};
     const Vector2D inverseOffset = {-transform.positionOffset.x * inverseScale.x, -transform.positionOffset.y * inverseScale.y};
     const auto     shader        = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARTRACKINGRESAMPLE));
-    preparePass(target, target->m_size, shader);
+    preparePass(renderingContext, target, target->m_size, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_HISTORY_TEX, 0);
     shader->setUniformFloat2(SHADER_FLUIDJAR_OLD_RESOLUTION, oldSize.x, oldSize.y);
     shader->setUniformFloat4(SHADER_FLUIDJAR_HISTORY_TRANSFORM, inverseScale.x, inverseScale.y, inverseOffset.x, inverseOffset.y);
@@ -516,14 +519,14 @@ void CFluidJarBlurMaterial::drawTrackingResample(SP<CGLFramebuffer> source, SP<C
     glBindVertexArray(0);
 }
 
-void CFluidJarBlurMaterial::drawVisualStep(SState& state, int steps) const {
+void CFluidJarBlurMaterial::drawVisualStep(CRenderingContext& renderingContext, SState& state, int steps) const {
     const auto target = state.visual[1 - state.currentVisual];
     bindNearestTexture(state.particles[state.currentParticles], GL_TEXTURE0);
     bindNearestTexture(state.graph[state.currentGraph], GL_TEXTURE1);
     bindNearestTexture(state.tracking[state.currentTracking], GL_TEXTURE2);
     bindNearestTexture(state.visual[state.currentVisual], GL_TEXTURE3);
     const auto shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_FLUIDJARVISUAL));
-    preparePass(target, state.simulationSize, shader);
+    preparePass(renderingContext, target, state.simulationSize, shader);
     shader->setUniformInt(SHADER_FLUIDJAR_PARTICLE_TEX, 0);
     shader->setUniformInt(SHADER_FLUIDJAR_GRAPH_TEX, 1);
     shader->setUniformInt(SHADER_FLUIDJAR_TRACKING_TEX, 2);
@@ -539,18 +542,18 @@ void CFluidJarBlurMaterial::drawVisualStep(SState& state, int steps) const {
     glActiveTexture(GL_TEXTURE0);
 }
 
-void CFluidJarBlurMaterial::preparePass(SP<CGLFramebuffer> target, const Vector2D& size, WP<CShader> shader) const {
+void CFluidJarBlurMaterial::preparePass(CRenderingContext& renderingContext, SP<CGLFramebuffer> target, const Vector2D& size, WP<CShader> shader) const {
     target->bind();
     g_pHyprRenderer->setViewport(0, 0, sc<int>(size.x), sc<int>(size.y));
-    g_pHyprRenderer->disableScissor();
+    g_pHyprRenderer->disableScissor(renderingContext);
     g_pHyprRenderer->blend(false);
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
-    const auto matrix  = g_pHyprRenderer->projectBoxToTarget({0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y});
+    const auto monitor = renderingContext.sceneMonitor;
+    const auto matrix  = g_pHyprRenderer->projectBoxToTarget(renderingContext, {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y});
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, matrix.getMatrix());
 }
 
-CBox CFluidJarBlurMaterial::transformedPatternBox(const SBlurContext& context) const {
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
+CBox CFluidJarBlurMaterial::transformedPatternBox(const CRenderingContext& renderingContext, const SBlurContext& context) const {
+    const auto monitor = renderingContext.sceneMonitor;
     if (!monitor)
         return {};
 

--- a/src/render/gl/blur/FluidJar.hpp
+++ b/src/render/gl/blur/FluidJar.hpp
@@ -65,24 +65,26 @@ namespace Render::GL {
 
         SState*       stateForContext(const SBlurContext& context, bool create);
         const SState* stateForContext(const SBlurContext& context) const;
-        void          updateState(SState& state, const CBox& extent);
-        void          initializeState(SState& state, const Vector2D& simulationSize, float fillAmount, float precision);
-        void          transformState(SState& state, const Vector2D& simulationSize, const SFluidJarGeometryTransform& transform, const std::array<float, 4>& wallVelocities);
+        void          updateState(CRenderingContext& renderingContext, SState& state, const CBox& extent);
+        void          initializeState(CRenderingContext& renderingContext, SState& state, const Vector2D& simulationSize, float fillAmount, float precision);
+        void          transformState(CRenderingContext& renderingContext, SState& state, const Vector2D& simulationSize, const SFluidJarGeometryTransform& transform,
+                                     const std::array<float, 4>& wallVelocities);
         void          allocateBuffers(std::array<SP<CGLFramebuffer>, 2>& buffers, const Vector2D& size, const std::string& name, DRMFormat format = DRM_FORMAT_ABGR16161616F) const;
-        void          clearBuffers(const std::array<SP<CGLFramebuffer>, 2>& buffers, const std::array<float, 4>& color) const;
-        void          clearIntegerBuffers(const std::array<SP<CGLFramebuffer>, 2>& buffers) const;
-        void          drawInitialize(const SState& state, SP<CGLFramebuffer> target) const;
-        void          drawResample(const SState& state, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldGridSize, int oldParticleCount,
-                                   const SFluidJarGeometryTransform& transform, const std::array<float, 4>& wallVelocities) const;
-        void          drawHistoryResample(SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize, const SFluidJarGeometryTransform& transform,
-                                          const std::array<float, 4>& fallback, bool linear) const;
-        void          drawParticleStep(SState& state, float dt) const;
-        void          drawGraphStep(SState& state) const;
-        void          drawTrackingStep(SState& state) const;
-        void          drawTrackingResample(SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize, const SFluidJarGeometryTransform& transform) const;
-        void          drawVisualStep(SState& state, int steps = 1) const;
-        void          preparePass(SP<CGLFramebuffer> target, const Vector2D& size, WP<CShader> shader) const;
-        CBox          transformedPatternBox(const SBlurContext& context) const;
+        void          clearBuffers(CRenderingContext& renderingContext, const std::array<SP<CGLFramebuffer>, 2>& buffers, const std::array<float, 4>& color) const;
+        void          clearIntegerBuffers(CRenderingContext& renderingContext, const std::array<SP<CGLFramebuffer>, 2>& buffers) const;
+        void          drawInitialize(CRenderingContext& renderingContext, const SState& state, SP<CGLFramebuffer> target) const;
+        void          drawResample(CRenderingContext& renderingContext, const SState& state, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldGridSize,
+                                   int oldParticleCount, const SFluidJarGeometryTransform& transform, const std::array<float, 4>& wallVelocities) const;
+        void          drawHistoryResample(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize,
+                                          const SFluidJarGeometryTransform& transform, const std::array<float, 4>& fallback, bool linear) const;
+        void          drawParticleStep(CRenderingContext& renderingContext, SState& state, float dt) const;
+        void          drawGraphStep(CRenderingContext& renderingContext, SState& state) const;
+        void          drawTrackingStep(CRenderingContext& renderingContext, SState& state) const;
+        void          drawTrackingResample(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, SP<CGLFramebuffer> target, const Vector2D& oldSize,
+                                           const SFluidJarGeometryTransform& transform) const;
+        void          drawVisualStep(CRenderingContext& renderingContext, SState& state, int steps = 1) const;
+        void          preparePass(CRenderingContext& renderingContext, SP<CGLFramebuffer> target, const Vector2D& size, WP<CShader> shader) const;
+        CBox          transformedPatternBox(const CRenderingContext& renderingContext, const SBlurContext& context) const;
         void          scheduleNextFrame(const SState& state) const;
         void          pruneStates();
 

--- a/src/render/gl/blur/HeatShimmer.cpp
+++ b/src/render/gl/blur/HeatShimmer.cpp
@@ -29,7 +29,7 @@ CHeatShimmerBlurProvider::CHeatShimmerBlurProvider(CHyprOpenGLImpl& impl) : CGla
     ;
 }
 
-bool CHeatShimmerBlurMaterial::isAnimated() const noexcept {
+bool CHeatShimmerBlurMaterial::isAnimated(const CRenderingContext&) const noexcept {
     static auto PBLURENABLED     = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
     static auto PGLASSREFRACTION = CConfigValue<Config::FLOAT>("decoration:blur:glass:refraction");
     static auto PGLASSROUGHNESS  = CConfigValue<Config::FLOAT>("decoration:blur:glass:roughness");

--- a/src/render/gl/blur/HeatShimmer.hpp
+++ b/src/render/gl/blur/HeatShimmer.hpp
@@ -10,7 +10,7 @@ namespace Render::GL {
       public:
         CHeatShimmerBlurMaterial();
 
-        bool isAnimated() const noexcept override;
+        bool isAnimated(const CRenderingContext&) const noexcept override;
         void bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const override;
 
       private:

--- a/src/render/gl/blur/Kawase.cpp
+++ b/src/render/gl/blur/Kawase.cpp
@@ -11,11 +11,11 @@ using namespace Render;
 using namespace Render::GL;
 using namespace NColorManagement;
 
-static SCMSettings blurIntermediateCMSettings(bool toIntermediate) {
-    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription();
+static SCMSettings blurIntermediateCMSettings(const CRenderingContext& context, bool toIntermediate) {
+    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription(context);
     const auto INTERMEDIATE = getDefaultImageDescription();
 
-    auto       settings = toIntermediate ? g_pHyprRenderer->getCMSettings(WORKBUFFER, INTERMEDIATE) : g_pHyprRenderer->getCMSettings(INTERMEDIATE, WORKBUFFER);
+    auto       settings = toIntermediate ? g_pHyprRenderer->getCMSettings(context, WORKBUFFER, INTERMEDIATE) : g_pHyprRenderer->getCMSettings(context, INTERMEDIATE, WORKBUFFER);
     auto&      range    = toIntermediate ? settings.dstTFRange : settings.srcTFRange;
     range.max           = std::max(range.max, sc<float>(WORKBUFFER->value().luminances.max));
     return settings;
@@ -34,8 +34,8 @@ eBlurType CDualKawaseBlurProvider::type() const noexcept {
     return m_material->type();
 }
 
-bool CDualKawaseBlurProvider::isAnimated() const noexcept {
-    return m_material->isAnimated();
+bool CDualKawaseBlurProvider::isAnimated(const CRenderingContext& context) const noexcept {
+    return m_material->isAnimated(context);
 }
 
 bool CDualKawaseBlurProvider::requiresLiveBlur() const noexcept {
@@ -59,17 +59,17 @@ float CDualKawaseBlurProvider::damageRadius() const {
     return dualKawaseDamageRadius(m_material->blurSizeForDamage(*PBLURSIZE), *PBLURPASSES) + m_material->sampleRadius();
 }
 
-SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context) {
+SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, float strength, const CRegion& originalDamage,
+                                                   const SBlurContext& blurContext) {
     TRACY_GPU_ZONE("RenderBlurFramebufferWithDamage");
-    auto&      m_renderData = g_pHyprRenderer->m_renderData;
 
     const auto BLENDBEFORE = m_impl.m_blend;
     m_impl.blend(false);
     m_impl.setCapStatus(GL_STENCIL_TEST, false);
 
-    CBox                       MONITORBOX = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+    CBox                       MONITORBOX = {0, 0, renderingContext.sceneMonitor->m_transformedSize.x, renderingContext.sceneMonitor->m_transformedSize.y};
 
-    const auto&                glMatrix = g_pHyprRenderer->projectBoxToTarget(MONITORBOX);
+    const auto&                glMatrix = g_pHyprRenderer->projectBoxToTarget(renderingContext, MONITORBOX);
 
     static auto                PBLURSIZE             = CConfigValue<Config::INTEGER>("decoration:blur:size");
     static auto                PBLURPASSES           = CConfigValue<Config::INTEGER>("decoration:blur:passes");
@@ -81,9 +81,10 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
     CRegion                    outputDamage{originalDamage};
 
     const SBlurMaterialContext materialContext{
-        .blurContext  = context,
-        .outputDamage = outputDamage,
-        .strength     = strength,
+        .renderingContext = renderingContext,
+        .blurContext      = blurContext,
+        .outputDamage     = outputDamage,
+        .strength         = strength,
     };
     m_material->prepare(materialContext);
 
@@ -93,11 +94,11 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
     const auto MATERIAL_REQUIREMENTS   = m_material->requirements();
     const bool REQUIRES_PREPARED_INPUT = MATERIAL_REQUIREMENTS.preparedInput;
 
-    const auto PMIRRORFB     = dynamicPointerCast<CGLFramebuffer>(m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
-    const auto PMIRRORSWAPFB = dynamicPointerCast<CGLFramebuffer>(m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
+    const auto PMIRRORFB     = dynamicPointerCast<CGLFramebuffer>(renderingContext.sceneMonitor->resources()->getUnusedWorkBuffer());
+    const auto PMIRRORSWAPFB = dynamicPointerCast<CGLFramebuffer>(renderingContext.sceneMonitor->resources()->getUnusedWorkBuffer());
     RASSERT(PMIRRORFB && PMIRRORSWAPFB, "Failed to obtain GL work buffers for dual Kawase blur");
 
-    const auto PPREPAREDFB = REQUIRES_PREPARED_INPUT ? dynamicPointerCast<CGLFramebuffer>(m_renderData.pMonitor->resources()->getUnusedWorkBuffer()) : PMIRRORSWAPFB;
+    const auto PPREPAREDFB = REQUIRES_PREPARED_INPUT ? dynamicPointerCast<CGLFramebuffer>(renderingContext.sceneMonitor->resources()->getUnusedWorkBuffer()) : PMIRRORSWAPFB;
     RASSERT(PPREPAREDFB, "Failed to obtain GL prepared work buffer for dual Kawase blur");
 
     auto currentRenderToFB = PMIRRORFB;
@@ -121,21 +122,21 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
 
         WP<CShader> shader;
 
-        const bool  skipCM = !m_impl.m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+        const bool  skipCM = !m_impl.m_cmSupported || !g_pHyprRenderer->workBufferImageDescription(renderingContext)->needsCM(getDefaultImageDescription());
         if (!skipCM) {
-            const auto settings = blurIntermediateCMSettings(/* toIntermediate */ true);
+            const auto settings = blurIntermediateCMSettings(renderingContext, /* toIntermediate */ true);
             shader              = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_BLURPREPARE, SH_FEAT_CM, settings.sourceTF, settings.targetTF));
 
-            m_impl.passCMUniforms(shader, g_pHyprRenderer->workBufferImageDescription(), getDefaultImageDescription(), false, -1.F, -1, settings);
+            m_impl.passCMUniforms(renderingContext, shader, g_pHyprRenderer->workBufferImageDescription(renderingContext), getDefaultImageDescription(), false, -1.F, -1, settings);
             shader->setUniformFloat(SHADER_SDR_SATURATION,
-                                    m_renderData.pMonitor->m_sdrSaturation > 0 &&
-                                            g_pHyprRenderer->workBufferImageDescription()->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                                        m_renderData.pMonitor->m_sdrSaturation :
+                                    renderingContext.sceneMonitor->m_sdrSaturation > 0 &&
+                                            g_pHyprRenderer->workBufferImageDescription(renderingContext)->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                                        renderingContext.sceneMonitor->m_sdrSaturation :
                                         1.0f);
             shader->setUniformFloat(SHADER_SDR_BRIGHTNESS,
-                                    m_renderData.pMonitor->m_sdrBrightness > 0 &&
-                                            g_pHyprRenderer->workBufferImageDescription()->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                                        m_renderData.pMonitor->m_sdrBrightness :
+                                    renderingContext.sceneMonitor->m_sdrBrightness > 0 &&
+                                            g_pHyprRenderer->workBufferImageDescription(renderingContext)->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                                        renderingContext.sceneMonitor->m_sdrBrightness :
                                         1.0f);
         } else
             shader = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_BLURPREPARE));
@@ -148,8 +149,8 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
         glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
         if (!workingDamage.empty()) {
-            workingDamage.forEachRect([this](const auto& RECT) {
-                m_impl.scissor(&RECT, false);
+            workingDamage.forEachRect([this, &renderingContext](const auto& RECT) {
+                m_impl.scissor(renderingContext, &RECT, false);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
@@ -174,19 +175,21 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
         shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
         shader->setUniformFloat(SHADER_RADIUS, *PBLURSIZE * strength);
         if (frag == SH_FRAG_BLUR1) {
-            shader->setUniformFloat2(SHADER_HALFPIXEL, 0.5f / (m_renderData.pMonitor->m_transformedSize.x / 2.f), 0.5f / (m_renderData.pMonitor->m_transformedSize.y / 2.f));
+            shader->setUniformFloat2(SHADER_HALFPIXEL, 0.5f / (renderingContext.sceneMonitor->m_transformedSize.x / 2.f),
+                                     0.5f / (renderingContext.sceneMonitor->m_transformedSize.y / 2.f));
             shader->setUniformInt(SHADER_PASSES, BLUR_PASSES);
             shader->setUniformFloat(SHADER_VIBRANCY, *PBLURVIBRANCY);
             shader->setUniformFloat(SHADER_VIBRANCY_DARKNESS, *PBLURVIBRANCYDARKNESS);
         } else
-            shader->setUniformFloat2(SHADER_HALFPIXEL, 0.5f / (m_renderData.pMonitor->m_transformedSize.x * 2.f), 0.5f / (m_renderData.pMonitor->m_transformedSize.y * 2.f));
+            shader->setUniformFloat2(SHADER_HALFPIXEL, 0.5f / (renderingContext.sceneMonitor->m_transformedSize.x * 2.f),
+                                     0.5f / (renderingContext.sceneMonitor->m_transformedSize.y * 2.f));
         shader->setUniformInt(SHADER_TEX, 0);
 
         glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
         if (!passDamage->empty()) {
-            passDamage->forEachRect([this](const auto& RECT) {
-                m_impl.scissor(&RECT, false);
+            passDamage->forEachRect([this, &renderingContext](const auto& RECT) {
+                m_impl.scissor(renderingContext, &RECT, false);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }
@@ -241,21 +244,21 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
             m_impl.setActiveTexture(GL_TEXTURE0);
         }
 
-        const bool skipCM = !m_impl.m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+        const bool skipCM = !m_impl.m_cmSupported || !g_pHyprRenderer->workBufferImageDescription(renderingContext)->needsCM(getDefaultImageDescription());
         if (!skipCM) {
-            const auto settings = blurIntermediateCMSettings(/* toIntermediate */ false);
+            const auto settings = blurIntermediateCMSettings(renderingContext, /* toIntermediate */ false);
             shader              = m_impl.useShader(m_impl.getShaderVariant(MATERIAL_REQUIREMENTS.finishFragment, SH_FEAT_CM, settings.sourceTF, settings.targetTF));
 
-            m_impl.passCMUniforms(shader, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(), false, -1.F, -1, settings);
+            m_impl.passCMUniforms(renderingContext, shader, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(renderingContext), false, -1.F, -1, settings);
             shader->setUniformFloat(SHADER_SDR_SATURATION,
-                                    m_renderData.pMonitor->m_sdrSaturation > 0 &&
-                                            g_pHyprRenderer->workBufferImageDescription()->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                                        m_renderData.pMonitor->m_sdrSaturation :
+                                    renderingContext.sceneMonitor->m_sdrSaturation > 0 &&
+                                            g_pHyprRenderer->workBufferImageDescription(renderingContext)->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                                        renderingContext.sceneMonitor->m_sdrSaturation :
                                         1.0f);
             shader->setUniformFloat(SHADER_SDR_BRIGHTNESS,
-                                    m_renderData.pMonitor->m_sdrBrightness > 0 &&
-                                            g_pHyprRenderer->workBufferImageDescription()->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                                        m_renderData.pMonitor->m_sdrBrightness :
+                                    renderingContext.sceneMonitor->m_sdrBrightness > 0 &&
+                                            g_pHyprRenderer->workBufferImageDescription(renderingContext)->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                                        renderingContext.sceneMonitor->m_sdrBrightness :
                                         1.0f);
         } else
             shader = m_impl.useShader(m_impl.getShaderVariant(MATERIAL_REQUIREMENTS.finishFragment));
@@ -271,8 +274,8 @@ SP<CGLFramebuffer> CDualKawaseBlurProvider::blurGL(SP<CGLFramebuffer> source, fl
         glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_VAO));
 
         if (!outputDamage.empty()) {
-            outputDamage.forEachRect([this](const auto& RECT) {
-                m_impl.scissor(&RECT, false /* this region is already transformed */);
+            outputDamage.forEachRect([this, &renderingContext](const auto& RECT) {
+                m_impl.scissor(renderingContext, &RECT, false /* this region is already transformed */);
                 glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
             });
         }

--- a/src/render/gl/blur/Kawase.hpp
+++ b/src/render/gl/blur/Kawase.hpp
@@ -12,12 +12,13 @@ namespace Render::GL {
         CDualKawaseBlurProvider(CHyprOpenGLImpl& impl, UP<IGLBlurMaterial> material);
 
         eBlurType type() const noexcept override;
-        bool      isAnimated() const noexcept override;
+        bool      isAnimated(const CRenderingContext& context) const noexcept override;
         bool      requiresLiveBlur() const noexcept override;
         void      expandDamage(CRegion& damage, float multiplier = 1.F) const override;
 
       protected:
-        SP<CGLFramebuffer> blurGL(SP<CGLFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context) override;
+        SP<CGLFramebuffer> blurGL(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, float strength, const CRegion& originalDamage,
+                                  const SBlurContext& blurContext) override;
 
       private:
         float               damageRadius() const;

--- a/src/render/gl/blur/Material.cpp
+++ b/src/render/gl/blur/Material.cpp
@@ -7,7 +7,7 @@
 using namespace Render;
 using namespace Render::GL;
 
-bool IGLBlurMaterial::isAnimated() const noexcept {
+bool IGLBlurMaterial::isAnimated(const CRenderingContext&) const noexcept {
     return false;
 }
 

--- a/src/render/gl/blur/Material.hpp
+++ b/src/render/gl/blur/Material.hpp
@@ -15,6 +15,7 @@ namespace Render::GL {
     };
 
     struct SBlurMaterialContext {
+        CRenderingContext&  renderingContext;
         const SBlurContext& blurContext;
         const CRegion&      outputDamage;
         float               strength = 1.F;
@@ -26,7 +27,7 @@ namespace Render::GL {
 
         virtual eBlurType                 type() const noexcept         = 0;
         virtual SBlurMaterialRequirements requirements() const noexcept = 0;
-        virtual bool                      isAnimated() const noexcept;
+        virtual bool                      isAnimated(const CRenderingContext& context) const noexcept;
         virtual int64_t                   blurSizeForDamage(int64_t size) const;
         virtual float                     sampleRadius() const;
         virtual void                      prepare(const SBlurMaterialContext& context);

--- a/src/render/gl/blur/Provider.cpp
+++ b/src/render/gl/blur/Provider.cpp
@@ -6,8 +6,9 @@
 using namespace Render;
 using namespace Render::GL;
 
-SP<IFramebuffer> IGLBlurProvider::blur(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context) {
+SP<IFramebuffer> IGLBlurProvider::blur(CRenderingContext& renderingContext, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                                       const SBlurContext& blurContext) {
     const auto glSource = dynamicPointerCast<CGLFramebuffer>(source);
     RASSERT(glSource, "Tried to use a GL blur provider with a non-GL framebuffer");
-    return blurGL(glSource, strength, originalDamage, context);
+    return blurGL(renderingContext, glSource, strength, originalDamage, blurContext);
 }

--- a/src/render/gl/blur/Provider.hpp
+++ b/src/render/gl/blur/Provider.hpp
@@ -7,11 +7,13 @@ namespace Render::GL {
 
     class IGLBlurProvider : public Render::IBlurProvider {
       public:
-        SP<IFramebuffer> blur(SP<IFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context = {}) final;
+        SP<IFramebuffer> blur(CRenderingContext& renderingContext, SP<IFramebuffer> source, float strength, const CRegion& originalDamage,
+                              const SBlurContext& blurContext = {}) final;
 
       protected:
         IGLBlurProvider() = default;
 
-        virtual SP<CGLFramebuffer> blurGL(SP<CGLFramebuffer> source, float strength, const CRegion& originalDamage, const SBlurContext& context) = 0;
+        virtual SP<CGLFramebuffer> blurGL(CRenderingContext& renderingContext, SP<CGLFramebuffer> source, float strength, const CRegion& originalDamage,
+                                          const SBlurContext& blurContext) = 0;
     };
 }

--- a/src/render/gl/blur/Ripple.cpp
+++ b/src/render/gl/blur/Ripple.cpp
@@ -106,16 +106,16 @@ void CRippleBlurMaterial::addImpulse() {
     damageImpulse(impulse);
 }
 
-bool CRippleBlurMaterial::isAnimated() const noexcept {
+bool CRippleBlurMaterial::isAnimated(const CRenderingContext& context) const noexcept {
     static auto PRIPPLESTRENGTH = CConfigValue<Config::FLOAT>("decoration:blur:ripple:strength");
     static auto PRIPPLEDURATION = CConfigValue<Config::FLOAT>("decoration:blur:ripple:duration");
     static auto PBLURENABLED    = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
 
-    if (!*PBLURENABLED || *PRIPPLESTRENGTH <= 0.F || *PRIPPLEDURATION <= 0.F || !g_pHyprRenderer->m_renderData.pMonitor)
+    if (!*PBLURENABLED || *PRIPPLESTRENGTH <= 0.F || *PRIPPLEDURATION <= 0.F || !context.sceneMonitor)
         return false;
 
     const auto now = Time::steadyNow();
-    return std::ranges::any_of(m_impulses, [&](const auto& impulse) { return impulseIsActive(impulse, g_pHyprRenderer->m_renderData.pMonitor, now, *PRIPPLEDURATION); });
+    return std::ranges::any_of(m_impulses, [&](const auto& impulse) { return impulseIsActive(impulse, context.sceneMonitor, now, *PRIPPLEDURATION); });
 }
 
 SBlurMaterialRequirements CRippleBlurMaterial::requirements() const noexcept {
@@ -130,7 +130,7 @@ void CRippleBlurMaterial::bindFinish(WP<CShader> shader, const SBlurMaterialCont
     static auto        PRIPPLEWIDTH    = CConfigValue<Config::FLOAT>("decoration:blur:ripple:width");
     static auto        PRIPPLEDURATION = CConfigValue<Config::FLOAT>("decoration:blur:ripple:duration");
 
-    const auto         monitor  = g_pHyprRenderer->m_renderData.pMonitor;
+    const auto         monitor  = context.renderingContext.sceneMonitor;
     const auto         now      = Time::steadyNow();
     const auto         duration = std::max(*PRIPPLEDURATION, 0.001F);
 

--- a/src/render/gl/blur/Ripple.hpp
+++ b/src/render/gl/blur/Ripple.hpp
@@ -15,7 +15,7 @@ namespace Render::GL {
 
         eBlurType                 type() const noexcept override;
         SBlurMaterialRequirements requirements() const noexcept override;
-        bool                      isAnimated() const noexcept override;
+        bool                      isAnimated(const CRenderingContext& context) const noexcept override;
         float                     sampleRadius() const override;
         void                      bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const override;
 

--- a/src/render/gl/blur/Water.cpp
+++ b/src/render/gl/blur/Water.cpp
@@ -74,7 +74,7 @@ eBlurType CWaterBlurMaterial::type() const noexcept {
     return eBlurType::BLUR_WATER;
 }
 
-bool CWaterBlurMaterial::isAnimated() const noexcept {
+bool CWaterBlurMaterial::isAnimated(const CRenderingContext& context) const noexcept {
     static auto PBLURENABLED   = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
     static auto PWATERSTRENGTH = CConfigValue<Config::FLOAT>("decoration:blur:water:strength");
 
@@ -83,7 +83,7 @@ bool CWaterBlurMaterial::isAnimated() const noexcept {
 
     pruneStates();
 
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
+    const auto monitor = context.sceneMonitor;
     if (!monitor)
         return false;
 
@@ -101,25 +101,25 @@ SBlurMaterialRequirements CWaterBlurMaterial::requirements() const noexcept {
 void CWaterBlurMaterial::prepare(const SBlurMaterialContext& context) {
     pruneStates();
 
-    const auto state = stateForContext(context.blurContext, false);
-    if (!state || !g_pHyprRenderer->m_renderData.pMonitor)
+    const auto state = stateForContext(context.renderingContext, context.blurContext, false);
+    if (!state || !context.renderingContext.sceneMonitor)
         return;
 
-    const auto extent = transformedPatternBox(context.blurContext);
-    state->monitor    = g_pHyprRenderer->m_renderData.pMonitor;
-    updateState(*state, extent);
+    const auto extent = transformedPatternBox(context.renderingContext, context.blurContext);
+    state->monitor    = context.renderingContext.sceneMonitor;
+    updateState(context.renderingContext, *state, extent);
 }
 
 void CWaterBlurMaterial::bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const {
     static auto PWATERSTRENGTH = CConfigValue<Config::FLOAT>("decoration:blur:water:strength");
 
-    const auto  state = stateForContext(context.blurContext);
+    const auto  state = stateForContext(context.renderingContext, context.blurContext);
     if (!state || !state->buffers[state->currentBuffer]) {
         shader->setUniformInt(SHADER_WATER_ENABLED, 0);
         return;
     }
 
-    const auto extent = transformedPatternBox(context.blurContext);
+    const auto extent = transformedPatternBox(context.renderingContext, context.blurContext);
     if (extent.width <= 0 || extent.height <= 0) {
         shader->setUniformInt(SHADER_WATER_ENABLED, 0);
         return;
@@ -147,20 +147,20 @@ float CWaterBlurMaterial::sampleRadius() const {
     return std::ceil(std::clamp(*PWATERSTRENGTH, 0.F, MAX_WATER_DISPLACEMENT));
 }
 
-CWaterBlurMaterial::SState* CWaterBlurMaterial::stateForContext(const SBlurContext& context, bool create) {
+CWaterBlurMaterial::SState* CWaterBlurMaterial::stateForContext(const CRenderingContext& renderingContext, const SBlurContext& context, bool create) {
     if (!context.owner.expired())
         return windowState(context.owner, create);
 
-    return monitorState(g_pHyprRenderer->m_renderData.pMonitor, create);
+    return monitorState(renderingContext.sceneMonitor, create);
 }
 
-const CWaterBlurMaterial::SState* CWaterBlurMaterial::stateForContext(const SBlurContext& context) const {
+const CWaterBlurMaterial::SState* CWaterBlurMaterial::stateForContext(const CRenderingContext& renderingContext, const SBlurContext& context) const {
     if (!context.owner.expired()) {
         const auto state = std::ranges::find_if(m_windowStates, [&](const auto& candidate) { return candidate.window == context.owner; });
         return state != m_windowStates.end() ? &*state : nullptr;
     }
 
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
+    const auto monitor = renderingContext.sceneMonitor;
     const auto state   = std::ranges::find_if(m_monitorStates, [&](const auto& candidate) { return candidate.monitor == monitor; });
     return state != m_monitorStates.end() ? &*state : nullptr;
 }
@@ -246,7 +246,7 @@ void CWaterBlurMaterial::queueImpulse(SState& state, Vector2D position, float ra
     state.activeUntil   = Time::steadyNow() + std::chrono::duration_cast<Time::steady_dur>(std::chrono::duration<float>(duration));
 }
 
-void CWaterBlurMaterial::updateState(SState& state, const CBox& extent) {
+void CWaterBlurMaterial::updateState(CRenderingContext& renderingContext, SState& state, const CBox& extent) {
     const auto now = Time::steadyNow();
     if (!stateIsActive(state, now) || state.lastFrame == m_frame)
         return;
@@ -257,22 +257,22 @@ void CWaterBlurMaterial::updateState(SState& state, const CBox& extent) {
     };
 
     if (state.reset || state.simulationSize != simulationSize)
-        resetState(state, simulationSize);
+        resetState(renderingContext, state, simulationSize);
 
     const auto dt = state.lastUpdate == Time::steady_tp{} ? 1.F / 60.F : std::clamp(sc<float>(std::chrono::duration<float>(now - state.lastUpdate).count()), 0.F, 1.F / 20.F);
-    drawStateStep(state, dt, extent);
+    drawStateStep(renderingContext, state, dt, extent);
     state.lastUpdate = now;
     state.lastFrame  = m_frame;
 }
 
-void CWaterBlurMaterial::resetState(SState& state, const Vector2D& simulationSize) {
+void CWaterBlurMaterial::resetState(CRenderingContext& renderingContext, SState& state, const Vector2D& simulationSize) {
     for (auto& buffer : state.buffers) {
         if (!buffer)
             buffer = dynamicPointerCast<CGLFramebuffer>(g_pHyprRenderer->createFB("Water simulation"));
 
         buffer->alloc(sc<int>(simulationSize.x), sc<int>(simulationSize.y), DRM_FORMAT_ARGB8888);
         buffer->bind();
-        g_pHyprRenderer->disableScissor();
+        g_pHyprRenderer->disableScissor(renderingContext);
         glClearColor(0.5F, 0.5F, 0.F, 1.F);
         glClear(GL_COLOR_BUFFER_BIT);
     }
@@ -283,7 +283,7 @@ void CWaterBlurMaterial::resetState(SState& state, const Vector2D& simulationSiz
     state.reset          = false;
 }
 
-void CWaterBlurMaterial::drawStateStep(SState& state, float dt, const CBox& extent) {
+void CWaterBlurMaterial::drawStateStep(CRenderingContext& renderingContext, SState& state, float dt, const CBox& extent) {
     static auto PWATERSPEED   = CConfigValue<Config::FLOAT>("decoration:blur:water:speed");
     static auto PWATERDAMPING = CConfigValue<Config::FLOAT>("decoration:blur:water:damping");
 
@@ -291,7 +291,7 @@ void CWaterBlurMaterial::drawStateStep(SState& state, float dt, const CBox& exte
     const auto  target = state.buffers[1 - state.currentBuffer];
     target->bind();
     g_pHyprRenderer->setViewport(0, 0, sc<int>(state.simulationSize.x), sc<int>(state.simulationSize.y));
-    g_pHyprRenderer->disableScissor();
+    g_pHyprRenderer->disableScissor(renderingContext);
 
     glActiveTexture(GL_TEXTURE0);
     const auto texture = source->getTexture();
@@ -299,8 +299,8 @@ void CWaterBlurMaterial::drawStateStep(SState& state, float dt, const CBox& exte
     texture->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     texture->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
-    const auto matrix  = g_pHyprRenderer->projectBoxToTarget({0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y});
+    const auto monitor = renderingContext.sceneMonitor;
+    const auto matrix  = g_pHyprRenderer->projectBoxToTarget(renderingContext, {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y});
     const auto shader  = m_impl.useShader(m_impl.getShaderVariant(SH_FRAG_WATERSTEP));
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, matrix.getMatrix());
     shader->setUniformInt(SHADER_WATER_STATE_TEX, 0);
@@ -325,8 +325,8 @@ void CWaterBlurMaterial::drawStateStep(SState& state, float dt, const CBox& exte
     state.currentBuffer = 1 - state.currentBuffer;
 }
 
-CBox CWaterBlurMaterial::transformedPatternBox(const SBlurContext& context) const {
-    const auto monitor = g_pHyprRenderer->m_renderData.pMonitor;
+CBox CWaterBlurMaterial::transformedPatternBox(const CRenderingContext& renderingContext, const SBlurContext& context) const {
+    const auto monitor = renderingContext.sceneMonitor;
     if (!monitor)
         return {};
 

--- a/src/render/gl/blur/Water.hpp
+++ b/src/render/gl/blur/Water.hpp
@@ -16,7 +16,7 @@ namespace Render::GL {
 
         eBlurType                 type() const noexcept override;
         SBlurMaterialRequirements requirements() const noexcept override;
-        bool                      isAnimated() const noexcept override;
+        bool                      isAnimated(const CRenderingContext& context) const noexcept override;
         float                     sampleRadius() const override;
         void                      prepare(const SBlurMaterialContext& context) override;
         void                      bindFinish(WP<CShader> shader, const SBlurMaterialContext& context) const override;
@@ -43,16 +43,16 @@ namespace Render::GL {
             bool                  reset         = true;
         };
 
-        SState*                     stateForContext(const SBlurContext& context, bool create);
-        const SState*               stateForContext(const SBlurContext& context) const;
+        SState*                     stateForContext(const CRenderingContext& renderingContext, const SBlurContext& context, bool create);
+        const SState*               stateForContext(const CRenderingContext& renderingContext, const SBlurContext& context) const;
         SState*                     windowState(PHLWINDOWREF window, bool create);
         SState*                     monitorState(PHLMONITORREF monitor, bool create);
         void                        addImpulse();
         void                        queueImpulse(SState& state, Vector2D position, float radius, float amplitude);
-        void                        updateState(SState& state, const CBox& extent);
-        void                        resetState(SState& state, const Vector2D& simulationSize);
-        void                        drawStateStep(SState& state, float dt, const CBox& extent);
-        CBox                        transformedPatternBox(const SBlurContext& context) const;
+        void                        updateState(CRenderingContext& renderingContext, SState& state, const CBox& extent);
+        void                        resetState(CRenderingContext& renderingContext, SState& state, const Vector2D& simulationSize);
+        void                        drawStateStep(CRenderingContext& renderingContext, SState& state, float dt, const CBox& extent);
+        CBox                        transformedPatternBox(const CRenderingContext& renderingContext, const SBlurContext& context) const;
         bool                        stateIsActive(const SState& state, const Time::steady_tp& now) const;
         void                        pruneStates() const;
 

--- a/src/render/pass/BackdropScopePassElement.cpp
+++ b/src/render/pass/BackdropScopePassElement.cpp
@@ -31,23 +31,23 @@ CBackdropScopePassElement::CBackdropScopePassElement(eAction action, SP<SBackdro
     ;
 }
 
-std::vector<UP<IPassElement>> CBackdropScopePassElement::draw() {
+std::vector<UP<IPassElement>> CBackdropScopePassElement::draw(Render::CRenderingContext& context) {
     if (!m_scope->required)
         return {};
 
     if (m_action == eAction::BEGIN)
-        g_pHyprRenderer->beginBackdropScope(m_scope);
+        g_pHyprRenderer->beginBackdropScope(context, m_scope);
     else
-        g_pHyprRenderer->endBackdropScope(m_scope);
+        g_pHyprRenderer->endBackdropScope(context, m_scope);
 
     return {};
 }
 
-bool CBackdropScopePassElement::needsLiveBlur() {
+bool CBackdropScopePassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CBackdropScopePassElement::needsPrecomputeBlur() {
+bool CBackdropScopePassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }
 

--- a/src/render/pass/BackdropScopePassElement.hpp
+++ b/src/render/pass/BackdropScopePassElement.hpp
@@ -28,9 +28,9 @@ class CBackdropScopePassElement : public IPassElement {
     CBackdropScopePassElement(eAction action, SP<SBackdropScope> scope);
     virtual ~CBackdropScopePassElement() = default;
 
-    virtual std::vector<UP<IPassElement>> draw();
-    virtual bool                          needsLiveBlur();
-    virtual bool                          needsPrecomputeBlur();
+    virtual std::vector<UP<IPassElement>> draw(Render::CRenderingContext& context);
+    virtual bool                          needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool                          needsPrecomputeBlur(const Render::CRenderingContext&);
     virtual bool                          undiscardable();
 
     virtual const char*                   passName();

--- a/src/render/pass/BorderPassElement.cpp
+++ b/src/render/pass/BorderPassElement.cpp
@@ -4,10 +4,10 @@ CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& da
     ;
 }
 
-bool CBorderPassElement::needsLiveBlur() {
+bool CBorderPassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CBorderPassElement::needsPrecomputeBlur() {
+bool CBorderPassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }

--- a/src/render/pass/BorderPassElement.hpp
+++ b/src/render/pass/BorderPassElement.hpp
@@ -17,8 +17,8 @@ class CBorderPassElement : public IPassElement {
     CBorderPassElement(const SBorderData& data_);
     virtual ~CBorderPassElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
 
     virtual const char* passName() {
         return "CBorderPassElement";

--- a/src/render/pass/BoxShadowPassElement.cpp
+++ b/src/render/pass/BoxShadowPassElement.cpp
@@ -1,0 +1,13 @@
+#include "BoxShadowPassElement.hpp"
+#include "../Renderer.hpp"
+
+CBoxShadowPassElement::CBoxShadowPassElement(const SBoxShadowData& data) : CShadowPassElement(SShadowData{}), m_boxData(data) {
+    ;
+}
+
+std::optional<CBox> CBoxShadowPassElement::boundingBox(const Render::CRenderingContext& context) {
+    if (!context.sceneMonitor)
+        return std::nullopt;
+
+    return m_boxData.box.copy().scale(1.F / context.sceneMonitor->m_scale).round();
+}

--- a/src/render/pass/BoxShadowPassElement.hpp
+++ b/src/render/pass/BoxShadowPassElement.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "ShadowPassElement.hpp"
+
+class CBoxShadowPassElement : public CShadowPassElement {
+  public:
+    struct SBoxShadowData {
+        CBox       box;
+        CBox       cutoutBox;
+        CBox       clipBox;
+        CHyprColor color;
+        float      a             = 1.F;
+        int        round         = 0;
+        float      roundingPower = 2.F;
+        int        range         = 0;
+    };
+
+    CBoxShadowPassElement(const SBoxShadowData& data);
+    virtual ~CBoxShadowPassElement() = default;
+
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context);
+
+    virtual const char*         passName() {
+        return "CBoxShadowPassElement";
+    }
+
+    SBoxShadowData m_boxData;
+};

--- a/src/render/pass/ClearPassElement.cpp
+++ b/src/render/pass/ClearPassElement.cpp
@@ -4,18 +4,18 @@ CClearPassElement::CClearPassElement(const CClearPassElement::SClearData& data_)
     ;
 }
 
-bool CClearPassElement::needsLiveBlur() {
+bool CClearPassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CClearPassElement::needsPrecomputeBlur() {
+bool CClearPassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-std::optional<CBox> CClearPassElement::boundingBox() {
+std::optional<CBox> CClearPassElement::boundingBox(const Render::CRenderingContext&) {
     return CBox{{}, {INT16_MAX, INT16_MAX}};
 }
 
-CRegion CClearPassElement::opaqueRegion() {
-    return *boundingBox();
+CRegion CClearPassElement::opaqueRegion(const Render::CRenderingContext& context) {
+    return *boundingBox(context);
 }

--- a/src/render/pass/ClearPassElement.hpp
+++ b/src/render/pass/ClearPassElement.hpp
@@ -10,10 +10,10 @@ class CClearPassElement : public IPassElement {
     CClearPassElement(const SClearData& data);
     virtual ~CClearPassElement() = default;
 
-    virtual bool                needsLiveBlur();
-    virtual bool                needsPrecomputeBlur();
-    virtual std::optional<CBox> boundingBox();
-    virtual CRegion             opaqueRegion();
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&);
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context);
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
 
     virtual const char*         passName() {
         return "CClearPassElement";

--- a/src/render/pass/FramebufferElement.cpp
+++ b/src/render/pass/FramebufferElement.cpp
@@ -4,11 +4,11 @@ CFramebufferElement::CFramebufferElement(const CFramebufferElement::SFramebuffer
     ;
 }
 
-bool CFramebufferElement::needsLiveBlur() {
+bool CFramebufferElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CFramebufferElement::needsPrecomputeBlur() {
+bool CFramebufferElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }
 

--- a/src/render/pass/FramebufferElement.hpp
+++ b/src/render/pass/FramebufferElement.hpp
@@ -11,8 +11,8 @@ class CFramebufferElement : public IPassElement {
     CFramebufferElement(const SFramebufferElementData& data_);
     virtual ~CFramebufferElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
     virtual bool        undiscardable();
 
     virtual const char* passName() {

--- a/src/render/pass/InnerGlowPassElement.cpp
+++ b/src/render/pass/InnerGlowPassElement.cpp
@@ -4,10 +4,10 @@ CInnerGlowPassElement::CInnerGlowPassElement(const CInnerGlowPassElement::SInner
     ;
 }
 
-bool CInnerGlowPassElement::needsLiveBlur() {
+bool CInnerGlowPassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CInnerGlowPassElement::needsPrecomputeBlur() {
+bool CInnerGlowPassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }

--- a/src/render/pass/InnerGlowPassElement.hpp
+++ b/src/render/pass/InnerGlowPassElement.hpp
@@ -13,8 +13,8 @@ class CInnerGlowPassElement : public IPassElement {
     CInnerGlowPassElement(const SInnerGlowData& data_);
     virtual ~CInnerGlowPassElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
 
     virtual const char* passName() {
         return "CInnerGlowPassElement";

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -25,20 +25,20 @@ bool CRenderPass::single() const {
     return m_passElements.size() == 1;
 }
 
-bool CRenderPass::needsLiveBlur() {
-    return std::ranges::any_of(m_passElements, [](const auto& el) { return el.element->needsLiveBlur(); });
+bool CRenderPass::needsLiveBlur(const CRenderingContext& context) {
+    return std::ranges::any_of(m_passElements, [&context](const auto& el) { return el.element->needsLiveBlur(context); });
 }
 
-bool CRenderPass::needsPrecomputeBlur() {
-    return std::ranges::any_of(m_passElements, [](const auto& el) { return el.element->needsPrecomputeBlur(); });
+bool CRenderPass::needsPrecomputeBlur(const CRenderingContext& context) {
+    return std::ranges::any_of(m_passElements, [&context](const auto& el) { return el.element->needsPrecomputeBlur(context); });
 }
 
 void CRenderPass::add(UP<IPassElement>&& el) {
     m_passElements.emplace_back(SPassElementData{.element = std::move(el)});
 }
 
-void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
-    const auto  pMonitor   = g_pHyprRenderer->m_renderData.pMonitor;
+void CRenderPass::simplify(CRenderingContext& context, bool willBlur, const CRegion& liveBlurRegion) {
+    const auto  pMonitor   = context.sceneMonitor;
     static auto PDEBUGPASS = CConfigValue<Config::INTEGER>("debug:pass");
 
     // TODO: use precompute blur for instances where there is nothing in between
@@ -51,7 +51,7 @@ void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
             continue;
         }
 
-        auto bb1 = el.element->boundingBox();
+        auto bb1 = el.element->boundingBox(context);
         if (!bb1 || newDamage.empty()) {
             el.elementDamage = newDamage;
             continue;
@@ -67,7 +67,7 @@ void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
 
         el.elementDamage = newDamage;
 
-        auto opaque = el.element->opaqueRegion();
+        auto opaque = el.element->opaqueRegion(context);
 
         if (!opaque.empty()) {
             // scale and rounding is very particular so we have to use CBoxes scale and round functions
@@ -101,7 +101,7 @@ void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
             if (!el2.element->needsLiveBlurCached)
                 continue;
 
-            const auto BB = el2.element->boundingBox();
+            const auto BB = el2.element->boundingBox(context);
             RASSERT(BB, "No bounding box for an element with live blur is illegal");
 
             m_totalLiveBlurRegion.add(BB->copy().scale(pMonitor->m_scale));
@@ -113,9 +113,9 @@ void CRenderPass::clear() {
     m_passElements.clear();
 }
 
-void CRenderPass::planBackdropScopes() {
+void CRenderPass::planBackdropScopes(const CRenderingContext& context) {
     CBackdropScopePlanner planner;
-    const CBox            bounds = {{}, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize};
+    const CBox            bounds = {{}, context.sceneMonitor->m_transformedSize};
 
     for (auto& el : m_passElements) {
         if (el.element->type() != EK_BACKDROP_SCOPE) {
@@ -137,20 +137,20 @@ void CRenderPass::planBackdropScopes() {
     RASSERT(planner.empty(), "Unclosed backdrop scope marker");
 }
 
-CRegion CRenderPass::render(const CRegion& damage_) {
-    const auto  pMonitor   = g_pHyprRenderer->m_renderData.pMonitor;
+CRegion CRenderPass::render(CRenderingContext& context, const CRegion& damage_) {
+    const auto  pMonitor   = context.sceneMonitor;
     static auto PDEBUGPASS = CConfigValue<Config::INTEGER>("debug:pass");
 
     // single pass: cache blur results and gather aggregate info
     bool    willBlur = false, willDisableSimplification = false, willPrecomputeBlur = false, requiresFullDamage = false;
     CRegion blurRegion;
     for (auto& el : m_passElements) {
-        el.element->needsLiveBlurCached       = el.element->needsLiveBlur();
-        el.element->needsPrecomputeBlurCached = el.element->needsPrecomputeBlur();
+        el.element->needsLiveBlurCached       = el.element->needsLiveBlur(context);
+        el.element->needsPrecomputeBlurCached = el.element->needsPrecomputeBlur(context);
 
         if (el.element->needsLiveBlurCached) {
             willBlur      = true;
-            const auto BB = el.element->boundingBox();
+            const auto BB = el.element->boundingBox(context);
             RASSERT(BB, "No bounding box for an element with live blur is illegal");
             blurRegion.add(*BB);
         }
@@ -171,9 +171,16 @@ CRegion CRenderPass::render(const CRegion& damage_) {
         m_totalLiveBlurRegion = CRegion{};
     }
 
+    context.precomputeBlur               = willPrecomputeBlur;
+    const auto UPDATE_MONITOR_BLUR_STATE = [&context] {
+        if (context.updatesMonitorBlurState && context.sceneMonitor)
+            context.sceneMonitor->m_blurFBShouldRender = context.precomputeBlur;
+    };
+
     if (m_damage.empty()) {
-        g_pHyprRenderer->m_renderData.damage      = m_damage;
-        g_pHyprRenderer->m_renderData.finalDamage = m_damage;
+        context.damage      = m_damage;
+        context.finalDamage = m_damage;
+        UPDATE_MONITOR_BLUR_STATE();
         return m_damage;
     }
 
@@ -198,7 +205,7 @@ CRegion CRenderPass::render(const CRegion& damage_) {
         blurRegion.intersect(m_damage);
         g_pHyprRenderer->expandBlurDamage(blurRegion);
 
-        g_pHyprRenderer->m_renderData.finalDamage = blurRegion.copy().add(m_damage);
+        context.finalDamage = blurRegion.copy().add(m_damage);
 
         // FIXME: why does this break on * 1.F ?
         // used to work when we expand all the damage... I think? Well, before pass.
@@ -207,45 +214,44 @@ CRegion CRenderPass::render(const CRegion& damage_) {
 
         m_damage = blurRegion.copy().add(m_damage);
     } else
-        g_pHyprRenderer->m_renderData.finalDamage = m_damage;
+        context.finalDamage = m_damage;
 
-    if (g_pHyprRenderer->m_renderData.noSimplify || willDisableSimplification) {
+    if (context.noSimplify || willDisableSimplification) {
         for (auto& el : m_passElements) {
             el.elementDamage = m_damage;
         }
     } else
-        simplify(willBlur, liveBlurRegion);
+        simplify(context, willBlur, liveBlurRegion);
 
-    planBackdropScopes();
+    planBackdropScopes(context);
 
-    if (g_pHyprRenderer->m_renderData.pMonitor)
-        g_pHyprRenderer->m_renderData.pMonitor->m_blurFBShouldRender = willPrecomputeBlur;
-
-    if (m_passElements.empty())
+    if (m_passElements.empty()) {
+        UPDATE_MONITOR_BLUR_STATE();
         return {};
+    }
 
-    const bool providerIsAnimated = g_pHyprRenderer->blurProviderIsAnimated();
+    const bool providerIsAnimated = g_pHyprRenderer->blurProviderIsAnimated(context);
     CRegion    animatedBlurDamage;
     bool       usesPrecomputedBlur = false;
 
     for (auto& el : m_passElements) {
         if (el.discard) {
-            el.element->discard();
+            el.element->discard(context);
             continue;
         }
 
-        g_pHyprRenderer->m_renderData.damage = el.elementDamage;
-        g_pHyprRenderer->draw(el.element, el.elementDamage);
+        context.damage = el.elementDamage;
+        g_pHyprRenderer->draw(context, el.element, el.elementDamage);
 
         if (!providerIsAnimated || (!el.element->needsLiveBlurCached && !el.element->needsPrecomputeBlurCached))
             continue;
 
-        const auto BB = el.element->boundingBox();
+        const auto BB = el.element->boundingBox(context);
         if (!BB)
             animatedBlurDamage.add(CBox{{}, pMonitor->m_transformedSize});
         else {
             auto box = BB->copy().scale(pMonitor->m_scale);
-            g_pHyprRenderer->m_renderData.renderModif.applyToBox(box);
+            context.renderModif.applyToBox(box);
             animatedBlurDamage.add(box);
         }
 
@@ -253,10 +259,10 @@ CRegion CRenderPass::render(const CRegion& damage_) {
     }
 
     animatedBlurDamage.intersect(CBox{{}, pMonitor->m_transformedSize});
-    g_pHyprRenderer->scheduleFrameForAnimatedBlur(animatedBlurDamage, usesPrecomputedBlur);
+    g_pHyprRenderer->scheduleFrameForAnimatedBlur(context, animatedBlurDamage, usesPrecomputedBlur);
 
     if (*PDEBUGPASS) {
-        renderDebugData();
+        renderDebugData(context);
         g_pEventLoopManager->doLater([] {
             for (auto& m : State::monitorState()->monitors()) {
                 g_pHyprRenderer->damageMonitor(m);
@@ -264,23 +270,24 @@ CRegion CRenderPass::render(const CRegion& damage_) {
         });
     }
 
-    g_pHyprRenderer->m_renderData.damage = m_damage;
+    context.damage = m_damage;
+    UPDATE_MONITOR_BLUR_STATE();
     return m_damage;
 }
 
-void CRenderPass::renderDebugData() {
-    const auto pMonitor = g_pHyprRenderer->m_renderData.pMonitor;
+void CRenderPass::renderDebugData(CRenderingContext& context) {
+    const auto pMonitor = context.sceneMonitor;
     CBox       box      = {{}, pMonitor->m_transformedSize};
     for (const auto& rg : m_occludedRegions) {
-        g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = Colors::RED.modifyA(0.1F)}, rg);
+        g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = Colors::RED.modifyA(0.1F)}), rg);
     }
 
-    g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = Colors::GREEN.modifyA(0.1F)}, m_totalLiveBlurRegion);
+    g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = Colors::GREEN.modifyA(0.1F)}), m_totalLiveBlurRegion);
 
     std::unordered_map<CWLSurfaceResource*, float> offsets;
 
     // render focus stuff
-    auto renderHLSurface = [&offsets, pMonitor, this](SP<ITexture> texture, SP<CWLSurfaceResource> surface, const CHyprColor& color) {
+    auto renderHLSurface = [&context, &offsets, pMonitor, this](SP<ITexture> texture, SP<CWLSurfaceResource> surface, const CHyprColor& color) {
         if (!surface || !texture)
             return;
 
@@ -298,7 +305,7 @@ void CRenderPass::renderDebugData() {
         if (box.intersection(CBox{{}, pMonitor->m_size}).empty())
             return;
 
-        g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = color}, m_damage);
+        g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = color}), m_damage);
 
         if (offsets.contains(surface.get()))
             box.translate(Vector2D{0.F, offsets[surface.get()]});
@@ -307,15 +314,15 @@ void CRenderPass::renderDebugData() {
 
         box = {box.pos(), texture->m_size};
 
-        g_pHyprRenderer->draw(
-            CRectPassElement::SRectData{
-                .box   = box,
-                .color = color,
-                .round = std::min(5.0, box.size().y),
-            },
-            m_damage);
+        g_pHyprRenderer->draw(context,
+                              makeUnique<CRectPassElement>(CRectPassElement::SRectData{
+                                  .box   = box,
+                                  .color = color,
+                                  .round = std::min(5.0, box.size().y),
+                              }),
+                              m_damage);
 
-        g_pHyprRenderer->draw(CTexPassElement::SRenderData{.tex = texture, .box = box}, m_damage);
+        g_pHyprRenderer->draw(context, makeUnique<CTexPassElement>(CTexPassElement::SRenderData{.tex = texture, .box = box}), m_damage);
 
         offsets[surface.get()] += texture->m_size.y;
     };
@@ -331,7 +338,7 @@ void CRenderPass::renderDebugData() {
             if (hlSurface) {
                 auto BOX = hlSurface->getSurfaceBoxGlobal();
                 if (BOX) {
-                    g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}}, m_damage);
+                    g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}}), m_damage);
                 }
             }
         }
@@ -343,19 +350,19 @@ void CRenderPass::renderDebugData() {
                                            Colors::WHITE, 12);
 
     if (tex)
-        g_pHyprRenderer->draw(
-            CTexPassElement::SRenderData{
-                .tex = tex,
-                .box = CBox{{0.F, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
-            },
-            m_damage);
+        g_pHyprRenderer->draw(context,
+                              makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
+                                  .tex = tex,
+                                  .box = CBox{{0.F, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
+                              }),
+                              m_damage);
 
     std::string passStructure;
     auto        yn   = [](const bool val) -> const char* { return val ? "yes" : "no"; };
     auto        tick = [](const bool val) -> const char* { return val ? "✔" : "✖"; };
     for (const auto& el : m_passElements | std::views::reverse) {
-        passStructure += std::format("{} {} (bb: {} op: {}, pb: {}, lb: {})\n", tick(!el.discard), el.element->passName(), yn(el.element->boundingBox().has_value()),
-                                     yn(!el.element->opaqueRegion().empty()), yn(el.element->needsPrecomputeBlurCached), yn(el.element->needsLiveBlurCached));
+        passStructure += std::format("{} {} (bb: {} op: {}, pb: {}, lb: {})\n", tick(!el.discard), el.element->passName(), yn(el.element->boundingBox(context).has_value()),
+                                     yn(!el.element->opaqueRegion(context).empty()), yn(el.element->needsPrecomputeBlurCached), yn(el.element->needsLiveBlurCached));
     }
 
     if (!passStructure.empty())
@@ -363,12 +370,12 @@ void CRenderPass::renderDebugData() {
 
     tex = g_pHyprRenderer->renderText(passStructure, Colors::WHITE, 12);
     if (tex)
-        g_pHyprRenderer->draw(
-            CTexPassElement::SRenderData{
-                .tex = tex,
-                .box = CBox{{pMonitor->m_size.x - tex->m_size.x, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
-            },
-            m_damage);
+        g_pHyprRenderer->draw(context,
+                              makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
+                                  .tex = tex,
+                                  .box = CBox{{pMonitor->m_size.x - tex->m_size.x, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
+                              }),
+                              m_damage);
 }
 
 void CRenderPass::removeAllOfType(const std::string& type) {

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -25,20 +25,20 @@ bool CRenderPass::single() const {
     return m_passElements.size() == 1;
 }
 
-bool CRenderPass::needsLiveBlur() {
-    return std::ranges::any_of(m_passElements, [](const auto& el) { return el.element->needsLiveBlur(); });
+bool CRenderPass::needsLiveBlur(const CRenderingContext& context) {
+    return std::ranges::any_of(m_passElements, [&context](const auto& el) { return el.element->needsLiveBlur(context); });
 }
 
-bool CRenderPass::needsPrecomputeBlur() {
-    return std::ranges::any_of(m_passElements, [](const auto& el) { return el.element->needsPrecomputeBlur(); });
+bool CRenderPass::needsPrecomputeBlur(const CRenderingContext& context) {
+    return std::ranges::any_of(m_passElements, [&context](const auto& el) { return el.element->needsPrecomputeBlur(context); });
 }
 
 void CRenderPass::add(UP<IPassElement>&& el) {
     m_passElements.emplace_back(SPassElementData{.element = std::move(el)});
 }
 
-void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
-    const auto  pMonitor   = g_pHyprRenderer->m_renderData.pMonitor;
+void CRenderPass::simplify(CRenderingContext& context, bool willBlur, const CRegion& liveBlurRegion) {
+    const auto  pMonitor   = context.sceneMonitor;
     static auto PDEBUGPASS = CConfigValue<Config::INTEGER>("debug:pass");
 
     // TODO: use precompute blur for instances where there is nothing in between
@@ -51,7 +51,7 @@ void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
             continue;
         }
 
-        auto bb1 = el.element->boundingBox();
+        auto bb1 = el.element->boundingBox(context);
         if (!bb1 || newDamage.empty()) {
             el.elementDamage = newDamage;
             continue;
@@ -67,7 +67,7 @@ void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
 
         el.elementDamage = newDamage;
 
-        auto opaque = el.element->opaqueRegion();
+        auto opaque = el.element->opaqueRegion(context);
 
         if (!opaque.empty()) {
             // scale and rounding is very particular so we have to use CBoxes scale and round functions
@@ -101,7 +101,7 @@ void CRenderPass::simplify(bool willBlur, const CRegion& liveBlurRegion) {
             if (!el2.element->needsLiveBlurCached)
                 continue;
 
-            const auto BB = el2.element->boundingBox();
+            const auto BB = el2.element->boundingBox(context);
             RASSERT(BB, "No bounding box for an element with live blur is illegal");
 
             m_totalLiveBlurRegion.add(BB->copy().scale(pMonitor->m_scale));
@@ -113,9 +113,9 @@ void CRenderPass::clear() {
     m_passElements.clear();
 }
 
-void CRenderPass::planBackdropScopes() {
+void CRenderPass::planBackdropScopes(const CRenderingContext& context) {
     CBackdropScopePlanner planner;
-    const CBox            bounds = {{}, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize};
+    const CBox            bounds = {{}, context.sceneMonitor->m_transformedSize};
 
     for (auto& el : m_passElements) {
         if (el.element->type() != EK_BACKDROP_SCOPE) {
@@ -137,20 +137,20 @@ void CRenderPass::planBackdropScopes() {
     RASSERT(planner.empty(), "Unclosed backdrop scope marker");
 }
 
-CRegion CRenderPass::render(const CRegion& damage_) {
-    const auto  pMonitor   = g_pHyprRenderer->m_renderData.pMonitor;
+CRegion CRenderPass::render(CRenderingContext& context, const CRegion& damage_) {
+    const auto  pMonitor   = context.sceneMonitor;
     static auto PDEBUGPASS = CConfigValue<Config::INTEGER>("debug:pass");
 
     // single pass: cache blur results and gather aggregate info
     bool    willBlur = false, willDisableSimplification = false, willPrecomputeBlur = false;
     CRegion blurRegion;
     for (auto& el : m_passElements) {
-        el.element->needsLiveBlurCached       = el.element->needsLiveBlur();
-        el.element->needsPrecomputeBlurCached = el.element->needsPrecomputeBlur();
+        el.element->needsLiveBlurCached       = el.element->needsLiveBlur(context);
+        el.element->needsPrecomputeBlurCached = el.element->needsPrecomputeBlur(context);
 
         if (el.element->needsLiveBlurCached) {
             willBlur      = true;
-            const auto BB = el.element->boundingBox();
+            const auto BB = el.element->boundingBox(context);
             RASSERT(BB, "No bounding box for an element with live blur is illegal");
             blurRegion.add(*BB);
         }
@@ -168,9 +168,16 @@ CRegion CRenderPass::render(const CRegion& damage_) {
         m_totalLiveBlurRegion = CRegion{};
     }
 
+    context.precomputeBlur               = willPrecomputeBlur;
+    const auto UPDATE_MONITOR_BLUR_STATE = [&context] {
+        if (context.updatesMonitorBlurState && context.sceneMonitor)
+            context.sceneMonitor->m_blurFBShouldRender = context.precomputeBlur;
+    };
+
     if (m_damage.empty()) {
-        g_pHyprRenderer->m_renderData.damage      = m_damage;
-        g_pHyprRenderer->m_renderData.finalDamage = m_damage;
+        context.damage      = m_damage;
+        context.finalDamage = m_damage;
+        UPDATE_MONITOR_BLUR_STATE();
         return m_damage;
     }
 
@@ -195,7 +202,7 @@ CRegion CRenderPass::render(const CRegion& damage_) {
         blurRegion.intersect(m_damage);
         g_pHyprRenderer->expandBlurDamage(blurRegion);
 
-        g_pHyprRenderer->m_renderData.finalDamage = blurRegion.copy().add(m_damage);
+        context.finalDamage = blurRegion.copy().add(m_damage);
 
         // FIXME: why does this break on * 1.F ?
         // used to work when we expand all the damage... I think? Well, before pass.
@@ -204,45 +211,44 @@ CRegion CRenderPass::render(const CRegion& damage_) {
 
         m_damage = blurRegion.copy().add(m_damage);
     } else
-        g_pHyprRenderer->m_renderData.finalDamage = m_damage;
+        context.finalDamage = m_damage;
 
-    if (g_pHyprRenderer->m_renderData.noSimplify || willDisableSimplification) {
+    if (context.noSimplify || willDisableSimplification) {
         for (auto& el : m_passElements) {
             el.elementDamage = m_damage;
         }
     } else
-        simplify(willBlur, liveBlurRegion);
+        simplify(context, willBlur, liveBlurRegion);
 
-    planBackdropScopes();
+    planBackdropScopes(context);
 
-    if (g_pHyprRenderer->m_renderData.pMonitor)
-        g_pHyprRenderer->m_renderData.pMonitor->m_blurFBShouldRender = willPrecomputeBlur;
-
-    if (m_passElements.empty())
+    if (m_passElements.empty()) {
+        UPDATE_MONITOR_BLUR_STATE();
         return {};
+    }
 
-    const bool providerIsAnimated = g_pHyprRenderer->blurProviderIsAnimated();
+    const bool providerIsAnimated = g_pHyprRenderer->blurProviderIsAnimated(context);
     CRegion    animatedBlurDamage;
     bool       usesPrecomputedBlur = false;
 
     for (auto& el : m_passElements) {
         if (el.discard) {
-            el.element->discard();
+            el.element->discard(context);
             continue;
         }
 
-        g_pHyprRenderer->m_renderData.damage = el.elementDamage;
-        g_pHyprRenderer->draw(el.element, el.elementDamage);
+        context.damage = el.elementDamage;
+        g_pHyprRenderer->draw(context, el.element, el.elementDamage);
 
         if (!providerIsAnimated || (!el.element->needsLiveBlurCached && !el.element->needsPrecomputeBlurCached))
             continue;
 
-        const auto BB = el.element->boundingBox();
+        const auto BB = el.element->boundingBox(context);
         if (!BB)
             animatedBlurDamage.add(CBox{{}, pMonitor->m_transformedSize});
         else {
             auto box = BB->copy().scale(pMonitor->m_scale);
-            g_pHyprRenderer->m_renderData.renderModif.applyToBox(box);
+            context.renderModif.applyToBox(box);
             animatedBlurDamage.add(box);
         }
 
@@ -250,10 +256,10 @@ CRegion CRenderPass::render(const CRegion& damage_) {
     }
 
     animatedBlurDamage.intersect(CBox{{}, pMonitor->m_transformedSize});
-    g_pHyprRenderer->scheduleFrameForAnimatedBlur(animatedBlurDamage, usesPrecomputedBlur);
+    g_pHyprRenderer->scheduleFrameForAnimatedBlur(context, animatedBlurDamage, usesPrecomputedBlur);
 
     if (*PDEBUGPASS) {
-        renderDebugData();
+        renderDebugData(context);
         g_pEventLoopManager->doLater([] {
             for (auto& m : State::monitorState()->monitors()) {
                 g_pHyprRenderer->damageMonitor(m);
@@ -261,23 +267,24 @@ CRegion CRenderPass::render(const CRegion& damage_) {
         });
     }
 
-    g_pHyprRenderer->m_renderData.damage = m_damage;
+    context.damage = m_damage;
+    UPDATE_MONITOR_BLUR_STATE();
     return m_damage;
 }
 
-void CRenderPass::renderDebugData() {
-    const auto pMonitor = g_pHyprRenderer->m_renderData.pMonitor;
+void CRenderPass::renderDebugData(CRenderingContext& context) {
+    const auto pMonitor = context.sceneMonitor;
     CBox       box      = {{}, pMonitor->m_transformedSize};
     for (const auto& rg : m_occludedRegions) {
-        g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = Colors::RED.modifyA(0.1F)}, rg);
+        g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = Colors::RED.modifyA(0.1F)}), rg);
     }
 
-    g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = Colors::GREEN.modifyA(0.1F)}, m_totalLiveBlurRegion);
+    g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = Colors::GREEN.modifyA(0.1F)}), m_totalLiveBlurRegion);
 
     std::unordered_map<CWLSurfaceResource*, float> offsets;
 
     // render focus stuff
-    auto renderHLSurface = [&offsets, pMonitor, this](SP<ITexture> texture, SP<CWLSurfaceResource> surface, const CHyprColor& color) {
+    auto renderHLSurface = [&context, &offsets, pMonitor, this](SP<ITexture> texture, SP<CWLSurfaceResource> surface, const CHyprColor& color) {
         if (!surface || !texture)
             return;
 
@@ -295,7 +302,7 @@ void CRenderPass::renderDebugData() {
         if (box.intersection(CBox{{}, pMonitor->m_size}).empty())
             return;
 
-        g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = color}, m_damage);
+        g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = color}), m_damage);
 
         if (offsets.contains(surface.get()))
             box.translate(Vector2D{0.F, offsets[surface.get()]});
@@ -304,15 +311,15 @@ void CRenderPass::renderDebugData() {
 
         box = {box.pos(), texture->m_size};
 
-        g_pHyprRenderer->draw(
-            CRectPassElement::SRectData{
-                .box   = box,
-                .color = color,
-                .round = std::min(5.0, box.size().y),
-            },
-            m_damage);
+        g_pHyprRenderer->draw(context,
+                              makeUnique<CRectPassElement>(CRectPassElement::SRectData{
+                                  .box   = box,
+                                  .color = color,
+                                  .round = std::min(5.0, box.size().y),
+                              }),
+                              m_damage);
 
-        g_pHyprRenderer->draw(CTexPassElement::SRenderData{.tex = texture, .box = box}, m_damage);
+        g_pHyprRenderer->draw(context, makeUnique<CTexPassElement>(CTexPassElement::SRenderData{.tex = texture, .box = box}), m_damage);
 
         offsets[surface.get()] += texture->m_size.y;
     };
@@ -328,7 +335,7 @@ void CRenderPass::renderDebugData() {
             if (hlSurface) {
                 auto BOX = hlSurface->getSurfaceBoxGlobal();
                 if (BOX) {
-                    g_pHyprRenderer->draw(CRectPassElement::SRectData{.box = box, .color = CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}}, m_damage);
+                    g_pHyprRenderer->draw(context, makeUnique<CRectPassElement>(CRectPassElement::SRectData{.box = box, .color = CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}}), m_damage);
                 }
             }
         }
@@ -340,19 +347,19 @@ void CRenderPass::renderDebugData() {
                                            Colors::WHITE, 12);
 
     if (tex)
-        g_pHyprRenderer->draw(
-            CTexPassElement::SRenderData{
-                .tex = tex,
-                .box = CBox{{0.F, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
-            },
-            m_damage);
+        g_pHyprRenderer->draw(context,
+                              makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
+                                  .tex = tex,
+                                  .box = CBox{{0.F, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
+                              }),
+                              m_damage);
 
     std::string passStructure;
     auto        yn   = [](const bool val) -> const char* { return val ? "yes" : "no"; };
     auto        tick = [](const bool val) -> const char* { return val ? "✔" : "✖"; };
     for (const auto& el : m_passElements | std::views::reverse) {
-        passStructure += std::format("{} {} (bb: {} op: {}, pb: {}, lb: {})\n", tick(!el.discard), el.element->passName(), yn(el.element->boundingBox().has_value()),
-                                     yn(!el.element->opaqueRegion().empty()), yn(el.element->needsPrecomputeBlurCached), yn(el.element->needsLiveBlurCached));
+        passStructure += std::format("{} {} (bb: {} op: {}, pb: {}, lb: {})\n", tick(!el.discard), el.element->passName(), yn(el.element->boundingBox(context).has_value()),
+                                     yn(!el.element->opaqueRegion(context).empty()), yn(el.element->needsPrecomputeBlurCached), yn(el.element->needsLiveBlurCached));
     }
 
     if (!passStructure.empty())
@@ -360,12 +367,12 @@ void CRenderPass::renderDebugData() {
 
     tex = g_pHyprRenderer->renderText(passStructure, Colors::WHITE, 12);
     if (tex)
-        g_pHyprRenderer->draw(
-            CTexPassElement::SRenderData{
-                .tex = tex,
-                .box = CBox{{pMonitor->m_size.x - tex->m_size.x, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
-            },
-            m_damage);
+        g_pHyprRenderer->draw(context,
+                              makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
+                                  .tex = tex,
+                                  .box = CBox{{pMonitor->m_size.x - tex->m_size.x, pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(pMonitor->m_scale),
+                              }),
+                              m_damage);
 }
 
 void CRenderPass::removeAllOfType(const std::string& type) {

--- a/src/render/pass/Pass.hpp
+++ b/src/render/pass/Pass.hpp
@@ -7,19 +7,20 @@ class CGradientValueData;
 
 namespace Render {
     class ITexture;
+    class CRenderingContext;
 
     class CRenderPass {
       public:
         bool    empty() const;
         bool    single() const;
-        bool    needsLiveBlur();
-        bool    needsPrecomputeBlur();
+        bool    needsLiveBlur(const CRenderingContext& context);
+        bool    needsPrecomputeBlur(const CRenderingContext& context);
 
         void    add(UP<IPassElement>&& elem);
         void    clear();
         void    removeAllOfType(const std::string& type);
 
-        CRegion render(const CRegion& damage_);
+        CRegion render(CRenderingContext& context, const CRegion& damage_);
 
       private:
         CRegion              m_damage;
@@ -34,9 +35,9 @@ namespace Render {
 
         std::vector<SPassElementData> m_passElements;
 
-        void                          simplify(bool willBlur, const CRegion& liveBlurRegion);
-        void                          planBackdropScopes();
-        void                          renderDebugData();
+        void                          simplify(CRenderingContext& context, bool willBlur, const CRegion& liveBlurRegion);
+        void                          planBackdropScopes(const CRenderingContext& context);
+        void                          renderDebugData(CRenderingContext& context);
 
         struct {
             bool         present = false;

--- a/src/render/pass/PassElement.cpp
+++ b/src/render/pass/PassElement.cpp
@@ -1,10 +1,10 @@
 #include "PassElement.hpp"
 
-std::optional<CBox> IPassElement::boundingBox() {
+std::optional<CBox> IPassElement::boundingBox(const Render::CRenderingContext&) {
     return std::nullopt;
 }
 
-CRegion IPassElement::opaqueRegion() {
+CRegion IPassElement::opaqueRegion(const Render::CRenderingContext&) {
     return {};
 }
 
@@ -16,7 +16,7 @@ bool IPassElement::requiresFullDamage() {
     return false;
 }
 
-void IPassElement::discard() {
+void IPassElement::discard(Render::CRenderingContext&) {
     ;
 }
 
@@ -24,6 +24,6 @@ bool IPassElement::undiscardable() {
     return false;
 }
 
-std::vector<UP<IPassElement>> IPassElement::draw() {
+std::vector<UP<IPassElement>> IPassElement::draw(Render::CRenderingContext&) {
     return {};
 }

--- a/src/render/pass/PassElement.cpp
+++ b/src/render/pass/PassElement.cpp
@@ -1,10 +1,10 @@
 #include "PassElement.hpp"
 
-std::optional<CBox> IPassElement::boundingBox() {
+std::optional<CBox> IPassElement::boundingBox(const Render::CRenderingContext&) {
     return std::nullopt;
 }
 
-CRegion IPassElement::opaqueRegion() {
+CRegion IPassElement::opaqueRegion(const Render::CRenderingContext&) {
     return {};
 }
 
@@ -12,7 +12,7 @@ bool IPassElement::disableSimplification() {
     return false;
 }
 
-void IPassElement::discard() {
+void IPassElement::discard(Render::CRenderingContext&) {
     ;
 }
 
@@ -20,6 +20,6 @@ bool IPassElement::undiscardable() {
     return false;
 }
 
-std::vector<UP<IPassElement>> IPassElement::draw() {
+std::vector<UP<IPassElement>> IPassElement::draw(Render::CRenderingContext&) {
     return {};
 }

--- a/src/render/pass/PassElement.hpp
+++ b/src/render/pass/PassElement.hpp
@@ -21,20 +21,24 @@ enum ePassElementType : uint8_t {
     EK_BACKDROP_SCOPE,
 };
 
+namespace Render {
+    class CRenderingContext;
+}
+
 class IPassElement {
   public:
     virtual ~IPassElement() = default;
 
-    virtual std::vector<UP<IPassElement>> draw();
+    virtual std::vector<UP<IPassElement>> draw(Render::CRenderingContext& context);
     //
-    virtual bool                needsLiveBlur()       = 0;
-    virtual bool                needsPrecomputeBlur() = 0;
-    virtual const char*         passName()            = 0;
-    virtual ePassElementType    type()                = 0;
-    virtual void                discard();
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&)       = 0;
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&) = 0;
+    virtual const char*         passName()                                            = 0;
+    virtual ePassElementType    type()                                                = 0;
+    virtual void                discard(Render::CRenderingContext& context);
     virtual bool                undiscardable();
-    virtual std::optional<CBox> boundingBox();  // in monitor-local logical coordinates
-    virtual CRegion             opaqueRegion(); // in monitor-local logical coordinates
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context); // in monitor-local logical coordinates
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
     virtual bool                disableSimplification();
     virtual bool                requiresFullDamage();
 

--- a/src/render/pass/PassElement.hpp
+++ b/src/render/pass/PassElement.hpp
@@ -21,20 +21,24 @@ enum ePassElementType : uint8_t {
     EK_BACKDROP_SCOPE,
 };
 
+namespace Render {
+    class CRenderingContext;
+}
+
 class IPassElement {
   public:
     virtual ~IPassElement() = default;
 
-    virtual std::vector<UP<IPassElement>> draw();
+    virtual std::vector<UP<IPassElement>> draw(Render::CRenderingContext& context);
     //
-    virtual bool                needsLiveBlur()       = 0;
-    virtual bool                needsPrecomputeBlur() = 0;
-    virtual const char*         passName()            = 0;
-    virtual ePassElementType    type()                = 0;
-    virtual void                discard();
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&)       = 0;
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&) = 0;
+    virtual const char*         passName()                                            = 0;
+    virtual ePassElementType    type()                                                = 0;
+    virtual void                discard(Render::CRenderingContext& context);
     virtual bool                undiscardable();
-    virtual std::optional<CBox> boundingBox();  // in monitor-local logical coordinates
-    virtual CRegion             opaqueRegion(); // in monitor-local logical coordinates
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context); // in monitor-local logical coordinates
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
     virtual bool                disableSimplification();
 
     // cached results, computed once per frame in CRenderPass::render()

--- a/src/render/pass/PreBlurElement.cpp
+++ b/src/render/pass/PreBlurElement.cpp
@@ -2,11 +2,11 @@
 
 CPreBlurElement::CPreBlurElement() = default;
 
-bool CPreBlurElement::needsLiveBlur() {
+bool CPreBlurElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CPreBlurElement::needsPrecomputeBlur() {
+bool CPreBlurElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }
 

--- a/src/render/pass/PreBlurElement.hpp
+++ b/src/render/pass/PreBlurElement.hpp
@@ -6,8 +6,8 @@ class CPreBlurElement : public IPassElement {
     CPreBlurElement();
     virtual ~CPreBlurElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
     virtual bool        disableSimplification();
     virtual bool        undiscardable();
 

--- a/src/render/pass/PreBlurElement.hpp
+++ b/src/render/pass/PreBlurElement.hpp
@@ -6,8 +6,8 @@ class CPreBlurElement : public IPassElement {
     CPreBlurElement();
     virtual ~CPreBlurElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
     virtual bool        disableSimplification();
     virtual bool        requiresFullDamage();
     virtual bool        undiscardable();

--- a/src/render/pass/RectPassElement.cpp
+++ b/src/render/pass/RectPassElement.cpp
@@ -5,23 +5,23 @@ CRectPassElement::CRectPassElement(const CRectPassElement::SRectData& data_) : m
     ;
 }
 
-bool CRectPassElement::needsLiveBlur() {
+bool CRectPassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return m_data.color.a < 1.F && m_data.blur && (!m_data.xray || g_pHyprRenderer->blurProviderRequiresLiveBlur());
 }
 
-bool CRectPassElement::needsPrecomputeBlur() {
+bool CRectPassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return m_data.color.a < 1.F && m_data.xray && m_data.blur && !g_pHyprRenderer->blurProviderRequiresLiveBlur();
 }
 
-std::optional<CBox> CRectPassElement::boundingBox() {
-    return m_data.box.copy().scale(1.F / g_pHyprRenderer->m_renderData.pMonitor->m_scale).round();
+std::optional<CBox> CRectPassElement::boundingBox(const Render::CRenderingContext& context) {
+    return m_data.box.copy().scale(1.F / context.sceneMonitor->m_scale).round();
 }
 
-CRegion CRectPassElement::opaqueRegion() {
+CRegion CRectPassElement::opaqueRegion(const Render::CRenderingContext& context) {
     if (m_data.color.a < 1.F)
         return CRegion{};
 
-    CRegion rg = boundingBox()->expand(-m_data.round);
+    CRegion rg = boundingBox(context)->expand(-m_data.round);
 
     if (!m_data.clipBox.empty())
         rg.intersect(m_data.clipBox);

--- a/src/render/pass/RectPassElement.hpp
+++ b/src/render/pass/RectPassElement.hpp
@@ -26,10 +26,10 @@ class CRectPassElement : public IPassElement {
     CRectPassElement(const SRectData& data);
     virtual ~CRectPassElement() = default;
 
-    virtual bool                needsLiveBlur();
-    virtual bool                needsPrecomputeBlur();
-    virtual std::optional<CBox> boundingBox();
-    virtual CRegion             opaqueRegion();
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&);
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context);
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
 
     virtual const char*         passName() {
         return "CRectPassElement";

--- a/src/render/pass/RendererHintsPassElement.cpp
+++ b/src/render/pass/RendererHintsPassElement.cpp
@@ -4,11 +4,11 @@ CRendererHintsPassElement::CRendererHintsPassElement(const CRendererHintsPassEle
     ;
 }
 
-bool CRendererHintsPassElement::needsLiveBlur() {
+bool CRendererHintsPassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CRendererHintsPassElement::needsPrecomputeBlur() {
+bool CRendererHintsPassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }
 

--- a/src/render/pass/RendererHintsPassElement.hpp
+++ b/src/render/pass/RendererHintsPassElement.hpp
@@ -11,8 +11,8 @@ class CRendererHintsPassElement : public IPassElement {
     CRendererHintsPassElement(const SData& data);
     virtual ~CRendererHintsPassElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
     virtual bool        undiscardable();
 
     virtual const char* passName() {

--- a/src/render/pass/ShadowPassElement.cpp
+++ b/src/render/pass/ShadowPassElement.cpp
@@ -4,10 +4,10 @@ CShadowPassElement::CShadowPassElement(const CShadowPassElement::SShadowData& da
     ;
 }
 
-bool CShadowPassElement::needsLiveBlur() {
+bool CShadowPassElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CShadowPassElement::needsPrecomputeBlur() {
+bool CShadowPassElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }

--- a/src/render/pass/ShadowPassElement.hpp
+++ b/src/render/pass/ShadowPassElement.hpp
@@ -13,8 +13,8 @@ class CShadowPassElement : public IPassElement {
     CShadowPassElement(const SShadowData& data_);
     virtual ~CShadowPassElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
 
     virtual const char* passName() {
         return "CShadowPassElement";

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -80,7 +80,7 @@ CBox CSurfacePassElement::getTexBox() {
     return m_cachedTexBox;
 }
 
-bool CSurfacePassElement::needsLiveBlur() {
+bool CSurfacePassElement::needsLiveBlur(const Render::CRenderingContext& context) {
     auto        PSURFACE = Desktop::View::CWLSurface::fromResource(m_data.surface);
 
     const float ALPHA = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
@@ -92,12 +92,12 @@ bool CSurfacePassElement::needsLiveBlur() {
     if (m_data.popup)
         return BLUR;
 
-    const bool NEWOPTIM = g_pHyprRenderer->shouldUseNewBlurOptimizations(m_data.pLS, m_data.pWindow);
+    const bool NEWOPTIM = g_pHyprRenderer->shouldUseNewBlurOptimizations(context, m_data.pLS, m_data.pWindow);
 
     return BLUR && (m_data.blockBlurOptimization || !NEWOPTIM);
 }
 
-bool CSurfacePassElement::needsPrecomputeBlur() {
+bool CSurfacePassElement::needsPrecomputeBlur(const Render::CRenderingContext& context) {
     auto        PSURFACE = Desktop::View::CWLSurface::fromResource(m_data.surface);
 
     const float ALPHA = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
@@ -109,16 +109,16 @@ bool CSurfacePassElement::needsPrecomputeBlur() {
     if (m_data.popup)
         return false;
 
-    const bool NEWOPTIM = g_pHyprRenderer->shouldUseNewBlurOptimizations(m_data.pLS, m_data.pWindow);
+    const bool NEWOPTIM = g_pHyprRenderer->shouldUseNewBlurOptimizations(context, m_data.pLS, m_data.pWindow);
 
     return BLUR && NEWOPTIM && !m_data.blockBlurOptimization;
 }
 
-std::optional<CBox> CSurfacePassElement::boundingBox() {
+std::optional<CBox> CSurfacePassElement::boundingBox(const Render::CRenderingContext&) {
     return getTexBox();
 }
 
-CRegion CSurfacePassElement::opaqueRegion() {
+CRegion CSurfacePassElement::opaqueRegion(const Render::CRenderingContext& context) {
     auto        PSURFACE = Desktop::View::CWLSurface::fromResource(m_data.surface);
 
     const float ALPHA = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
@@ -133,10 +133,10 @@ CRegion CSurfacePassElement::opaqueRegion() {
         return opaqueSurf.translate(m_data.pos + m_data.localPos - m_data.pMonitor->m_position).expand(-m_data.rounding);
     }
 
-    return m_data.texture && m_data.texture->m_opaque ? boundingBox()->expand(-m_data.rounding) : CRegion{};
+    return m_data.texture && m_data.texture->m_opaque ? boundingBox(context)->expand(-m_data.rounding) : CRegion{};
 }
 
-CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
+CRegion CSurfacePassElement::visibleRegion(Render::CRenderingContext& context, bool& cancel) {
     auto PSURFACE = Desktop::View::CWLSurface::fromResource(m_data.surface);
     if (!PSURFACE)
         return {};
@@ -157,8 +157,8 @@ CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
     // deal with any rounding errors that might come from scaling
     visibleRegion.expand(1);
 
-    auto uvTL = g_pHyprRenderer->m_renderData.primarySurfaceUVTopLeft;
-    auto uvBR = g_pHyprRenderer->m_renderData.primarySurfaceUVBottomRight;
+    auto uvTL = context.primarySurfaceUVTopLeft;
+    auto uvBR = context.primarySurfaceUVBottomRight;
 
     if (uvTL == Vector2D(-1, -1))
         uvTL = Vector2D(0, 0);
@@ -178,9 +178,9 @@ CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
     return visibleRegion;
 }
 
-void CSurfacePassElement::discard() {
-    if (!g_pHyprRenderer->m_bBlockSurfaceFeedback) {
+void CSurfacePassElement::discard(Render::CRenderingContext& context) {
+    if (!context.blockSurfaceFeedback) {
         Log::logger->log(Log::TRACE, "discard for invisible surface");
-        m_data.surface->presentFeedback(m_data.when, m_data.pMonitor->m_self.lock(), true);
+        m_data.surface->presentFeedback(m_data.when, context.outputMonitor.lock(), true);
     }
 }

--- a/src/render/pass/SurfacePassElement.hpp
+++ b/src/render/pass/SurfacePassElement.hpp
@@ -7,6 +7,7 @@
 class CWLSurfaceResource;
 namespace Render {
     class ITexture;
+    class CRenderingContext;
 }
 class CSyncTimeline;
 
@@ -56,12 +57,12 @@ class CSurfacePassElement : public IPassElement {
     CSurfacePassElement(const SRenderData& data);
     virtual ~CSurfacePassElement() = default;
 
-    virtual bool                needsLiveBlur();
-    virtual bool                needsPrecomputeBlur();
-    virtual std::optional<CBox> boundingBox();
-    virtual CRegion             opaqueRegion();
-    virtual void                discard();
-    CRegion                     visibleRegion(bool& cancel);
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&);
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context);
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
+    virtual void                discard(Render::CRenderingContext& context);
+    CRegion                     visibleRegion(Render::CRenderingContext& context, bool& cancel);
 
     virtual const char*         passName() {
         return "CSurfacePassElement";

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -17,15 +17,15 @@ CTexPassElement::CTexPassElement(CTexPassElement::SRenderData&& data) : m_data(s
     ;
 }
 
-bool CTexPassElement::needsLiveBlur() {
-    return usesLiveBlur();
+bool CTexPassElement::needsLiveBlur(const Render::CRenderingContext& context) {
+    return usesLiveBlur(context);
 }
 
-bool CTexPassElement::needsPrecomputeBlur() {
-    return m_data.blur && !usesLiveBlur();
+bool CTexPassElement::needsPrecomputeBlur(const Render::CRenderingContext& context) {
+    return m_data.blur && !usesLiveBlur(context);
 }
 
-bool CTexPassElement::usesLiveBlur() {
+bool CTexPassElement::usesLiveBlur(const Render::CRenderingContext& context) {
     if (m_usesLiveBlur.has_value())
         return *m_usesLiveBlur;
 
@@ -35,21 +35,21 @@ bool CTexPassElement::usesLiveBlur() {
     }
 
     m_usesLiveBlur =
-        m_data.blur && (m_data.blockBlurOptimization.value_or(false) || !g_pHyprRenderer->shouldUseNewBlurOptimizations(m_data.currentLS.lock(), m_data.blurOwner.lock()));
+        m_data.blur && (m_data.blockBlurOptimization.value_or(false) || !g_pHyprRenderer->shouldUseNewBlurOptimizations(context, m_data.currentLS.lock(), m_data.blurOwner.lock()));
     return *m_usesLiveBlur;
 }
 
-std::optional<CBox> CTexPassElement::boundingBox() {
+std::optional<CBox> CTexPassElement::boundingBox(const Render::CRenderingContext& context) {
     if (m_data.motionBlur.enabled)
-        return m_data.motionBlur.extents().copy().scale(1.F / g_pHyprRenderer->m_renderData.pMonitor->m_scale).round();
+        return m_data.motionBlur.extents().copy().scale(1.F / context.sceneMonitor->m_scale).round();
 
-    return m_data.box.copy().scale(1.F / g_pHyprRenderer->m_renderData.pMonitor->m_scale).round();
+    return m_data.box.copy().scale(1.F / context.sceneMonitor->m_scale).round();
 }
 
-CRegion CTexPassElement::opaqueRegion() {
+CRegion CTexPassElement::opaqueRegion(const Render::CRenderingContext&) {
     return {}; // TODO:
 }
 
-void CTexPassElement::discard() {
+void CTexPassElement::discard(Render::CRenderingContext& context) {
     ;
 }

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -75,13 +75,13 @@ class CTexPassElement : public IPassElement {
     CTexPassElement(SRenderData&& data);
     virtual ~CTexPassElement() = default;
 
-    virtual bool                needsLiveBlur();
-    virtual bool                needsPrecomputeBlur();
-    virtual std::optional<CBox> boundingBox();
-    virtual CRegion             opaqueRegion();
-    virtual void                discard();
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&);
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context);
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
+    virtual void                discard(Render::CRenderingContext& context);
 
-    bool                        usesLiveBlur();
+    bool                        usesLiveBlur(const Render::CRenderingContext& context);
 
     virtual const char*         passName() {
         return "CTexPassElement";

--- a/src/render/pass/TextureMatteElement.cpp
+++ b/src/render/pass/TextureMatteElement.cpp
@@ -4,10 +4,10 @@ CTextureMatteElement::CTextureMatteElement(const CTextureMatteElement::STextureM
     ;
 }
 
-bool CTextureMatteElement::needsLiveBlur() {
+bool CTextureMatteElement::needsLiveBlur(const Render::CRenderingContext&) {
     return false;
 }
 
-bool CTextureMatteElement::needsPrecomputeBlur() {
+bool CTextureMatteElement::needsPrecomputeBlur(const Render::CRenderingContext&) {
     return false;
 }

--- a/src/render/pass/TextureMatteElement.hpp
+++ b/src/render/pass/TextureMatteElement.hpp
@@ -18,8 +18,8 @@ class CTextureMatteElement : public IPassElement {
     CTextureMatteElement(const STextureMatteData& data_);
     virtual ~CTextureMatteElement() = default;
 
-    virtual bool        needsLiveBlur();
-    virtual bool        needsPrecomputeBlur();
+    virtual bool        needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool        needsPrecomputeBlur(const Render::CRenderingContext&);
 
     virtual const char* passName() {
         return "CTextureMatteElement";

--- a/src/render/pass/TransformedWindowPassElement.cpp
+++ b/src/render/pass/TransformedWindowPassElement.cpp
@@ -4,22 +4,22 @@ CTransformedWindowPassElement::CTransformedWindowPassElement(CTransformedWindowP
     ;
 }
 
-bool CTransformedWindowPassElement::needsLiveBlur() {
-    return (m_data.blur && m_data.blurUsesLive) || (m_data.pass && m_data.pass->needsLiveBlur());
+bool CTransformedWindowPassElement::needsLiveBlur(const Render::CRenderingContext& context) {
+    return (m_data.blur && m_data.blurUsesLive) || (m_data.pass && m_data.pass->needsLiveBlur(context));
 }
 
-bool CTransformedWindowPassElement::needsPrecomputeBlur() {
-    return (m_data.blur && !m_data.blurUsesLive) || (m_data.pass && m_data.pass->needsPrecomputeBlur());
+bool CTransformedWindowPassElement::needsPrecomputeBlur(const Render::CRenderingContext& context) {
+    return (m_data.blur && !m_data.blurUsesLive) || (m_data.pass && m_data.pass->needsPrecomputeBlur(context));
 }
 
-std::optional<CBox> CTransformedWindowPassElement::boundingBox() {
+std::optional<CBox> CTransformedWindowPassElement::boundingBox(const Render::CRenderingContext&) {
     if (m_data.motionBlur.enabled)
         return m_data.motionBlur.extents();
 
     return m_data.transformedBox.empty() ? m_data.currentBox : m_data.transformedBox;
 }
 
-CRegion CTransformedWindowPassElement::opaqueRegion() {
+CRegion CTransformedWindowPassElement::opaqueRegion(const Render::CRenderingContext&) {
     return {};
 }
 

--- a/src/render/pass/TransformedWindowPassElement.hpp
+++ b/src/render/pass/TransformedWindowPassElement.hpp
@@ -24,10 +24,10 @@ class CTransformedWindowPassElement : public IPassElement {
     CTransformedWindowPassElement(SData&& data);
     virtual ~CTransformedWindowPassElement() = default;
 
-    virtual bool                needsLiveBlur();
-    virtual bool                needsPrecomputeBlur();
-    virtual std::optional<CBox> boundingBox();
-    virtual CRegion             opaqueRegion();
+    virtual bool                needsLiveBlur(const Render::CRenderingContext&);
+    virtual bool                needsPrecomputeBlur(const Render::CRenderingContext&);
+    virtual std::optional<CBox> boundingBox(const Render::CRenderingContext& context);
+    virtual CRegion             opaqueRegion(const Render::CRenderingContext& context);
     virtual bool                disableSimplification();
 
     virtual const char*         passName() {

--- a/src/render/scene/MonitorScene.cpp
+++ b/src/render/scene/MonitorScene.cpp
@@ -13,20 +13,20 @@ CMonitorScene::CMonitorScene(PHLMONITOR mon) : m_monitor(mon) {
     ;
 }
 
-void CMonitorScene::draw(Time::steady_tp tp) {
+void CMonitorScene::draw(CRenderingContext& context, Time::steady_tp tp) {
     RASSERT(m_monitor, "Attemted to CMonitorScene::draw() a null monitor");
 
     if (m_monitor->isMirror()) {
         g_pHyprRenderer->blend(false);
-        g_pHyprRenderer->renderMirrored();
+        g_pHyprRenderer->renderMirrored(context);
         g_pHyprRenderer->blend(true);
         Event::bus()->m_events.render.stage.emit(RENDER_POST_MIRROR);
     } else {
         CBox renderBox = {0, 0, sc<int>(m_monitor->m_transformedSize.x), sc<int>(m_monitor->m_transformedSize.y)};
-        g_pHyprRenderer->renderWorkspace(m_monitor.lock(), m_monitor->m_activeWorkspace, tp, renderBox);
-        g_pHyprRenderer->renderLockscreen(m_monitor.lock(), tp, renderBox);
+        g_pHyprRenderer->renderWorkspace(context, m_monitor.lock(), m_monitor->m_activeWorkspace, tp, renderBox);
+        g_pHyprRenderer->renderLockscreen(context, m_monitor.lock(), tp, renderBox);
 
         // render IME even above the lockscreen - allow the user to use it to potentially input stuff on it.
-        g_pHyprRenderer->renderIME(m_monitor.lock(), tp, renderBox);
+        g_pHyprRenderer->renderIME(context, m_monitor.lock(), tp, renderBox);
     }
 }

--- a/src/render/scene/MonitorScene.cpp
+++ b/src/render/scene/MonitorScene.cpp
@@ -1,0 +1,32 @@
+#include "MonitorScene.hpp"
+
+#include "../../output/Monitor.hpp"
+#include "../../state/MonitorState.hpp"
+#include "../../event/EventBus.hpp"
+
+#include "../../macros.hpp"
+#include "../Renderer.hpp"
+
+using namespace Render;
+
+CMonitorScene::CMonitorScene(PHLMONITOR mon) : m_monitor(mon) {
+    ;
+}
+
+void CMonitorScene::draw(Time::steady_tp tp) {
+    RASSERT(m_monitor, "Attemted to CMonitorScene::draw() a null monitor");
+
+    if (m_monitor->isMirror()) {
+        g_pHyprRenderer->blend(false);
+        g_pHyprRenderer->renderMirrored();
+        g_pHyprRenderer->blend(true);
+        Event::bus()->m_events.render.stage.emit(RENDER_POST_MIRROR);
+    } else {
+        CBox renderBox = {0, 0, sc<int>(m_monitor->m_transformedSize.x), sc<int>(m_monitor->m_transformedSize.y)};
+        g_pHyprRenderer->renderWorkspace(m_monitor.lock(), m_monitor->m_activeWorkspace, tp, renderBox);
+        g_pHyprRenderer->renderLockscreen(m_monitor.lock(), tp, renderBox);
+
+        // render IME even above the lockscreen - allow the user to use it to potentially input stuff on it.
+        g_pHyprRenderer->renderIME(m_monitor.lock(), tp, renderBox);
+    }
+}

--- a/src/render/scene/MonitorScene.hpp
+++ b/src/render/scene/MonitorScene.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Scene.hpp"
+#include "../../desktop/DesktopTypes.hpp"
+
+namespace Render {
+    class CMonitorScene : public IScene {
+      public:
+        CMonitorScene(PHLMONITOR mon);
+        ~CMonitorScene() = default;
+
+        virtual void draw(Time::steady_tp tp) override;
+
+      private:
+        PHLMONITORREF m_monitor;
+    };
+};

--- a/src/render/scene/MonitorScene.hpp
+++ b/src/render/scene/MonitorScene.hpp
@@ -9,7 +9,7 @@ namespace Render {
         CMonitorScene(PHLMONITOR mon);
         ~CMonitorScene() = default;
 
-        virtual void draw(Time::steady_tp tp) override;
+        virtual void draw(CRenderingContext&, Time::steady_tp tp) override;
 
       private:
         PHLMONITORREF m_monitor;

--- a/src/render/scene/Scene.hpp
+++ b/src/render/scene/Scene.hpp
@@ -3,11 +3,13 @@
 #include "../../helpers/time/Time.hpp"
 
 namespace Render {
+    class CRenderingContext;
+
     class IScene {
       public:
         virtual ~IScene() = default;
 
-        virtual void draw(Time::steady_tp tp) = 0;
+        virtual void draw(CRenderingContext&, Time::steady_tp tp) = 0;
 
       protected:
         IScene() = default;

--- a/src/render/scene/Scene.hpp
+++ b/src/render/scene/Scene.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../../helpers/time/Time.hpp"
+
+namespace Render {
+    class IScene {
+      public:
+        virtual ~IScene() = default;
+
+        virtual void draw(Time::steady_tp tp) = 0;
+
+      protected:
+        IScene() = default;
+    };
+}

--- a/src/render/scene/SceneStack.cpp
+++ b/src/render/scene/SceneStack.cpp
@@ -1,0 +1,21 @@
+#include "SceneStack.hpp"
+
+#include "../../macros.hpp"
+
+using namespace Render;
+
+void CSceneStack::push(SP<IScene> scene) {
+    m_scenes.emplace_back(std::move(scene));
+}
+
+SP<IScene> CSceneStack::pop() {
+    RASSERT(!m_scenes.empty(), "CSceneStack: called pop() on an empty SceneStack");
+    auto x = m_scenes.back();
+    m_scenes.pop_back();
+    return x;
+}
+
+SP<IScene> CSceneStack::current() const {
+    RASSERT(!m_scenes.empty(), "CSceneStack: called current() on an empty SceneStack");
+    return m_scenes.back();
+}

--- a/src/render/scene/SceneStack.cpp
+++ b/src/render/scene/SceneStack.cpp
@@ -2,6 +2,8 @@
 
 #include "../../macros.hpp"
 
+#include <algorithm>
+
 using namespace Render;
 
 void CSceneStack::push(SP<IScene> scene) {
@@ -9,13 +11,28 @@ void CSceneStack::push(SP<IScene> scene) {
 }
 
 SP<IScene> CSceneStack::pop() {
-    RASSERT(!m_scenes.empty(), "CSceneStack: called pop() on an empty SceneStack");
+    RASSERT(m_scenes.size() > 1, "CSceneStack: called pop() without an override scene");
     auto x = m_scenes.back();
     m_scenes.pop_back();
     return x;
 }
 
+bool CSceneStack::remove(const SP<IScene>& scene) {
+    const auto IT =
+        std::ranges::find_if(m_scenes.begin() + std::min<size_t>(m_scenes.size(), 1), m_scenes.end(), [&scene](const auto& candidate) { return candidate.get() == scene.get(); });
+
+    if (IT == m_scenes.end())
+        return false;
+
+    m_scenes.erase(IT);
+    return true;
+}
+
 SP<IScene> CSceneStack::current() const {
     RASSERT(!m_scenes.empty(), "CSceneStack: called current() on an empty SceneStack");
     return m_scenes.back();
+}
+
+bool CSceneStack::hasOverride() const {
+    return m_scenes.size() > 1;
 }

--- a/src/render/scene/SceneStack.hpp
+++ b/src/render/scene/SceneStack.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../../helpers/memory/Memory.hpp"
+
+#include <vector>
+
+namespace Render {
+    class IScene;
+
+    /*
+     * A SceneStack holds a stack of scenes to be rendered.
+     * This is used for hyprland to be able to "push" a new scene without
+     * overriding the last one. For example, an overlay will "push" itself -> become
+     * the "current" scene, and "pop" at the end, letting the default monitor
+     * scene be rendered again.
+     *
+     * Only the "current" (top) scene is rendered.
+     *
+     * TODO: make this not a stack once we can have situations where A+ B+ C+ B- can occur.
+     */
+    class CSceneStack {
+      public:
+        CSceneStack()  = default;
+        ~CSceneStack() = default;
+
+        CSceneStack(const CSceneStack&) = delete;
+        CSceneStack(CSceneStack&)       = delete;
+        CSceneStack(CSceneStack&&)      = delete;
+
+        void       push(SP<IScene> scene);
+        SP<IScene> pop();
+
+        SP<IScene> current() const;
+
+      private:
+        std::vector<SP<IScene>> m_scenes;
+    };
+};

--- a/src/render/scene/SceneStack.hpp
+++ b/src/render/scene/SceneStack.hpp
@@ -15,8 +15,6 @@ namespace Render {
      * scene be rendered again.
      *
      * Only the "current" (top) scene is rendered.
-     *
-     * TODO: make this not a stack once we can have situations where A+ B+ C+ B- can occur.
      */
     class CSceneStack {
       public:
@@ -29,8 +27,10 @@ namespace Render {
 
         void       push(SP<IScene> scene);
         SP<IScene> pop();
+        bool       remove(const SP<IScene>& scene);
 
         SP<IScene> current() const;
+        bool       hasOverride() const;
 
       private:
         std::vector<SP<IScene>> m_scenes;

--- a/src/render/transformer/MotionBlurTransformer.cpp
+++ b/src/render/transformer/MotionBlurTransformer.cpp
@@ -7,6 +7,7 @@
 #include "../../managers/eventLoop/EventLoopManager.hpp"
 #include "../../managers/eventLoop/EventLoopTimer.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
+#include "../../output/WorkspaceTransition.hpp"
 #include "../Renderer.hpp"
 
 #include <algorithm>
@@ -111,8 +112,9 @@ std::optional<MotionBlur::SState> CMotionBlurTransformer::state(bool allowStale)
 
     static auto    PMBSAMPLES = CConfigValue<Config::INTEGER>("decoration:motion_blur:samples");
 
-    const Vector2D RENDEROFFSET = ((PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) || !PWINDOW->m_workspace ? Vector2D{} : PWINDOW->m_workspace->m_renderOffset->value()) +
-        PWINDOW->presentation().floatingOffset();
+    const auto     PWORKSPACE   = PWINDOW->m_workspace;
+    const Vector2D RENDEROFFSET = ((PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? Vector2D{} : g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE)) +
+        g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW);
     return m_motionBlur.state(std::clamp(sc<int>(*PMBSAMPLES), 2, 64), RENDEROFFSET, allowStale);
 }
 

--- a/src/render/transformer/MotionBlurTransformer.cpp
+++ b/src/render/transformer/MotionBlurTransformer.cpp
@@ -33,7 +33,7 @@ bool CMotionBlurTransformer::shouldEnable(PHLWINDOW window) {
     return *PMBENABLED && *PMBSAMPLES > 1 && !Fullscreen::controller()->isFullscreen(window);
 }
 
-SWindowTransformBuffer CMotionBlurTransformer::transform(const SWindowTransformBuffer& in, const SWindowTransformContext&) {
+SWindowTransformBuffer CMotionBlurTransformer::transform(CRenderingContext&, const SWindowTransformBuffer& in, const SWindowTransformContext&) {
     return in;
 }
 
@@ -68,15 +68,15 @@ CBox CMotionBlurTransformer::transformBoxForDamage(const CBox& currentBox) const
     return damaged;
 }
 
-void CMotionBlurTransformer::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) {
+void CMotionBlurTransformer::amendTransformedRenderData(CRenderingContext& context, const CBox& currentBox, SMotionBlurData* pMotionBlurData) {
     if (!pMotionBlurData)
         return;
 
-    const auto PMONITOR = g_pHyprRenderer->m_renderData.pMonitor;
+    const auto PMONITOR = context.sceneMonitor;
     if (!PMONITOR)
         return;
 
-    const auto STATE = state();
+    const auto STATE = state(context, false);
     if (!STATE)
         return;
 
@@ -110,12 +110,28 @@ std::optional<MotionBlur::SState> CMotionBlurTransformer::state(bool allowStale)
     if (!shouldEnable(PWINDOW))
         return std::nullopt;
 
-    static auto    PMBSAMPLES = CConfigValue<Config::INTEGER>("decoration:motion_blur:samples");
+    const auto     PWORKSPACE       = PWINDOW->m_workspace;
+    const auto     WORKSPACEMONITOR = PWORKSPACE ? PWORKSPACE->m_monitor.lock() : nullptr;
+    const Vector2D RENDEROFFSET =
+        ((PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) || !WORKSPACEMONITOR ? Vector2D{} : WORKSPACEMONITOR->m_workspaceTransition->offsetValue(PWORKSPACE)) +
+        PWINDOW->presentation().floatingOffset();
+    return state(RENDEROFFSET, allowStale);
+}
+
+std::optional<MotionBlur::SState> CMotionBlurTransformer::state(const CRenderingContext& context, bool allowStale) const {
+    const auto PWINDOW = m_window.lock();
+    if (!shouldEnable(PWINDOW))
+        return std::nullopt;
 
     const auto     PWORKSPACE   = PWINDOW->m_workspace;
-    const Vector2D RENDEROFFSET = ((PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? Vector2D{} : g_pHyprRenderer->workspaceRenderOffset(PWORKSPACE)) +
-        g_pHyprRenderer->windowRenderFloatingOffset(PWINDOW);
-    return m_motionBlur.state(std::clamp(sc<int>(*PMBSAMPLES), 2, 64), RENDEROFFSET, allowStale);
+    const Vector2D RENDEROFFSET = ((PWINDOW->m_state & Desktop::View::WINDOW_STATE_PINNED) ? Vector2D{} : g_pHyprRenderer->workspaceRenderOffset(context, PWORKSPACE)) +
+        g_pHyprRenderer->windowRenderFloatingOffset(context, PWINDOW);
+    return state(RENDEROFFSET, allowStale);
+}
+
+std::optional<MotionBlur::SState> CMotionBlurTransformer::state(const Vector2D& renderOffset, bool allowStale) const {
+    static auto PMBSAMPLES = CConfigValue<Config::INTEGER>("decoration:motion_blur:samples");
+    return m_motionBlur.state(std::clamp(sc<int>(*PMBSAMPLES), 2, 64), renderOffset, allowStale);
 }
 
 void CMotionBlurTransformer::armExpiryTimer() {

--- a/src/render/transformer/MotionBlurTransformer.hpp
+++ b/src/render/transformer/MotionBlurTransformer.hpp
@@ -10,13 +10,13 @@ namespace Render {
 
         static bool                       shouldEnable(PHLWINDOW window);
 
-        virtual SWindowTransformBuffer    transform(const SWindowTransformBuffer& in, const SWindowTransformContext& context);
+        virtual SWindowTransformBuffer    transform(CRenderingContext&, const SWindowTransformBuffer& in, const SWindowTransformContext& context);
         virtual int                       priority() const;
         virtual bool                      active() const;
         virtual bool                      allocatesOutputBuffer() const;
         virtual CBox                      sourceBoxForOutput(const CBox& outputBox, const CBox& inputBox) const;
         virtual CBox                      transformBoxForDamage(const CBox& currentBox) const;
-        virtual void                      amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData);
+        virtual void                      amendTransformedRenderData(CRenderingContext&, const CBox& currentBox, SMotionBlurData* pMotionBlurData);
 
         void                              record(const CBox& previous, const CBox& current);
         void                              reset();
@@ -24,11 +24,13 @@ namespace Render {
         std::optional<MotionBlur::SState> state(bool allowStale = false) const;
 
       private:
-        void                 armExpiryTimer();
-        void                 disarmExpiryTimer();
+        std::optional<MotionBlur::SState> state(const CRenderingContext&, bool allowStale) const;
+        std::optional<MotionBlur::SState> state(const Vector2D& renderOffset, bool allowStale) const;
+        void                              armExpiryTimer();
+        void                              disarmExpiryTimer();
 
-        PHLWINDOWREF         m_window;
-        MotionBlur::CTracker m_motionBlur;
-        SP<CEventLoopTimer>  m_expiryTimer;
+        PHLWINDOWREF                      m_window;
+        MotionBlur::CTracker              m_motionBlur;
+        SP<CEventLoopTimer>               m_expiryTimer;
     };
 }

--- a/src/render/transformer/Transformer.cpp
+++ b/src/render/transformer/Transformer.cpp
@@ -15,7 +15,7 @@ CBox Render::pixelBoxForLogical(const CBox& box, double scale) {
     return {x1, y1, x2 - x1, y2 - y1};
 }
 
-void IWindowTransformer::preWindowRender(CSurfacePassElement::SRenderData* pRenderData) {
+void IWindowTransformer::preWindowRender(CRenderingContext&, CSurfacePassElement::SRenderData* pRenderData) {
     ;
 }
 
@@ -47,6 +47,6 @@ CBox IWindowTransformer::transformBoxForDamage(const CBox& currentBox) const {
     return transformedExtents(currentBox);
 }
 
-void IWindowTransformer::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) {
+void IWindowTransformer::amendTransformedRenderData(CRenderingContext&, const CBox& currentBox, SMotionBlurData* pMotionBlurData) {
     ;
 }

--- a/src/render/transformer/Transformer.hpp
+++ b/src/render/transformer/Transformer.hpp
@@ -10,6 +10,8 @@
 class CEventLoopTimer;
 
 namespace Render {
+    class CRenderingContext;
+
     CBox pixelBoxForLogical(const CBox& box, double scale);
 
     struct SWindowTransformBuffer {
@@ -52,7 +54,7 @@ namespace Render {
 
         // called by Hyprland. For more data about what is being rendered, inspect render data.
         // returns the output framebuffer and the monitor-local pixel box represented by it.
-        virtual SWindowTransformBuffer transform(const SWindowTransformBuffer& in, const SWindowTransformContext& context) = 0;
+        virtual SWindowTransformBuffer transform(CRenderingContext&, const SWindowTransformBuffer& in, const SWindowTransformContext& context) = 0;
 
         virtual int                    priority() const;
         virtual bool                   active() const;
@@ -63,9 +65,9 @@ namespace Render {
         virtual CBox                   transformBoxForDamage(const CBox& currentBox) const;
 
         // called by Hyprland before a window main pass is started.
-        virtual void preWindowRender(CSurfacePassElement::SRenderData* pRenderData);
+        virtual void preWindowRender(CRenderingContext&, CSurfacePassElement::SRenderData* pRenderData);
 
         // called by Hyprland before the transformed window fb is rendered back to the main fb.
-        virtual void amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData);
+        virtual void amendTransformedRenderData(CRenderingContext&, const CBox& currentBox, SMotionBlurData* pMotionBlurData);
     };
 }

--- a/src/render/transformer/TransformerList.cpp
+++ b/src/render/transformer/TransformerList.cpp
@@ -66,21 +66,22 @@ CBox CWindowTransformerList::transformBoxForDamage(const CBox& currentBox) const
     return box;
 }
 
-void CWindowTransformerList::preWindowRender(CSurfacePassElement::SRenderData* pRenderData) const {
+void CWindowTransformerList::preWindowRender(CRenderingContext& context, CSurfacePassElement::SRenderData* pRenderData) const {
     for (auto const& transformer : m_transformers) {
         if (transformer->active())
-            transformer->preWindowRender(pRenderData);
+            transformer->preWindowRender(context, pRenderData);
     }
 }
 
-void CWindowTransformerList::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) const {
+void CWindowTransformerList::amendTransformedRenderData(CRenderingContext& context, const CBox& currentBox, SMotionBlurData* pMotionBlurData) const {
     for (auto const& transformer : m_transformers) {
         if (transformer->active())
-            transformer->amendTransformedRenderData(currentBox, pMotionBlurData);
+            transformer->amendTransformedRenderData(context, currentBox, pMotionBlurData);
     }
 }
 
-SWindowTransformBuffer CWindowTransformerList::transform(const SWindowTransformBuffer& in, const SWindowTransformPlan& plan, const SWindowTransformContext& context) const {
+SWindowTransformBuffer CWindowTransformerList::transform(CRenderingContext& renderingContext, const SWindowTransformBuffer& in, const SWindowTransformPlan& plan,
+                                                         const SWindowTransformContext& context) const {
     SWindowTransformBuffer last  = in;
     size_t                 stage = 0;
     for (auto const& transformer : m_transformers) {
@@ -94,7 +95,7 @@ SWindowTransformBuffer CWindowTransformerList::transform(const SWindowTransformB
         stageContext.currentBox = plan.stages[stage].fullInputBox;
         stageContext.inputBox   = plan.stages[stage].inputBox;
         stageContext.outputBox  = plan.stages[stage].outputBox;
-        last                    = transformer->transform(last, stageContext);
+        last                    = transformer->transform(renderingContext, last, stageContext);
         if (!last.success)
             break;
 

--- a/src/render/transformer/TransformerList.hpp
+++ b/src/render/transformer/TransformerList.hpp
@@ -44,9 +44,9 @@ namespace Render {
         SWindowTransformPlan   plan(const CBox& currentBox, const CBox& outputBox) const;
         CBox                   transformBoxForDamage(const CBox& currentBox) const;
 
-        void                   preWindowRender(CSurfacePassElement::SRenderData* pRenderData) const;
-        void                   amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) const;
-        SWindowTransformBuffer transform(const SWindowTransformBuffer& in, const SWindowTransformPlan& plan, const SWindowTransformContext& context) const;
+        void                   preWindowRender(CRenderingContext&, CSurfacePassElement::SRenderData* pRenderData) const;
+        void                   amendTransformedRenderData(CRenderingContext&, const CBox& currentBox, SMotionBlurData* pMotionBlurData) const;
+        SWindowTransformBuffer transform(CRenderingContext&, const SWindowTransformBuffer& in, const SWindowTransformPlan& plan, const SWindowTransformContext& context) const;
 
         void                   removeInactive();
 

--- a/src/render/transformer/WobbleTransformer.cpp
+++ b/src/render/transformer/WobbleTransformer.cpp
@@ -60,7 +60,7 @@ void CWobbleTransformer::ensureTickListener() {
     g_wobbleTickListener = Event::bus()->m_events.tick.listen([] { tickWobbles(); });
 }
 
-SWindowTransformBuffer CWobbleTransformer::transform(const SWindowTransformBuffer& in, const SWindowTransformContext& context) {
+SWindowTransformBuffer CWobbleTransformer::transform(CRenderingContext& renderingContext, const SWindowTransformBuffer& in, const SWindowTransformContext& context) {
     if (!m_active || context.standalone || context.renderingSnapshot || !context.monitor || !in.framebuffer || !in.framebuffer->getTexture())
         return in;
 
@@ -89,25 +89,18 @@ SWindowTransformBuffer CWobbleTransformer::transform(const SWindowTransformBuffe
     if (VERTICES.empty())
         return {.framebuffer = in.framebuffer, .box = in.box, .success = false};
 
-    auto&         renderData    = g_pHyprRenderer->m_renderData;
-    const CRegion oldDamage     = renderData.damage.copy();
-    const auto    oldProjection = renderData.projectionType;
-    const auto    oldFBSize     = renderData.fbSize;
-
     {
-        auto guard        = g_pHyprRenderer->bindTempFB(OUT);
-        renderData.damage = CRegion{0, 0, sc<int>(OUTPUTCANVAS.w), sc<int>(OUTPUTCANVAS.h)};
-        renderData.fbSize = OUTPUTCANVAS.size();
-        g_pHyprRenderer->setProjectionType(RPT_EXPORT);
+        CRenderingContext child{renderingContext, renderingContext.renderPass()};
+        auto              guard = g_pHyprRenderer->bindTempFB(child, OUT);
+        child.damage            = CRegion{0, 0, sc<int>(OUTPUTCANVAS.w), sc<int>(OUTPUTCANVAS.h)};
+        child.fbSize            = OUTPUTCANVAS.size();
+        g_pHyprRenderer->setProjectionType(child, RPT_EXPORT);
 
-        g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
-        GL::g_pHyprOpenGL->renderTextureMesh(in.framebuffer->getTexture(), LOCALOUTPUTBOX, VERTICES,
-                                             GL::CHyprOpenGLImpl::STextureRenderData{.damage = &renderData.damage, .a = 1.F, .allowCustomUV = true});
+        g_pHyprRenderer->draw(child, CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+        GL::g_pHyprOpenGL->renderTextureMesh(child, in.framebuffer->getTexture(), LOCALOUTPUTBOX, VERTICES,
+                                             GL::CHyprOpenGLImpl::STextureRenderData{.damage = &child.damage, .a = 1.F, .allowCustomUV = true});
     }
 
-    renderData.damage = oldDamage;
-    renderData.fbSize = oldFBSize;
-    g_pHyprRenderer->setProjectionType(oldProjection);
     return {.framebuffer = OUT, .box = OUTPUTCANVAS};
 }
 

--- a/src/render/transformer/WobbleTransformer.hpp
+++ b/src/render/transformer/WobbleTransformer.hpp
@@ -16,7 +16,7 @@ namespace Render {
         static bool                    shouldEnable(PHLWINDOW window);
         static void                    ensureTickListener();
 
-        virtual SWindowTransformBuffer transform(const SWindowTransformBuffer& in, const SWindowTransformContext& context);
+        virtual SWindowTransformBuffer transform(CRenderingContext&, const SWindowTransformBuffer& in, const SWindowTransformContext& context);
         virtual int                    priority() const;
         virtual bool                   active() const;
         virtual bool                   blocksDirectScanout() const;

--- a/src/render/types.hpp
+++ b/src/render/types.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "Framebuffer.hpp"
 #include "../desktop/DesktopTypes.hpp"
 #include "../helpers/cm/ColorManagement.hpp"
@@ -10,7 +12,12 @@
 #include <hyprutils/math/Region.hpp>
 #include <hyprutils/math/Vector2D.hpp>
 
+struct SBackdropScope;
+
 namespace Render {
+    class CRenderPass;
+    class IRenderbuffer;
+
     const std::vector<const char*> ASSET_PATHS = {
 #ifdef DATAROOTDIR
         DATAROOTDIR,
@@ -69,44 +76,6 @@ namespace Render {
         bool                                               enabled = true;
     };
 
-    struct SRenderData {
-        // can be private
-        Hyprutils::Math::Mat3x3 targetProjection;
-
-        // ----------------------
-
-        // used by public
-        Hyprutils::Math::Vector2D fbSize = {-1, -1};
-        PHLMONITORREF             pMonitor;
-
-        eRenderProjectionType     projectionType = RPT_MONITOR;
-
-        SP<IFramebuffer>          currentFB = nullptr; // current rendering to
-        SP<IFramebuffer>          mainFB    = nullptr; // main to render to
-        SP<IFramebuffer>          outFB     = nullptr; // out to render to (if offloaded, etc)
-
-        CRegion                   damage;
-        CRegion                   finalDamage; // damage used for final off -> main
-
-        SRenderModifData          renderModif;
-        float                     mouseZoomFactor    = 1.f;
-        bool                      mouseZoomUseMouse  = true; // true by default
-        bool                      useNearestNeighbor = false;
-        bool                      blockScreenShader  = false;
-
-        Vector2D                  primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-        Vector2D                  primarySurfaceUVBottomRight = Vector2D(-1, -1);
-
-        // TODO remove and pass directly
-        CBox                   clipBox = {}; // scaled coordinates
-        PHLWINDOWREF           currentWindow;
-        WP<CWLSurfaceResource> surface;
-
-        bool                   transformDamage            = true;
-        bool                   noSimplify                 = false;
-        bool                   renderingTransformedSource = false;
-    };
-
     struct STFRange {
         float min = 0;
         float max = 80;
@@ -129,5 +98,88 @@ namespace Render {
         bool                                 needsSDRmod             = false;
         float                                sdrSaturation           = 1.0;
         float                                sdrBrightnessMultiplier = 1.0;
+    };
+
+    struct SCMSettingsCacheEntry {
+        uint64_t    srcDescId = 0, dstDescId = 0;
+        void*       surfacePtr      = nullptr; // read-only!!
+        bool        modifySDR       = false;
+        float       sdrMinLuminance = -1.F;
+        int         sdrMaxLuminance = -1;
+        SCMSettings settings;
+    };
+
+    struct SCMSettingsCache {
+        std::vector<SCMSettingsCacheEntry> entries;
+    };
+
+    struct SBackdropCapture {
+        SP<SBackdropScope> scope;
+        SP<IFramebuffer>   framebuffer;
+    };
+
+    class CRenderingContext {
+      public:
+        CRenderingContext(PHLMONITORREF sceneMonitor, CRenderPass& pass, PHLMONITORREF outputMonitor = {});
+        CRenderingContext(const CRenderingContext& parent, CRenderPass& pass);
+        CRenderingContext(const CRenderingContext& parent, CRenderPass& pass, PHLMONITORREF sceneMonitor);
+
+        CRenderPass&                  renderPass() const;
+
+        Mat3x3                        targetProjection;
+        Vector2D                      fbSize = {-1, -1};
+
+        PHLMONITORREF                 sceneMonitor;
+        PHLMONITORREF                 outputMonitor;
+
+        eRenderProjectionType         projectionType = RPT_MONITOR;
+
+        SP<IFramebuffer>              currentFB;
+        SP<IFramebuffer>              mainFB;
+        SP<IFramebuffer>              outFB;
+
+        CRegion                       damage;
+        CRegion                       finalDamage;
+
+        SRenderModifData              renderModif;
+        float                         mouseZoomFactor    = 1.F;
+        bool                          mouseZoomUseMouse  = true;
+        bool                          useNearestNeighbor = false;
+        bool                          blockScreenShader  = false;
+
+        Vector2D                      primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+        Vector2D                      primarySurfaceUVBottomRight = Vector2D(-1, -1);
+
+        CBox                          clipBox;
+        PHLWINDOWREF                  currentWindow;
+        WP<CWLSurfaceResource>        surface;
+
+        bool                          transformDamage            = true;
+        bool                          noSimplify                 = false;
+        bool                          renderingTransformedSource = false;
+
+        PHLWORKSPACEREF               isolatedWorkspace;
+        bool                          isolatedWorkspaceFullScene = false;
+        bool                          blockSurfaceFeedback       = false;
+        bool                          renderingSnapshot          = false;
+        bool                          precomputeBlur             = false;
+        bool                          updatesMonitorBlurState    = true;
+
+        eRenderMode                   renderMode             = RENDER_MODE_NORMAL;
+        bool                          fakeFrame              = false;
+        bool                          offloadedFramebuffer   = false;
+        bool                          applyFinalScreenShader = false;
+
+        SP<Aquamarine::IBuffer>       buffer;
+        SP<IRenderbuffer>             renderbuffer;
+
+        SP<SCMSettingsCache>          cmSettingsCache;
+        std::vector<SBackdropCapture> backdropCaptures;
+
+      private:
+        CRenderingContext(const CRenderingContext&)                             = default;
+        CRenderingContext&                  operator=(const CRenderingContext&) = delete;
+
+        std::reference_wrapper<CRenderPass> m_pass;
     };
 }

--- a/src/state/MonitorState.cpp
+++ b/src/state/MonitorState.cpp
@@ -100,7 +100,7 @@ static void checkDefaultCursorWarp(PHLMONITOR monitor) {
     }
 
     // modechange happened check if cursor is on that monitor and warp it to middle to not place it out of bounds if resolution changed.
-    if (State::monitorState()->query().vec(Pointer::mgr()->position()).run() == monitor) {
+    if (State::monitorState()->query().vec(Pointer::mgr()->untransformedPosition()).run() == monitor) {
         Pointer::pointerController()->warpTo(POS, true);
         g_pInputManager->refocus();
     }

--- a/src/state/WorkspacePlacementController.cpp
+++ b/src/state/WorkspacePlacementController.cpp
@@ -13,6 +13,7 @@
 #include "../desktop/view/window/Window.hpp"
 #include "../helpers/MiscFunctions.hpp"
 #include "../output/Monitor.hpp"
+#include "../output/WorkspaceTransition.hpp"
 #include "../layout/target/Target.hpp"
 #include "../layout/LayoutManager.hpp"
 #include "../layout/space/Space.hpp"
@@ -152,6 +153,7 @@ void CWorkspacePlacementController::swapActiveWorkspaces(PHLMONITOR pMonitorA, P
     const auto PWORKSPACEA = pMonitorA->m_activeWorkspace;
     const auto PWORKSPACEB = pMonitorB->m_activeWorkspace;
 
+    pMonitorA->m_workspaceTransition->transferTo(*pMonitorB->m_workspaceTransition, PWORKSPACEA);
     PWORKSPACEA->m_monitor = pMonitorB;
     PWORKSPACEA->m_events.monitorChanged.emit();
 
@@ -175,6 +177,7 @@ void CWorkspacePlacementController::swapActiveWorkspaces(PHLMONITOR pMonitorA, P
         }
     }
 
+    pMonitorB->m_workspaceTransition->transferTo(*pMonitorA->m_workspaceTransition, PWORKSPACEB);
     PWORKSPACEB->m_monitor = pMonitorA;
     PWORKSPACEB->m_events.monitorChanged.emit();
 
@@ -291,6 +294,15 @@ void CWorkspacePlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspa
     }
 
     // move the workspace
+    const bool TRANSFERREDTRANSITION = POLDMON && POLDMON->m_workspaceTransition->get(pWorkspace);
+    if (POLDMON) {
+        POLDMON->m_workspaceTransition->transferTo(*pMonitor->m_workspaceTransition, pWorkspace);
+        if (TRANSFERREDTRANSITION) {
+            g_pHyprRenderer->damageMonitor(POLDMON);
+            g_pHyprRenderer->damageMonitor(pMonitor);
+        }
+    }
+
     pWorkspace->m_monitor = pMonitor;
     pWorkspace->m_space->recheckWorkArea();
     pWorkspace->m_events.monitorChanged.emit();

--- a/src/state/WorkspaceState.cpp
+++ b/src/state/WorkspaceState.cpp
@@ -71,11 +71,7 @@ PHLWORKSPACE CWorkspaceStateTracker::create(const WORKSPACEID& id, const MONITOR
         return nullptr;
     }
 
-    const auto PWORKSPACE = CWorkspace::create(id, PMONITOR, NAME, SPECIAL, isEmpty);
-
-    PWORKSPACE->m_alpha->setValueAndWarp(0);
-
-    return PWORKSPACE;
+    return CWorkspace::create(id, PMONITOR, NAME, SPECIAL, isEmpty);
 }
 
 WORKSPACEID CWorkspaceStateTracker::nextAvailableNamedWorkspace() const {

--- a/tests/config/lua/LuaBindingsInternal.cpp
+++ b/tests/config/lua/LuaBindingsInternal.cpp
@@ -4,7 +4,9 @@
 #include <Compositor.hpp>
 
 #include <config/lua/types/LuaConfigInt.hpp>
+#include <config/shared/actions/ConfigActions.hpp>
 #include <config/values/types/IntValue.hpp>
+#include <overview/Overview.hpp>
 
 #include <gtest/gtest.h>
 
@@ -45,6 +47,62 @@ namespace Config::Lua {
 }
 
 namespace {
+    class CTestOverview final : public Overview::IOverview, public Overview::IOverviewNavigable, public Overview::IOverviewQueryOpenable, public Overview::IOverviewStateProvider {
+      public:
+        virtual void open(PHLMONITOR) override {
+            m_open = true;
+        }
+
+        virtual void open(PHLMONITOR, const std::string& query) override {
+            m_open  = true;
+            m_query = query;
+        }
+
+        virtual void close() override {
+            m_open = false;
+        }
+
+        virtual bool isOpen() const override {
+            return m_open;
+        }
+
+        virtual Overview::SOverviewState state() const override {
+            return {.open = m_open, .query = m_open ? m_query : ""};
+        }
+
+        virtual bool moveLeft() override {
+            m_moves--;
+            return true;
+        }
+
+        virtual bool moveRight() override {
+            m_moves++;
+            return true;
+        }
+
+        bool        m_open  = false;
+        int         m_moves = 0;
+        std::string m_query;
+    };
+
+    class CScopedTestOverview {
+      public:
+        CScopedTestOverview() : m_previous(std::move(Overview::overview())) {
+            Overview::overview() = makeUnique<CTestOverview>();
+        }
+
+        ~CScopedTestOverview() {
+            Overview::overview() = std::move(m_previous);
+        }
+
+        CTestOverview& get() const {
+            return *dynamic_cast<CTestOverview*>(Overview::overview().get());
+        }
+
+      private:
+        UP<Overview::IOverview> m_previous;
+    };
+
     class CLuaState {
       public:
         CLuaState() : m_lua(luaL_newstate()) {
@@ -160,10 +218,86 @@ TEST(ConfigLuaBindingsInternal, dispatcherRegistrationIncludesOverviewTable) {
     ASSERT_TRUE(lua_istable(L, -1));
     lua_getfield(L, -1, "toggle");
     EXPECT_TRUE(lua_isfunction(L, -1));
+    lua_pop(L, 1);
+    lua_getfield(L, -1, "move_left");
+    EXPECT_TRUE(lua_isfunction(L, -1));
+    lua_pop(L, 1);
+    lua_getfield(L, -1, "move_right");
+    EXPECT_TRUE(lua_isfunction(L, -1));
     lua_pop(L, 2);
 
     lua_getfield(L, -1, "no_op");
     EXPECT_TRUE(lua_isfunction(L, -1));
+}
+
+TEST(ConfigLuaBindingsInternal, overviewActionsForwardQueryAndNavigation) {
+    CScopedTestOverview overview;
+
+    ASSERT_TRUE(Config::Actions::overview(Config::Actions::TOGGLE_ACTION_ENABLE, "query with spaces"));
+    EXPECT_TRUE(overview.get().m_open);
+    EXPECT_EQ(overview.get().m_query, "query with spaces");
+
+    EXPECT_TRUE(Config::Actions::overviewMoveLeft());
+    EXPECT_TRUE(Config::Actions::overviewMoveRight());
+    EXPECT_EQ(overview.get().m_moves, 0);
+
+    ASSERT_TRUE(Config::Actions::overview(Config::Actions::TOGGLE_ACTION_DISABLE));
+    EXPECT_FALSE(overview.get().m_open);
+    const auto moveResult = Config::Actions::overviewMoveLeft();
+    ASSERT_FALSE(moveResult);
+    EXPECT_EQ(moveResult.error().code, Config::Actions::eActionErrorCode::INVALID_STATE);
+}
+
+TEST(ConfigLuaBindingsInternal, overviewToggleDispatcherPreservesQuery) {
+    CScopedTestOverview overview;
+    CLuaState           state;
+    const auto          lua = state.get();
+
+    lua_newtable(lua);
+    Internal::registerDispatcherBindings(lua);
+    lua_setglobal(lua, "hl");
+
+    lua_getglobal(lua, "hl");
+    lua_getfield(lua, -1, "dsp");
+    lua_getfield(lua, -1, "overview");
+    lua_getfield(lua, -1, "toggle");
+    lua_createtable(lua, 0, 1);
+    constexpr char QUERY[] = {'q', '\0', 'x'};
+    lua_pushlstring(lua, QUERY, sizeof(QUERY));
+    lua_setfield(lua, -2, "query");
+    lua_call(lua, 1, 1);
+
+    ASSERT_TRUE(Internal::pushDispatcherFunction(lua, -1));
+    lua_call(lua, 0, 1);
+    EXPECT_TRUE(overview.get().m_open);
+    EXPECT_EQ(overview.get().m_query, std::string(QUERY, sizeof(QUERY)));
+
+    ASSERT_EQ(luaL_dostring(lua, "assert(hl.dsp.overview.toggle({ query = true }) == nil)"), LUA_OK) << lua_tostring(lua, -1);
+    ASSERT_EQ(luaL_dostring(lua, "assert(hl.dsp.overview.toggle({ query = 42 }) == nil)"), LUA_OK) << lua_tostring(lua, -1);
+}
+
+TEST(ConfigLuaBindingsInternal, getOverviewReturnsStableStateTable) {
+    CScopedTestOverview overview;
+    CLuaState           state;
+    const auto          lua = state.get();
+
+    lua_newtable(lua);
+    Internal::registerQueryBindings(lua);
+    lua_setglobal(lua, "hl");
+
+    ASSERT_EQ(luaL_dostring(lua, R"(
+        local overview = hl.get_overview()
+        assert(type(overview) == "table")
+        assert(overview.open == false)
+        assert(overview.monitor == nil)
+        assert(overview.workspace == nil)
+        assert(overview.query == "")
+    )"),
+              LUA_OK)
+        << lua_tostring(lua, -1);
+
+    overview.get().m_open = true;
+    ASSERT_EQ(luaL_dostring(lua, "assert(hl.get_overview().open == true)"), LUA_OK) << lua_tostring(lua, -1);
 }
 
 TEST(ConfigLuaBindingsInternal, parseDirectionAliases) {

--- a/tests/config/lua/LuaBindingsInternal.cpp
+++ b/tests/config/lua/LuaBindingsInternal.cpp
@@ -146,6 +146,26 @@ namespace {
     }
 }
 
+TEST(ConfigLuaBindingsInternal, dispatcherRegistrationIncludesOverviewTable) {
+    CLuaState  S;
+    const auto L = S.get();
+
+    lua_newtable(L);
+    Internal::registerDispatcherBindings(L);
+
+    lua_getfield(L, 1, "dsp");
+    ASSERT_TRUE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "overview");
+    ASSERT_TRUE(lua_istable(L, -1));
+    lua_getfield(L, -1, "toggle");
+    EXPECT_TRUE(lua_isfunction(L, -1));
+    lua_pop(L, 2);
+
+    lua_getfield(L, -1, "no_op");
+    EXPECT_TRUE(lua_isfunction(L, -1));
+}
+
 TEST(ConfigLuaBindingsInternal, parseDirectionAliases) {
     EXPECT_EQ(Internal::parseDirectionStr("left"), Math::DIRECTION_LEFT);
     EXPECT_EQ(Internal::parseDirectionStr("l"), Math::DIRECTION_LEFT);

--- a/tests/config/shared/AnimationTree.cpp
+++ b/tests/config/shared/AnimationTree.cpp
@@ -1,0 +1,13 @@
+#include <config/shared/animation/AnimationTree.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(AnimationTree, HasOverviewAnimations) {
+    const auto& tree = Config::animationTree();
+
+    EXPECT_TRUE(tree->nodeExists("overview"));
+    EXPECT_TRUE(tree->nodeExists("overviewIn"));
+    EXPECT_TRUE(tree->nodeExists("overviewOut"));
+    EXPECT_TRUE(tree->nodeExists("overviewMove"));
+    EXPECT_TRUE(tree->nodeExists("overviewFade"));
+}

--- a/tests/config/shared/ConfigValues.cpp
+++ b/tests/config/shared/ConfigValues.cpp
@@ -1,0 +1,20 @@
+#include <config/values/ConfigValues.hpp>
+
+#include <gtest/gtest.h>
+
+#include <ranges>
+
+TEST(ConfigValues, hasOverviewBorderColors) {
+    const auto findColor = [](std::string_view name) -> const Config::Values::CColorValue* {
+        const auto IT = std::ranges::find_if(Config::Values::CONFIG_VALUES, [name](const auto& value) { return std::string_view{value->name()} == name; });
+        return IT == Config::Values::CONFIG_VALUES.end() ? nullptr : dc<const Config::Values::CColorValue*>(IT->get());
+    };
+
+    const auto* ACTIVE   = findColor("overview:col.active_border");
+    const auto* INACTIVE = findColor("overview:col.inactive_border");
+
+    ASSERT_NE(ACTIVE, nullptr);
+    ASSERT_NE(INACTIVE, nullptr);
+    EXPECT_EQ(ACTIVE->defaultVal(), 0xffffffff);
+    EXPECT_EQ(INACTIVE->defaultVal(), 0xff444444);
+}

--- a/tests/config/shared/ConfigValues.cpp
+++ b/tests/config/shared/ConfigValues.cpp
@@ -18,3 +18,34 @@ TEST(ConfigValues, hasOverviewBorderColors) {
     EXPECT_EQ(ACTIVE->defaultVal(), 0xffffffff);
     EXPECT_EQ(INACTIVE->defaultVal(), 0xff444444);
 }
+
+TEST(ConfigValues, hasOverviewSearchModes) {
+    const auto findString = [](std::string_view name) -> const Config::Values::CStringValue* {
+        const auto IT = std::ranges::find_if(Config::Values::CONFIG_VALUES, [name](const auto& value) { return std::string_view{value->name()} == name; });
+        return IT == Config::Values::CONFIG_VALUES.end() ? nullptr : dc<const Config::Values::CStringValue*>(IT->get());
+    };
+
+    const auto findInt = [](std::string_view name) -> const Config::Values::CIntValue* {
+        const auto IT = std::ranges::find_if(Config::Values::CONFIG_VALUES, [name](const auto& value) { return std::string_view{value->name()} == name; });
+        return IT == Config::Values::CONFIG_VALUES.end() ? nullptr : dc<const Config::Values::CIntValue*>(IT->get());
+    };
+
+    const auto* WINDOW_PREFIX    = findString("overview:search:window_prefix");
+    const auto* WORKSPACE_PREFIX = findString("overview:search:workspace_prefix");
+    const auto* DEFAULT_MODE     = findInt("overview:search:default_mode");
+
+    ASSERT_NE(WINDOW_PREFIX, nullptr);
+    ASSERT_NE(WORKSPACE_PREFIX, nullptr);
+    ASSERT_NE(DEFAULT_MODE, nullptr);
+    EXPECT_EQ(WINDOW_PREFIX->defaultVal(), "/");
+    EXPECT_EQ(WORKSPACE_PREFIX->defaultVal(), ".");
+    EXPECT_EQ(DEFAULT_MODE->defaultVal(), 0);
+
+    EXPECT_TRUE(WINDOW_PREFIX->validator()("/").has_value());
+    EXPECT_FALSE(WINDOW_PREFIX->validator()("").has_value());
+    EXPECT_FALSE(WINDOW_PREFIX->validator()("//").has_value());
+    ASSERT_TRUE(DEFAULT_MODE->m_map.has_value());
+    EXPECT_EQ(DEFAULT_MODE->m_map->at("all"), 0);
+    EXPECT_EQ(DEFAULT_MODE->m_map->at("window"), 1);
+    EXPECT_EQ(DEFAULT_MODE->m_map->at("workspace"), 2);
+}

--- a/tests/helpers/KeyboardEventHandlerStack.cpp
+++ b/tests/helpers/KeyboardEventHandlerStack.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <managers/SeatManager.hpp>
+
+class CTestKeyboard : public IKeyboard {
+  public:
+    virtual bool isVirtual() override {
+        return false;
+    }
+
+    virtual SP<Aquamarine::IKeyboard> aq() override {
+        return nullptr;
+    }
+};
+
+class CTestKeyboardEventHandler : public IKeyboardEventHandler {
+  public:
+    struct SEvent {
+        uint32_t              keycode = 0;
+        wl_keyboard_key_state state   = WL_KEYBOARD_KEY_STATE_RELEASED;
+    };
+
+    virtual void onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboard>) override {
+        m_events.emplace_back(SEvent{
+            .keycode = event.keycode,
+            .state   = event.state,
+        });
+    }
+
+    std::vector<SEvent> m_events;
+};
+
+static IKeyboard::SKeyEvent keyEvent(uint32_t keycode, wl_keyboard_key_state state) {
+    return IKeyboard::SKeyEvent{
+        .keycode = keycode,
+        .state   = state,
+    };
+}
+
+TEST(KeyboardEventHandlerStack, RoutesNewPressesToTopHandler) {
+    CKeyboardEventHandlerStack stack;
+    const auto                 KEYBOARD = makeShared<CTestKeyboard>();
+    const auto                 FIRST    = makeShared<CTestKeyboardEventHandler>();
+    const auto                 SECOND   = makeShared<CTestKeyboardEventHandler>();
+
+    stack.push(FIRST);
+    EXPECT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+
+    stack.push(SECOND);
+    EXPECT_TRUE(stack.dispatch(keyEvent(11, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+
+    ASSERT_EQ(FIRST->m_events.size(), 1);
+    EXPECT_EQ(FIRST->m_events.front().keycode, 10);
+    ASSERT_EQ(SECOND->m_events.size(), 1);
+    EXPECT_EQ(SECOND->m_events.front().keycode, 11);
+}
+
+TEST(KeyboardEventHandlerStack, RoutesReleaseToPressOwner) {
+    CKeyboardEventHandlerStack stack;
+    const auto                 KEYBOARD = makeShared<CTestKeyboard>();
+    const auto                 FIRST    = makeShared<CTestKeyboardEventHandler>();
+    const auto                 SECOND   = makeShared<CTestKeyboardEventHandler>();
+
+    stack.push(FIRST);
+    ASSERT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+    stack.push(SECOND);
+
+    EXPECT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_RELEASED), KEYBOARD, false));
+    ASSERT_EQ(FIRST->m_events.size(), 2);
+    EXPECT_EQ(FIRST->m_events.back().state, WL_KEYBOARD_KEY_STATE_RELEASED);
+    EXPECT_TRUE(SECOND->m_events.empty());
+}
+
+TEST(KeyboardEventHandlerStack, RemovingTopRestoresPreviousHandler) {
+    CKeyboardEventHandlerStack stack;
+    const auto                 KEYBOARD = makeShared<CTestKeyboard>();
+    const auto                 FIRST    = makeShared<CTestKeyboardEventHandler>();
+    const auto                 SECOND   = makeShared<CTestKeyboardEventHandler>();
+
+    stack.push(FIRST);
+    stack.push(SECOND);
+    EXPECT_TRUE(stack.remove(SECOND));
+    EXPECT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+
+    ASSERT_EQ(FIRST->m_events.size(), 1);
+    EXPECT_TRUE(SECOND->m_events.empty());
+}
+
+TEST(KeyboardEventHandlerStack, ConsumesOwnedReleaseAfterHandlerExpires) {
+    CKeyboardEventHandlerStack stack;
+    const auto                 KEYBOARD = makeShared<CTestKeyboard>();
+    auto                       HANDLER  = makeShared<CTestKeyboardEventHandler>();
+
+    stack.push(HANDLER);
+    ASSERT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+    HANDLER.reset();
+
+    EXPECT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_RELEASED), KEYBOARD, true));
+    EXPECT_FALSE(stack.dispatch(keyEvent(11, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+}
+
+TEST(KeyboardEventHandlerStack, DropsOwnershipWithKeyboard) {
+    CKeyboardEventHandlerStack stack;
+    const auto                 KEYBOARD = makeShared<CTestKeyboard>();
+    const auto                 HANDLER  = makeShared<CTestKeyboardEventHandler>();
+
+    stack.push(HANDLER);
+    ASSERT_TRUE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_PRESSED), KEYBOARD, true));
+    stack.onKeyboardRemoved(KEYBOARD);
+
+    EXPECT_FALSE(stack.dispatch(keyEvent(10, WL_KEYBOARD_KEY_STATE_RELEASED), KEYBOARD, true));
+    EXPECT_EQ(HANDLER->m_events.size(), 1);
+}

--- a/tests/helpers/PointerTransformer.cpp
+++ b/tests/helpers/PointerTransformer.cpp
@@ -1,0 +1,17 @@
+#include <pointer/PointerTransformer.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Pointer;
+
+TEST(PointerTransformer, ownsCallback) {
+    const CPointerTransformer transformer{[offset = Vector2D{15, -7}](Vector2D position) { return position + offset; }};
+
+    EXPECT_EQ(transformer.transform({10, 20}), Vector2D(25, 13));
+}
+
+TEST(PointerTransformer, emptyCallbackReturnsInput) {
+    const CPointerTransformer transformer{std::function<Vector2D(Vector2D)>{}};
+
+    EXPECT_EQ(transformer.transform({10, 20}), Vector2D(10, 20));
+}

--- a/tests/overview/OverviewGesture.cpp
+++ b/tests/overview/OverviewGesture.cpp
@@ -1,0 +1,123 @@
+#include <managers/input/trackpad/gestures/OverviewGesture.hpp>
+#include <overview/Overview.hpp>
+
+#include <gtest/gtest.h>
+
+class CTestInteractiveOverview final : public Overview::IOverview, public Overview::IOverviewGesture {
+  public:
+    virtual void open(PHLMONITOR) override {
+        m_open = true;
+    }
+
+    virtual void close() override {
+        m_open = false;
+    }
+
+    virtual bool isOpen() const override {
+        return m_open;
+    }
+
+    virtual bool beginGesture(PHLMONITOR) override {
+        m_beginCount++;
+        return m_acceptBegin;
+    }
+
+    virtual void updateGesture(float completion) override {
+        m_completion = completion;
+    }
+
+    virtual void endGesture(bool commit) override {
+        m_endCount++;
+        m_committed = commit;
+    }
+
+    bool  m_open        = false;
+    bool  m_acceptBegin = true;
+    bool  m_committed   = false;
+    float m_completion  = 0.F;
+    int   m_beginCount  = 0;
+    int   m_endCount    = 0;
+};
+
+class CScopedTestOverview {
+  public:
+    CScopedTestOverview() : m_previous(std::move(Overview::overview())) {
+        Overview::overview() = makeUnique<CTestInteractiveOverview>();
+    }
+
+    ~CScopedTestOverview() {
+        Overview::overview() = std::move(m_previous);
+    }
+
+    CTestInteractiveOverview& get() const {
+        return *dynamic_cast<CTestInteractiveOverview*>(Overview::overview().get());
+    }
+
+  private:
+    UP<Overview::IOverview> m_previous;
+};
+
+TEST(OverviewGesture, tracksSwipeAndUsesCommitThreshold) {
+    CScopedTestOverview         scopedOverview;
+    COverviewTrackpadGesture    gesture;
+    IPointer::SSwipeUpdateEvent update{.delta = {0, -40}};
+    IPointer::SSwipeEndEvent    end;
+
+    gesture.begin({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_UP});
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_UP});
+
+    EXPECT_EQ(scopedOverview.get().m_beginCount, 1);
+    EXPECT_FLOAT_EQ(scopedOverview.get().m_completion, 0.2F);
+
+    gesture.end({.swipe = &end, .direction = TRACKPAD_GESTURE_DIR_UP});
+    EXPECT_EQ(scopedOverview.get().m_endCount, 1);
+    EXPECT_FALSE(scopedOverview.get().m_committed);
+
+    update.delta = {0, -60};
+    gesture.begin({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_UP});
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_UP});
+    gesture.end({.swipe = &end, .direction = TRACKPAD_GESTURE_DIR_UP});
+
+    EXPECT_TRUE(scopedOverview.get().m_committed);
+}
+
+TEST(OverviewGesture, reversesAndClampsProgress) {
+    CScopedTestOverview         scopedOverview;
+    COverviewTrackpadGesture    gesture;
+    IPointer::SSwipeUpdateEvent update{.delta = {-250, 0}};
+
+    gesture.begin({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_LEFT});
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_LEFT});
+    EXPECT_FLOAT_EQ(scopedOverview.get().m_completion, 1.F);
+
+    update.delta = {300, 0};
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_LEFT});
+    EXPECT_FLOAT_EQ(scopedOverview.get().m_completion, 0.F);
+}
+
+TEST(OverviewGesture, cancellationOverridesCommit) {
+    CScopedTestOverview         scopedOverview;
+    IPointer::SSwipeUpdateEvent update{.delta = {0, 200}};
+    IPointer::SSwipeEndEvent    end{.cancelled = true};
+
+    {
+        COverviewTrackpadGesture gesture;
+        gesture.begin({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_DOWN});
+        gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_DOWN});
+        gesture.end({.swipe = &end, .direction = TRACKPAD_GESTURE_DIR_DOWN});
+    }
+
+    EXPECT_EQ(scopedOverview.get().m_endCount, 1);
+    EXPECT_FALSE(scopedOverview.get().m_committed);
+}
+
+TEST(OverviewGesture, supportsScaledPinchDistance) {
+    CScopedTestOverview         scopedOverview;
+    COverviewTrackpadGesture    gesture;
+    IPointer::SPinchUpdateEvent update{.scale = 1.1};
+
+    gesture.begin({.pinch = &update, .direction = TRACKPAD_GESTURE_DIR_PINCH_IN, .scale = 2.F});
+    gesture.update({.pinch = &update, .direction = TRACKPAD_GESTURE_DIR_PINCH_IN, .scale = 2.F});
+
+    EXPECT_FLOAT_EQ(scopedOverview.get().m_completion, 0.4F);
+}

--- a/tests/overview/OverviewGesture.cpp
+++ b/tests/overview/OverviewGesture.cpp
@@ -1,9 +1,10 @@
 #include <managers/input/trackpad/gestures/OverviewGesture.hpp>
+#include <managers/input/trackpad/gestures/WorkspaceSwipeGesture.hpp>
 #include <overview/Overview.hpp>
 
 #include <gtest/gtest.h>
 
-class CTestInteractiveOverview final : public Overview::IOverview, public Overview::IOverviewGesture {
+class CTestInteractiveOverview final : public Overview::IOverview, public Overview::IOverviewGestureOpenable, public Overview::IOverviewGestureMovable {
   public:
     virtual void open(PHLMONITOR) override {
         m_open = true;
@@ -17,26 +18,45 @@ class CTestInteractiveOverview final : public Overview::IOverview, public Overvi
         return m_open;
     }
 
-    virtual bool beginGesture(PHLMONITOR) override {
+    virtual bool beginOpenGesture(PHLMONITOR) override {
         m_beginCount++;
         return m_acceptBegin;
     }
 
-    virtual void updateGesture(float completion) override {
+    virtual void updateOpenGesture(float completion) override {
         m_completion = completion;
     }
 
-    virtual void endGesture(bool commit) override {
+    virtual void endOpenGesture(bool commit) override {
         m_endCount++;
         m_committed = commit;
     }
 
-    bool  m_open        = false;
-    bool  m_acceptBegin = true;
-    bool  m_committed   = false;
-    float m_completion  = 0.F;
-    int   m_beginCount  = 0;
-    int   m_endCount    = 0;
+    virtual bool beginMoveGesture() override {
+        m_moveBeginCount++;
+        return m_acceptMoveBegin;
+    }
+
+    virtual void updateMoveGesture(float delta) override {
+        m_moveUpdateCount++;
+        m_moveDelta = delta;
+    }
+
+    virtual void endMoveGesture() override {
+        m_moveEndCount++;
+    }
+
+    bool  m_open            = false;
+    bool  m_acceptBegin     = true;
+    bool  m_acceptMoveBegin = true;
+    bool  m_committed       = false;
+    float m_completion      = 0.F;
+    float m_moveDelta       = 0.F;
+    int   m_beginCount      = 0;
+    int   m_endCount        = 0;
+    int   m_moveBeginCount  = 0;
+    int   m_moveUpdateCount = 0;
+    int   m_moveEndCount    = 0;
 };
 
 class CScopedTestOverview {
@@ -120,4 +140,44 @@ TEST(OverviewGesture, supportsScaledPinchDistance) {
     gesture.update({.pinch = &update, .direction = TRACKPAD_GESTURE_DIR_PINCH_IN, .scale = 2.F});
 
     EXPECT_FLOAT_EQ(scopedOverview.get().m_completion, 0.4F);
+}
+
+TEST(WorkspaceSwipeGesture, delegatesDeltaToOpenOverview) {
+    CScopedTestOverview         scopedOverview;
+    CWorkspaceSwipeGesture      gesture;
+    IPointer::SSwipeUpdateEvent update{.delta = {-20, 0}};
+    IPointer::SSwipeEndEvent    end{.cancelled = true};
+    scopedOverview.get().m_open = true;
+
+    gesture.begin({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL, .scale = 2.F});
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL, .scale = 2.F});
+
+    EXPECT_EQ(scopedOverview.get().m_moveBeginCount, 1);
+    EXPECT_EQ(scopedOverview.get().m_moveUpdateCount, 1);
+    EXPECT_FLOAT_EQ(scopedOverview.get().m_moveDelta, -40.F);
+
+    update.delta = {5, 0};
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL, .scale = 2.F});
+    EXPECT_EQ(scopedOverview.get().m_moveUpdateCount, 2);
+    EXPECT_FLOAT_EQ(scopedOverview.get().m_moveDelta, 10.F);
+
+    gesture.end({.swipe = &end, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL, .scale = 2.F});
+    EXPECT_EQ(scopedOverview.get().m_moveEndCount, 1);
+}
+
+TEST(WorkspaceSwipeGesture, ignoresUpdatesWhenMoveBeginIsRejected) {
+    CScopedTestOverview         scopedOverview;
+    CWorkspaceSwipeGesture      gesture;
+    IPointer::SSwipeUpdateEvent update{.delta = {20, 0}};
+    IPointer::SSwipeEndEvent    end;
+    scopedOverview.get().m_open            = true;
+    scopedOverview.get().m_acceptMoveBegin = false;
+
+    gesture.begin({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL});
+    gesture.update({.swipe = &update, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL});
+    gesture.end({.swipe = &end, .direction = TRACKPAD_GESTURE_DIR_HORIZONTAL});
+
+    EXPECT_EQ(scopedOverview.get().m_moveBeginCount, 1);
+    EXPECT_EQ(scopedOverview.get().m_moveUpdateCount, 0);
+    EXPECT_EQ(scopedOverview.get().m_moveEndCount, 0);
 }

--- a/tests/overview/OverviewLayout.cpp
+++ b/tests/overview/OverviewLayout.cpp
@@ -1,0 +1,24 @@
+#include <overview/hyprland/scene/OverviewLayout.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace Overview::Hyprland;
+
+TEST(Overview, overviewLayoutSeparatesSearchMiniStripAndMainArea) {
+    const auto LAYOUT = OverviewLayout::calculate({1920, 1080}, 1.5F);
+
+    EXPECT_FALSE(LAYOUT.logicalSearch.empty());
+    EXPECT_FALSE(LAYOUT.logicalMiniStrip.empty());
+    EXPECT_FALSE(LAYOUT.logicalMain.empty());
+    EXPECT_LE(LAYOUT.logicalSearch.y + LAYOUT.logicalSearch.h, LAYOUT.logicalMiniStrip.y);
+    EXPECT_LE(LAYOUT.logicalMiniStrip.y + LAYOUT.logicalMiniStrip.h, LAYOUT.logicalMain.y);
+    EXPECT_LT(LAYOUT.logicalMain.h, 1080 * 0.9F);
+    EXPECT_FLOAT_EQ(LAYOUT.pixelMiniStrip.w, std::round(LAYOUT.logicalMiniStrip.w * 1.5F));
+}
+
+TEST(Overview, overviewLayoutHandlesInvalidOutputs) {
+    EXPECT_TRUE(OverviewLayout::calculate({}, 1.F).logicalMain.empty());
+    EXPECT_TRUE(OverviewLayout::calculate({1920, 1080}, 0.F).logicalMain.empty());
+}

--- a/tests/overview/Query.cpp
+++ b/tests/overview/Query.cpp
@@ -1,0 +1,157 @@
+#include <overview/hyprland/Query.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Overview::Hyprland;
+using namespace Overview::Hyprland::Mode;
+
+TEST(OverviewQuery, selectsPrefixedModes) {
+    const CQuery WINDOW_QUERY{"/firefox"};
+    const CQuery WORKSPACE_QUERY{".coding"};
+
+    EXPECT_EQ(WINDOW_QUERY.mode(), eQueryMode::WINDOW);
+    EXPECT_EQ(WINDOW_QUERY.term(), "firefox");
+    EXPECT_EQ(WORKSPACE_QUERY.mode(), eQueryMode::WORKSPACE);
+    EXPECT_EQ(WORKSPACE_QUERY.term(), "coding");
+}
+
+TEST(OverviewQuery, resolvesModeForProvidedQuery) {
+    const CQuery QUERY{"unprefixed"};
+
+    EXPECT_EQ(QUERY.mode("/firefox"), eQueryMode::WINDOW);
+    EXPECT_EQ(QUERY.mode(".coding"), eQueryMode::WORKSPACE);
+    EXPECT_EQ(QUERY.mode("unprefixed"), eQueryMode::ALL);
+}
+
+TEST(OverviewQuery, supportsCustomPrefixes) {
+    const SQueryConfig CONFIG{.windowPrefix = '!', .workspacePrefix = '@'};
+    const CQuery       WINDOW_QUERY{"!firefox", CONFIG};
+    const CQuery       WORKSPACE_QUERY{"@coding", CONFIG};
+    const CQuery       OLD_PREFIX{"/firefox", CONFIG};
+
+    EXPECT_EQ(WINDOW_QUERY.mode(), eQueryMode::WINDOW);
+    EXPECT_EQ(WINDOW_QUERY.term(), "firefox");
+    EXPECT_EQ(WORKSPACE_QUERY.mode(), eQueryMode::WORKSPACE);
+    EXPECT_EQ(WORKSPACE_QUERY.term(), "coding");
+    EXPECT_EQ(OLD_PREFIX.mode(), eQueryMode::ALL);
+    EXPECT_EQ(OLD_PREFIX.term(), "/firefox");
+}
+
+TEST(OverviewQuery, usesConfiguredDefaultWithoutStrippingUnknownPrefix) {
+    const CQuery QUERY{"?coding", SQueryConfig{.defaultMode = eQueryMode::WORKSPACE}};
+
+    EXPECT_EQ(QUERY.mode(), eQueryMode::WORKSPACE);
+    EXPECT_EQ(QUERY.term(), "?coding");
+}
+
+TEST(OverviewQuery, supportsEveryDefaultMode) {
+    EXPECT_EQ(CQuery("term", SQueryConfig{.defaultMode = eQueryMode::ALL}).mode(), eQueryMode::ALL);
+    EXPECT_EQ(CQuery("term", SQueryConfig{.defaultMode = eQueryMode::WINDOW}).mode(), eQueryMode::WINDOW);
+    EXPECT_EQ(CQuery("term", SQueryConfig{.defaultMode = eQueryMode::WORKSPACE}).mode(), eQueryMode::WORKSPACE);
+}
+
+TEST(OverviewQuery, resolvesDuplicatePrefixesInRegistrationOrder) {
+    const CQuery QUERY{"/term", SQueryConfig{.windowPrefix = '/', .workspacePrefix = '/'}};
+
+    EXPECT_EQ(QUERY.mode(), eQueryMode::WINDOW);
+    EXPECT_EQ(QUERY.term(), "term");
+}
+
+TEST(OverviewQuery, emptyEffectiveQueryDoesNotFilterOrMatchWindows) {
+    const CQuery QUERY{"/"};
+
+    EXPECT_TRUE(QUERY.empty());
+    EXPECT_EQ(QUERY.matchWorkspace("anything"), eWorkspaceMatch::MATCH);
+    EXPECT_FALSE(QUERY.matchesWindow("anything", "anything"));
+}
+
+TEST(OverviewQuery, windowModeMatchesOnlyWindowClassAndTitle) {
+    const CQuery QUERY{"/fire"};
+    bool         selectorCalled = false;
+
+    EXPECT_TRUE(QUERY.matchesWindow("Firefox", "New Tab"));
+    EXPECT_TRUE(QUERY.matchesWindow("org.example.App", "Wildfire"));
+    EXPECT_FALSE(QUERY.matchesWindow("org.example.App", "New Tab"));
+    EXPECT_EQ(QUERY.matchWorkspace("fire",
+                                   [&](std::string_view) {
+                                       selectorCalled = true;
+                                       return true;
+                                   }),
+              eWorkspaceMatch::NONE);
+    EXPECT_FALSE(selectorCalled);
+    EXPECT_TRUE(QUERY.usesWindowMetadata());
+}
+
+TEST(OverviewQuery, workspaceModeMatchesNamesAndExactNames) {
+    const CQuery QUERY{".coding"};
+
+    EXPECT_EQ(QUERY.matchWorkspace("Main Coding"), eWorkspaceMatch::MATCH);
+    EXPECT_EQ(QUERY.matchWorkspace("CoDiNg"), eWorkspaceMatch::EXACT);
+    EXPECT_EQ(QUERY.matchWorkspace("gaming"), eWorkspaceMatch::NONE);
+    EXPECT_FALSE(QUERY.matchesWindow("coding", "coding"));
+    EXPECT_FALSE(QUERY.usesWindowMetadata());
+}
+
+TEST(OverviewQuery, workspaceModeDelegatesStaticSelectors) {
+    const CQuery QUERY{".m[DP-1]"};
+    bool         selectorCalled = false;
+
+    const auto   MATCH = QUERY.matchWorkspace("coding", [&](std::string_view selector) {
+        selectorCalled = true;
+        EXPECT_EQ(selector, "m[DP-1]");
+        return true;
+    });
+
+    EXPECT_TRUE(selectorCalled);
+    EXPECT_EQ(MATCH, eWorkspaceMatch::MATCH);
+}
+
+TEST(OverviewQuery, workspaceModeRecognizesWhitespaceWrappedSelectors) {
+    for (const auto& raw : {". name:coding ", ". 1 ", ". m[DP-1] "}) {
+        const CQuery QUERY{raw};
+        bool         selectorCalled = false;
+
+        EXPECT_EQ(QUERY.matchWorkspace("unrelated",
+                                       [&](std::string_view) {
+                                           selectorCalled = true;
+                                           return true;
+                                       }),
+                  eWorkspaceMatch::MATCH);
+        EXPECT_TRUE(selectorCalled);
+    }
+}
+
+TEST(OverviewQuery, workspaceModeRejectsUnmatchedAndMalformedSelectors) {
+    const CQuery QUERY{".m[DP-1"};
+    bool         selectorCalled = false;
+
+    EXPECT_EQ(QUERY.matchWorkspace("coding",
+                                   [&](std::string_view selector) {
+                                       selectorCalled = true;
+                                       EXPECT_EQ(selector, "m[DP-1");
+                                       return false;
+                                   }),
+              eWorkspaceMatch::NONE);
+    EXPECT_TRUE(selectorCalled);
+}
+
+TEST(OverviewQuery, plainWorkspaceSearchDoesNotInvokeSelectorParser) {
+    const CQuery QUERY{".missing"};
+    bool         selectorCalled = false;
+
+    EXPECT_EQ(QUERY.matchWorkspace("coding",
+                                   [&](std::string_view) {
+                                       selectorCalled = true;
+                                       return true;
+                                   }),
+              eWorkspaceMatch::NONE);
+    EXPECT_FALSE(selectorCalled);
+}
+
+TEST(OverviewQuery, combinedModePreservesExistingMatching) {
+    const CQuery QUERY{"fire"};
+
+    EXPECT_EQ(QUERY.matchWorkspace("Wildfire"), eWorkspaceMatch::MATCH);
+    EXPECT_EQ(QUERY.matchWorkspace("FiRe"), eWorkspaceMatch::EXACT);
+    EXPECT_TRUE(QUERY.matchesWindow("Firefox", "New Tab"));
+}

--- a/tests/overview/StringUtils.cpp
+++ b/tests/overview/StringUtils.cpp
@@ -1,12 +1,11 @@
-#include <overview/hyprland/scene/OverviewScene.hpp>
+#include <overview/hyprland/StringUtils.hpp>
 
 #include <gtest/gtest.h>
 
-#include <cmath>
-
 using namespace Overview::Hyprland;
+using namespace Overview::Hyprland::StringUtils;
 
-TEST(Overview, workspaceSearchMatchesASCIIInsensitiveSubstrings) {
+TEST(Overview, searchMatchesASCIIInsensitiveSubstrings) {
     EXPECT_TRUE(matchesName("Alpha", "alp"));
     EXPECT_TRUE(matchesName("Alpha", "PHA"));
     EXPECT_TRUE(matchesName("workspace 10", "1"));
@@ -14,7 +13,12 @@ TEST(Overview, workspaceSearchMatchesASCIIInsensitiveSubstrings) {
     EXPECT_FALSE(matchesName("Alpha", "beta"));
 }
 
-TEST(Overview, workspaceSearchLeavesNonASCIICaseSensitive) {
+TEST(Overview, searchLeavesNonASCIICaseSensitive) {
     EXPECT_TRUE(matchesName("Ärger", "Är"));
     EXPECT_FALSE(matchesName("Ärger", "är"));
+}
+
+TEST(Overview, searchMatchesInsensitive) {
+    EXPECT_TRUE(fullMatchCaseIns("pEeNoR", "PEENOR"));
+    EXPECT_FALSE(fullMatchCaseIns("FUCKERS", "fucker"));
 }

--- a/tests/overview/WorkspaceMiniStripLayout.cpp
+++ b/tests/overview/WorkspaceMiniStripLayout.cpp
@@ -1,0 +1,35 @@
+#include <overview/hyprland/scene/WorkspaceMiniStripLayout.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+using Hyprutils::Math::Vector2D;
+
+TEST(Overview, workspaceMiniStripCentersTilesAndPreservesAspectRatios) {
+    const CBox                  BOUNDS      = {{40, 50}, {1000, 120}};
+    const std::vector<Vector2D> sourceSizes = {{1920, 1080}, {1080, 1920}, {3440, 1440}};
+
+    const auto                  BOXES = WorkspaceMiniStripLayout::calculate(BOUNDS, sourceSizes, 1, 0.15F);
+    ASSERT_EQ(BOXES.size(), sourceSizes.size());
+    EXPECT_FLOAT_EQ(BOXES.at(0).h, BOUNDS.h);
+    EXPECT_FLOAT_EQ(BOXES.at(1).h, BOUNDS.h);
+    EXPECT_FLOAT_EQ(BOXES.at(2).h, BOUNDS.h);
+    EXPECT_NEAR(BOXES.at(0).w / BOXES.at(0).h, 1920.F / 1080.F, 0.001F);
+    EXPECT_NEAR(BOXES.at(1).w / BOXES.at(1).h, 1080.F / 1920.F, 0.001F);
+    EXPECT_NEAR(BOXES.at(2).w / BOXES.at(2).h, 3440.F / 1440.F, 0.001F);
+    EXPECT_NEAR((BOXES.front().x + BOXES.back().x + BOXES.back().w) / 2.F, BOUNDS.x + BOUNDS.w / 2.F, 0.001F);
+}
+
+TEST(Overview, workspaceMiniStripKeepsSelectedTileVisibleOnOverflow) {
+    const CBox                  BOUNDS = {{40, 50}, {500, 100}};
+    const std::vector<Vector2D> sourceSizes(8, {1920, 1080});
+
+    const auto                  FIRST = WorkspaceMiniStripLayout::calculate(BOUNDS, sourceSizes, 0, 0.15F);
+    const auto                  LAST  = WorkspaceMiniStripLayout::calculate(BOUNDS, sourceSizes, sourceSizes.size() - 1, 0.15F);
+
+    EXPECT_FLOAT_EQ(FIRST.front().x, BOUNDS.x);
+    EXPECT_FLOAT_EQ(LAST.back().x + LAST.back().w, BOUNDS.x + BOUNDS.w);
+    EXPECT_FALSE(FIRST.front().intersection(BOUNDS).empty());
+    EXPECT_FALSE(LAST.back().intersection(BOUNDS).empty());
+}

--- a/tests/overview/WorkspacePointerMapping.cpp
+++ b/tests/overview/WorkspacePointerMapping.cpp
@@ -1,0 +1,54 @@
+#include <overview/hyprland/scene/WorkspacePointerMapping.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+using Hyprutils::Math::Vector2D;
+
+TEST(Overview, workspacePointerMappingMapsTileCenter) {
+    const CBox TILE   = {{100, 200}, {800, 400}};
+    const CBox SOURCE = {{-1920, 120}, {1920, 1080}};
+
+    const auto MAPPED = WorkspacePointerMapping::mapClamped({500, 400}, TILE, SOURCE);
+
+    ASSERT_TRUE(MAPPED.has_value());
+    EXPECT_DOUBLE_EQ(MAPPED->x, -960);
+    EXPECT_DOUBLE_EQ(MAPPED->y, 660);
+}
+
+TEST(Overview, workspacePointerMappingClampsOutsideTile) {
+    const CBox TILE   = {{100, 200}, {800, 400}};
+    const CBox SOURCE = {{1920, -1080}, {2560, 1440}};
+
+    const auto TOP_LEFT     = WorkspacePointerMapping::mapClamped({-500, -500}, TILE, SOURCE);
+    const auto BOTTOM_RIGHT = WorkspacePointerMapping::mapClamped({5000, 5000}, TILE, SOURCE);
+
+    ASSERT_TRUE(TOP_LEFT.has_value());
+    EXPECT_EQ(*TOP_LEFT, SOURCE.pos());
+
+    ASSERT_TRUE(BOTTOM_RIGHT.has_value());
+    EXPECT_LT(BOTTOM_RIGHT->x, SOURCE.x + SOURCE.w);
+    EXPECT_LT(BOTTOM_RIGHT->y, SOURCE.y + SOURCE.h);
+    EXPECT_DOUBLE_EQ(std::nextafter(BOTTOM_RIGHT->x, INFINITY), SOURCE.x + SOURCE.w);
+    EXPECT_DOUBLE_EQ(std::nextafter(BOTTOM_RIGHT->y, INFINITY), SOURCE.y + SOURCE.h);
+}
+
+TEST(Overview, workspacePointerMappingHandlesFractionalGeometry) {
+    const CBox TILE   = {{12.5, 20.25}, {333.5, 187.75}};
+    const CBox SOURCE = {{-1280, 64}, {1280, 1024}};
+
+    const auto MAPPED = WorkspacePointerMapping::mapClamped({95.875, 67.1875}, TILE, SOURCE);
+
+    ASSERT_TRUE(MAPPED.has_value());
+    EXPECT_NEAR(MAPPED->x, -960, 0.0001);
+    EXPECT_NEAR(MAPPED->y, 320, 0.0001);
+}
+
+TEST(Overview, workspacePointerMappingRejectsInvalidGeometry) {
+    EXPECT_FALSE(WorkspacePointerMapping::mapClamped({10, 20}, {{}, {}}, {{0, 0}, {1920, 1080}}).has_value());
+    EXPECT_FALSE(WorkspacePointerMapping::mapClamped({10, 20}, {{0, 0}, {1920, 1080}}, {{}, {}}).has_value());
+    EXPECT_FALSE(WorkspacePointerMapping::mapClamped(Vector2D{INFINITY, 20.0}, {{0, 0}, {1920, 1080}}, {{0, 0}, {1920, 1080}}).has_value());
+}

--- a/tests/overview/WorkspaceScene.cpp
+++ b/tests/overview/WorkspaceScene.cpp
@@ -1,0 +1,20 @@
+#include <overview/hyprland/scene/OverviewScene.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace Overview::Hyprland;
+
+TEST(Overview, workspaceSearchMatchesASCIIInsensitiveSubstrings) {
+    EXPECT_TRUE(matchesName("Alpha", "alp"));
+    EXPECT_TRUE(matchesName("Alpha", "PHA"));
+    EXPECT_TRUE(matchesName("workspace 10", "1"));
+    EXPECT_TRUE(matchesName("anything", ""));
+    EXPECT_FALSE(matchesName("Alpha", "beta"));
+}
+
+TEST(Overview, workspaceSearchLeavesNonASCIICaseSensitive) {
+    EXPECT_TRUE(matchesName("Ärger", "Är"));
+    EXPECT_FALSE(matchesName("Ärger", "är"));
+}

--- a/tests/overview/WorkspaceSearch.cpp
+++ b/tests/overview/WorkspaceSearch.cpp
@@ -1,0 +1,30 @@
+#include <overview/hyprland/scene/WorkspaceSearch.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using namespace Overview::Hyprland;
+
+TEST(Overview, workspaceSearchGeometryFitsTopMarginAtFractionalScale) {
+    const auto GEOMETRY = WorkspaceSearch::calculateGeometry({1920, 1080}, 1.5F);
+
+    EXPECT_GT(GEOMETRY.logicalBox.w, 0);
+    EXPECT_GT(GEOMETRY.logicalBox.h, 0);
+    EXPECT_GE(GEOMETRY.logicalBox.x, 0);
+    EXPECT_GE(GEOMETRY.logicalBox.y, 0);
+    EXPECT_LE(GEOMETRY.logicalBox.x + GEOMETRY.logicalBox.w, 1920);
+    EXPECT_LE(GEOMETRY.logicalBox.y + GEOMETRY.logicalBox.h, 1080 * 0.05F);
+    EXPECT_FLOAT_EQ(GEOMETRY.pixelBox.w, std::round(GEOMETRY.logicalBox.w * 1.5F));
+    EXPECT_FLOAT_EQ(GEOMETRY.pixelBox.h, std::round(GEOMETRY.logicalBox.h * 1.5F));
+}
+
+TEST(Overview, workspaceSearchGeometryHandlesSmallAndInvalidOutputs) {
+    const auto SMALL = WorkspaceSearch::calculateGeometry({320, 200}, 1.F);
+    EXPECT_FALSE(SMALL.logicalBox.empty());
+    EXPECT_LE(SMALL.logicalBox.x + SMALL.logicalBox.w, 320);
+    EXPECT_LE(SMALL.logicalBox.y + SMALL.logicalBox.h, 200 * 0.05F);
+
+    EXPECT_TRUE(WorkspaceSearch::calculateGeometry({}, 1.F).logicalBox.empty());
+    EXPECT_TRUE(WorkspaceSearch::calculateGeometry({1920, 1080}, 0.F).logicalBox.empty());
+}

--- a/tests/overview/WorkspaceTapeLayout.cpp
+++ b/tests/overview/WorkspaceTapeLayout.cpp
@@ -1,0 +1,50 @@
+#include <overview/hyprland/scene/WorkspaceTapeLayout.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::Vector2D;
+
+TEST(Overview, workspaceTapeLayoutFitsTilesAndKeepsUniformGaps) {
+    constexpr Vector2D          MONITOR_SIZE = {1920, 1080};
+    constexpr float             TILE_SCALE   = 0.9F;
+    constexpr float             GAP_SCALE    = 0.02F;
+    constexpr float             EXPECTED_GAP = MONITOR_SIZE.x * GAP_SCALE;
+
+    const std::vector<Vector2D> sourceSizes = {
+        {1080, 1920},
+        {1920, 1080},
+        {3440, 1440},
+    };
+
+    const auto BOXES = WorkspaceTapeLayout::calculate(MONITOR_SIZE, sourceSizes, 1, TILE_SCALE, GAP_SCALE);
+    ASSERT_EQ(BOXES.size(), sourceSizes.size());
+
+    EXPECT_FLOAT_EQ(BOXES.at(1).w, MONITOR_SIZE.x * TILE_SCALE);
+    EXPECT_FLOAT_EQ(BOXES.at(1).h, MONITOR_SIZE.y * TILE_SCALE);
+    EXPECT_FLOAT_EQ(BOXES.at(1).x, (MONITOR_SIZE.x - BOXES.at(1).w) / 2.F);
+    EXPECT_FLOAT_EQ(BOXES.at(1).y, (MONITOR_SIZE.y - BOXES.at(1).h) / 2.F);
+
+    EXPECT_FLOAT_EQ(BOXES.at(0).h, MONITOR_SIZE.y * TILE_SCALE);
+    EXPECT_LT(BOXES.at(0).w, MONITOR_SIZE.x * TILE_SCALE);
+    EXPECT_FLOAT_EQ(BOXES.at(2).w, MONITOR_SIZE.x * TILE_SCALE);
+    EXPECT_LT(BOXES.at(2).h, MONITOR_SIZE.y * TILE_SCALE);
+
+    EXPECT_FLOAT_EQ(BOXES.at(1).x - BOXES.at(0).x - BOXES.at(0).w, EXPECTED_GAP);
+    EXPECT_FLOAT_EQ(BOXES.at(2).x - BOXES.at(1).x - BOXES.at(1).w, EXPECTED_GAP);
+    EXPECT_FLOAT_EQ(BOXES.at(0).y, (MONITOR_SIZE.y - BOXES.at(0).h) / 2.F);
+    EXPECT_FLOAT_EQ(BOXES.at(2).y, (MONITOR_SIZE.y - BOXES.at(2).h) / 2.F);
+}
+
+TEST(Overview, workspaceTapeLayoutHandlesEmptyAndInvalidSources) {
+    EXPECT_TRUE(WorkspaceTapeLayout::calculate({1920, 1080}, {}, 0, 0.9F, 0.02F).empty());
+
+    const std::vector<Vector2D> sourceSizes = {{0, 0}};
+    const auto                  BOXES       = WorkspaceTapeLayout::calculate({1920, 1080}, sourceSizes, 10, 0.9F, 0.02F);
+
+    ASSERT_EQ(BOXES.size(), 1U);
+    EXPECT_NEAR(BOXES.at(0).w, 1728, 0.001);
+    EXPECT_NEAR(BOXES.at(0).h, 972, 0.001);
+    EXPECT_NEAR(BOXES.at(0).x, 96, 0.001);
+    EXPECT_NEAR(BOXES.at(0).y, 54, 0.001);
+}

--- a/tests/overview/WorkspaceTapeLayout.cpp
+++ b/tests/overview/WorkspaceTapeLayout.cpp
@@ -3,13 +3,13 @@
 #include <gtest/gtest.h>
 
 using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
 using Hyprutils::Math::Vector2D;
 
 TEST(Overview, workspaceTapeLayoutFitsTilesAndKeepsUniformGaps) {
-    constexpr Vector2D          MONITOR_SIZE = {1920, 1080};
-    constexpr float             TILE_SCALE   = 0.9F;
+    const CBox                  BOUNDS       = {{96, 200}, {1728, 800}};
     constexpr float             GAP_SCALE    = 0.02F;
-    constexpr float             EXPECTED_GAP = MONITOR_SIZE.x * GAP_SCALE;
+    const float                 EXPECTED_GAP = BOUNDS.w * GAP_SCALE;
 
     const std::vector<Vector2D> sourceSizes = {
         {1080, 1920},
@@ -17,30 +17,30 @@ TEST(Overview, workspaceTapeLayoutFitsTilesAndKeepsUniformGaps) {
         {3440, 1440},
     };
 
-    const auto BOXES = WorkspaceTapeLayout::calculate(MONITOR_SIZE, sourceSizes, 1, TILE_SCALE, GAP_SCALE);
+    const auto BOXES = WorkspaceTapeLayout::calculate(BOUNDS, sourceSizes, 1, GAP_SCALE);
     ASSERT_EQ(BOXES.size(), sourceSizes.size());
 
-    EXPECT_FLOAT_EQ(BOXES.at(1).w, MONITOR_SIZE.x * TILE_SCALE);
-    EXPECT_FLOAT_EQ(BOXES.at(1).h, MONITOR_SIZE.y * TILE_SCALE);
-    EXPECT_FLOAT_EQ(BOXES.at(1).x, (MONITOR_SIZE.x - BOXES.at(1).w) / 2.F);
-    EXPECT_FLOAT_EQ(BOXES.at(1).y, (MONITOR_SIZE.y - BOXES.at(1).h) / 2.F);
+    EXPECT_FLOAT_EQ(BOXES.at(1).w, BOUNDS.h * 1920.F / 1080.F);
+    EXPECT_FLOAT_EQ(BOXES.at(1).h, BOUNDS.h);
+    EXPECT_FLOAT_EQ(BOXES.at(1).x, BOUNDS.x + (BOUNDS.w - BOXES.at(1).w) / 2.F);
+    EXPECT_FLOAT_EQ(BOXES.at(1).y, BOUNDS.y + (BOUNDS.h - BOXES.at(1).h) / 2.F);
 
-    EXPECT_FLOAT_EQ(BOXES.at(0).h, MONITOR_SIZE.y * TILE_SCALE);
-    EXPECT_LT(BOXES.at(0).w, MONITOR_SIZE.x * TILE_SCALE);
-    EXPECT_FLOAT_EQ(BOXES.at(2).w, MONITOR_SIZE.x * TILE_SCALE);
-    EXPECT_LT(BOXES.at(2).h, MONITOR_SIZE.y * TILE_SCALE);
+    EXPECT_FLOAT_EQ(BOXES.at(0).h, BOUNDS.h);
+    EXPECT_LT(BOXES.at(0).w, BOUNDS.w);
+    EXPECT_FLOAT_EQ(BOXES.at(2).w, BOUNDS.w);
+    EXPECT_LT(BOXES.at(2).h, BOUNDS.h);
 
     EXPECT_FLOAT_EQ(BOXES.at(1).x - BOXES.at(0).x - BOXES.at(0).w, EXPECTED_GAP);
     EXPECT_FLOAT_EQ(BOXES.at(2).x - BOXES.at(1).x - BOXES.at(1).w, EXPECTED_GAP);
-    EXPECT_FLOAT_EQ(BOXES.at(0).y, (MONITOR_SIZE.y - BOXES.at(0).h) / 2.F);
-    EXPECT_FLOAT_EQ(BOXES.at(2).y, (MONITOR_SIZE.y - BOXES.at(2).h) / 2.F);
+    EXPECT_FLOAT_EQ(BOXES.at(0).y, BOUNDS.y + (BOUNDS.h - BOXES.at(0).h) / 2.F);
+    EXPECT_FLOAT_EQ(BOXES.at(2).y, BOUNDS.y + (BOUNDS.h - BOXES.at(2).h) / 2.F);
 }
 
 TEST(Overview, workspaceTapeLayoutHandlesEmptyAndInvalidSources) {
-    EXPECT_TRUE(WorkspaceTapeLayout::calculate({1920, 1080}, {}, 0, 0.9F, 0.02F).empty());
+    EXPECT_TRUE(WorkspaceTapeLayout::calculate({{0, 0}, {1920, 1080}}, {}, 0, 0.02F).empty());
 
     const std::vector<Vector2D> sourceSizes = {{0, 0}};
-    const auto                  BOXES       = WorkspaceTapeLayout::calculate({1920, 1080}, sourceSizes, 10, 0.9F, 0.02F);
+    const auto                  BOXES       = WorkspaceTapeLayout::calculate({{96, 54}, {1728, 972}}, sourceSizes, 10, 0.02F);
 
     ASSERT_EQ(BOXES.size(), 1U);
     EXPECT_NEAR(BOXES.at(0).w, 1728, 0.001);

--- a/tests/overview/WorkspaceTileShadow.cpp
+++ b/tests/overview/WorkspaceTileShadow.cpp
@@ -1,0 +1,30 @@
+#include <overview/hyprland/scene/WorkspaceTileShadow.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Overview::Hyprland;
+using Hyprutils::Math::CBox;
+
+TEST(Overview, workspaceTileShadowScalesAndExpandsGeometry) {
+    const CBox TILE = {100, 200, 800, 450};
+
+    const auto SHADOW = WorkspaceTileShadow::calculate(TILE, 2.F, 0.8F, 0.5F, 14.F, 20.F);
+    ASSERT_TRUE(SHADOW);
+
+    EXPECT_EQ(SHADOW->range, 14);
+    EXPECT_EQ(SHADOW->rounding, 20);
+    EXPECT_FLOAT_EQ(SHADOW->opacity, 0.5F);
+    EXPECT_EQ(SHADOW->outerBox, TILE.copy().expand(14));
+}
+
+TEST(Overview, workspaceTileShadowFollowsVisibility) {
+    const CBox TILE = {0, 0, 1920, 1080};
+
+    EXPECT_FALSE(WorkspaceTileShadow::calculate(TILE, 1.F, 1.F, 0.F, 14.F, 20.F));
+    EXPECT_FALSE(WorkspaceTileShadow::calculate(TILE, 1.F, 0.F, 1.F, 14.F, 20.F));
+    EXPECT_FALSE(WorkspaceTileShadow::calculate(TILE, 0.F, 1.F, 1.F, 14.F, 20.F));
+
+    const auto SHADOW = WorkspaceTileShadow::calculate(TILE, 1.F, 0.25F, 1.F, 14.F, 20.F);
+    ASSERT_TRUE(SHADOW);
+    EXPECT_FLOAT_EQ(SHADOW->opacity, 0.25F);
+}

--- a/tests/render/BackdropScopePassElement.cpp
+++ b/tests/render/BackdropScopePassElement.cpp
@@ -1,6 +1,7 @@
 #include <render/pass/BackdropScopePassElement.hpp>
 #include <render/pass/TexPassElement.hpp>
 #include <render/pass/TransformedWindowPassElement.hpp>
+#include <render/types.hpp>
 
 #include <gtest/gtest.h>
 
@@ -20,13 +21,15 @@ TEST(BackdropScopePassElement, MarkersAreBalancedPassMetadata) {
 TEST(BackdropScopePassElement, MarkersSurviveSimplificationWithoutRequestingBlur) {
     const auto                scope = makeShared<SBackdropScope>();
     CBackdropScopePassElement marker{CBackdropScopePassElement::eAction::BEGIN, scope};
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
 
     EXPECT_TRUE(marker.undiscardable());
-    EXPECT_FALSE(marker.needsLiveBlur());
-    EXPECT_FALSE(marker.needsPrecomputeBlur());
+    EXPECT_FALSE(marker.needsLiveBlur(context));
+    EXPECT_FALSE(marker.needsPrecomputeBlur(context));
     EXPECT_FALSE(marker.disableSimplification());
-    EXPECT_FALSE(marker.boundingBox().has_value());
-    EXPECT_TRUE(marker.opaqueRegion().empty());
+    EXPECT_FALSE(marker.boundingBox(context).has_value());
+    EXPECT_TRUE(marker.opaqueRegion(context).empty());
 }
 
 TEST(BackdropScopePlanner, ActivatesOnlyInnermostScopeAndClipsDamage) {
@@ -61,43 +64,51 @@ TEST(BackdropScopePlanner, UnionsLiveBlurDamageWithinScope) {
 }
 
 TEST(BackdropScopePlanner, TransformedWindowReportsNestedLiveBlur) {
-    auto nestedPass = makeUnique<Render::CRenderPass>();
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    auto                      nestedPass = makeUnique<Render::CRenderPass>();
     nestedPass->add(makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
         .blur                  = true,
         .blockBlurOptimization = true,
     }));
 
     CTransformedWindowPassElement transformed{CTransformedWindowPassElement::SData{.pass = std::move(nestedPass)}};
-    EXPECT_TRUE(transformed.needsLiveBlur());
+    EXPECT_TRUE(transformed.needsLiveBlur(context));
 }
 
 TEST(BackdropScopePlanner, TransformedWindowReportsNestedPrecomputedBlur) {
-    auto nestedPass = makeUnique<Render::CRenderPass>();
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    auto                      nestedPass = makeUnique<Render::CRenderPass>();
     nestedPass->add(makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
         .blur             = true,
         .liveBlurOverride = false,
     }));
 
     CTransformedWindowPassElement transformed{CTransformedWindowPassElement::SData{.pass = std::move(nestedPass)}};
-    EXPECT_TRUE(transformed.needsPrecomputeBlur());
+    EXPECT_TRUE(transformed.needsPrecomputeBlur(context));
 }
 
 TEST(BackdropScopePlanner, TransformedWindowPreservesLiveBlurMode) {
+    Render::CRenderPass           pass;
+    Render::CRenderingContext     context{{}, pass};
     CTransformedWindowPassElement transformed{CTransformedWindowPassElement::SData{
         .blur         = true,
         .blurUsesLive = true,
     }};
 
-    EXPECT_TRUE(transformed.needsLiveBlur());
-    EXPECT_FALSE(transformed.needsPrecomputeBlur());
+    EXPECT_TRUE(transformed.needsLiveBlur(context));
+    EXPECT_FALSE(transformed.needsPrecomputeBlur(context));
 }
 
 TEST(BackdropScopePlanner, TransformedWindowPreservesPrecomputedBlurMode) {
+    Render::CRenderPass           pass;
+    Render::CRenderingContext     context{{}, pass};
     CTransformedWindowPassElement transformed{CTransformedWindowPassElement::SData{
         .blur         = true,
         .blurUsesLive = false,
     }};
 
-    EXPECT_FALSE(transformed.needsLiveBlur());
-    EXPECT_TRUE(transformed.needsPrecomputeBlur());
+    EXPECT_FALSE(transformed.needsLiveBlur(context));
+    EXPECT_TRUE(transformed.needsPrecomputeBlur(context));
 }

--- a/tests/render/BlurDamage.cpp
+++ b/tests/render/BlurDamage.cpp
@@ -8,13 +8,17 @@
 #include <render/gl/blur/Prism.hpp>
 #include <render/gl/blur/Ripple.hpp>
 #include <render/gl/blur/Water.hpp>
+#include <render/pass/Pass.hpp>
 #include <render/ShaderLoader.hpp>
+#include <render/types.hpp>
 
 #include <gtest/gtest.h>
 
 using namespace Render::GL;
 
 TEST(BlurMaterial, DefaultUsesPlainFinish) {
+    Render::CRenderPass        pass;
+    Render::CRenderingContext  context{{}, pass};
     const CDefaultBlurMaterial material;
     const auto                 requirements = material.requirements();
 
@@ -22,7 +26,7 @@ TEST(BlurMaterial, DefaultUsesPlainFinish) {
     EXPECT_EQ(requirements.finishFragment, Render::SH_FRAG_BLURFINISH);
     EXPECT_FALSE(requirements.preparedInput);
     EXPECT_FALSE(requirements.liveBlur);
-    EXPECT_FALSE(material.isAnimated());
+    EXPECT_FALSE(material.isAnimated(context));
     EXPECT_EQ(material.blurSizeForDamage(100), 40);
     EXPECT_FLOAT_EQ(material.sampleRadius(), 0.F);
 }
@@ -62,19 +66,23 @@ TEST(BlurMaterial, AuroraUsesAnimatedGlassFinish) {
 }
 
 TEST(BlurMaterial, HazeUsesStaticPearlescentFinish) {
-    const CHazeBlurMaterial haze;
-    const auto              requirements = haze.requirements();
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    const CHazeBlurMaterial   haze;
+    const auto                requirements = haze.requirements();
 
     EXPECT_EQ(haze.type(), Render::eBlurType::BLUR_HAZE);
     EXPECT_EQ(requirements.finishFragment, Render::SH_FRAG_HAZEFINISH);
     EXPECT_FALSE(requirements.preparedInput);
     EXPECT_FALSE(requirements.liveBlur);
-    EXPECT_FALSE(haze.isAnimated());
+    EXPECT_FALSE(haze.isAnimated(context));
     EXPECT_EQ(haze.blurSizeForDamage(100), 40);
     EXPECT_FLOAT_EQ(haze.sampleRadius(), 0.F);
 }
 
 TEST(BlurMaterial, AcrylicUsesPreparedLiveFinish) {
+    Render::CRenderPass        pass;
+    Render::CRenderingContext  context{{}, pass};
     const CAcrylicBlurMaterial acrylic;
     const auto                 requirements = acrylic.requirements();
 
@@ -82,7 +90,7 @@ TEST(BlurMaterial, AcrylicUsesPreparedLiveFinish) {
     EXPECT_EQ(requirements.finishFragment, Render::SH_FRAG_ACRYLICFINISH);
     EXPECT_TRUE(requirements.preparedInput);
     EXPECT_TRUE(requirements.liveBlur);
-    EXPECT_FALSE(acrylic.isAnimated());
+    EXPECT_FALSE(acrylic.isAnimated(context));
 }
 
 TEST(BlurDamage, DualKawaseUsesOperationalMinimums) {

--- a/tests/render/RenderingContext.cpp
+++ b/tests/render/RenderingContext.cpp
@@ -1,0 +1,84 @@
+#include <render/pass/Pass.hpp>
+#include <render/types.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(Render, renderingContextUsesExplicitPassAndFreshRootState) {
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+
+    EXPECT_EQ(&context.renderPass(), &pass);
+    EXPECT_FALSE(context.sceneMonitor);
+    EXPECT_FALSE(context.outputMonitor);
+    ASSERT_TRUE(context.cmSettingsCache);
+    EXPECT_TRUE(context.cmSettingsCache->entries.empty());
+
+    EXPECT_EQ(context.fbSize, Vector2D(-1, -1));
+    EXPECT_EQ(context.projectionType, Render::RPT_MONITOR);
+    EXPECT_FALSE(context.currentFB);
+    EXPECT_FALSE(context.mainFB);
+    EXPECT_FALSE(context.outFB);
+    EXPECT_TRUE(context.damage.empty());
+    EXPECT_TRUE(context.finalDamage.empty());
+    EXPECT_FLOAT_EQ(context.mouseZoomFactor, 1.F);
+    EXPECT_TRUE(context.mouseZoomUseMouse);
+    EXPECT_FALSE(context.useNearestNeighbor);
+    EXPECT_TRUE(context.transformDamage);
+    EXPECT_FALSE(context.noSimplify);
+    EXPECT_FALSE(context.renderingTransformedSource);
+    EXPECT_FALSE(context.isolatedWorkspace);
+    EXPECT_FALSE(context.isolatedWorkspaceFullScene);
+    EXPECT_FALSE(context.blockSurfaceFeedback);
+    EXPECT_FALSE(context.renderingSnapshot);
+    EXPECT_FALSE(context.precomputeBlur);
+    EXPECT_TRUE(context.updatesMonitorBlurState);
+    EXPECT_EQ(context.renderMode, Render::RENDER_MODE_NORMAL);
+    EXPECT_FALSE(context.fakeFrame);
+    EXPECT_FALSE(context.offloadedFramebuffer);
+    EXPECT_FALSE(context.applyFinalScreenShader);
+    EXPECT_FALSE(context.buffer);
+    EXPECT_FALSE(context.renderbuffer);
+}
+
+TEST(Render, childRenderingContextSharesResourcesWithDistinctPass) {
+    Render::CRenderPass       parentPass;
+    Render::CRenderPass       childPass;
+    Render::CRenderingContext parent{{}, parentPass};
+    parent.noSimplify        = true;
+    parent.blockScreenShader = true;
+    parent.renderingSnapshot = true;
+    parent.precomputeBlur    = true;
+    parent.renderMode        = Render::RENDER_MODE_TO_BUFFER;
+    parent.fbSize            = {1920, 1080};
+
+    Render::CRenderingContext child{parent, childPass};
+
+    EXPECT_EQ(&child.renderPass(), &childPass);
+    EXPECT_EQ(&parent.renderPass(), &parentPass);
+    EXPECT_EQ(child.outputMonitor.lock(), parent.outputMonitor.lock());
+    EXPECT_EQ(child.cmSettingsCache.get(), parent.cmSettingsCache.get());
+    EXPECT_FALSE(child.updatesMonitorBlurState);
+    EXPECT_TRUE(child.noSimplify);
+    EXPECT_TRUE(child.blockScreenShader);
+    EXPECT_TRUE(child.renderingSnapshot);
+    EXPECT_TRUE(child.precomputeBlur);
+    EXPECT_EQ(child.renderMode, Render::RENDER_MODE_TO_BUFFER);
+    EXPECT_EQ(child.fbSize, Vector2D(1920, 1080));
+
+    child.noSimplify        = false;
+    child.blockScreenShader = false;
+    child.renderingSnapshot = false;
+    child.precomputeBlur    = false;
+    child.renderMode        = Render::RENDER_MODE_NORMAL;
+    child.fbSize            = {1, 2};
+    child.damage.add(CBox(1, 2, 3, 4));
+
+    EXPECT_TRUE(parent.noSimplify);
+    EXPECT_TRUE(parent.blockScreenShader);
+    EXPECT_TRUE(parent.renderingSnapshot);
+    EXPECT_TRUE(parent.precomputeBlur);
+    EXPECT_TRUE(parent.updatesMonitorBlurState);
+    EXPECT_EQ(parent.renderMode, Render::RENDER_MODE_TO_BUFFER);
+    EXPECT_EQ(parent.fbSize, Vector2D(1920, 1080));
+    EXPECT_TRUE(parent.damage.empty());
+}

--- a/tests/render/TexPassElement.cpp
+++ b/tests/render/TexPassElement.cpp
@@ -1,40 +1,50 @@
 #include <render/pass/TexPassElement.hpp>
+#include <render/pass/Pass.hpp>
+#include <render/types.hpp>
 
 #include <gtest/gtest.h>
 
 TEST(TexPassElement, ReportsNoBlur) {
-    CTexPassElement element{CTexPassElement::SRenderData{}};
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    CTexPassElement           element{CTexPassElement::SRenderData{}};
 
-    EXPECT_FALSE(element.needsLiveBlur());
-    EXPECT_FALSE(element.needsPrecomputeBlur());
+    EXPECT_FALSE(element.needsLiveBlur(context));
+    EXPECT_FALSE(element.needsPrecomputeBlur(context));
 }
 
 TEST(TexPassElement, ReportsExplicitLiveBlur) {
-    CTexPassElement element{CTexPassElement::SRenderData{
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    CTexPassElement           element{CTexPassElement::SRenderData{
         .blur                  = true,
         .blockBlurOptimization = true,
     }};
 
-    EXPECT_TRUE(element.needsLiveBlur());
-    EXPECT_FALSE(element.needsPrecomputeBlur());
+    EXPECT_TRUE(element.needsLiveBlur(context));
+    EXPECT_FALSE(element.needsPrecomputeBlur(context));
 }
 
 TEST(TexPassElement, LiveBlurOverrideForcesLiveBlur) {
-    CTexPassElement element{CTexPassElement::SRenderData{
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    CTexPassElement           element{CTexPassElement::SRenderData{
         .blur             = true,
         .liveBlurOverride = true,
     }};
 
-    EXPECT_TRUE(element.needsLiveBlur());
-    EXPECT_FALSE(element.needsPrecomputeBlur());
+    EXPECT_TRUE(element.needsLiveBlur(context));
+    EXPECT_FALSE(element.needsPrecomputeBlur(context));
 }
 
 TEST(TexPassElement, LiveBlurOverrideForcesPrecomputedBlur) {
-    CTexPassElement element{CTexPassElement::SRenderData{
+    Render::CRenderPass       pass;
+    Render::CRenderingContext context{{}, pass};
+    CTexPassElement           element{CTexPassElement::SRenderData{
         .blur             = true,
         .liveBlurOverride = false,
     }};
 
-    EXPECT_FALSE(element.needsLiveBlur());
-    EXPECT_TRUE(element.needsPrecomputeBlur());
+    EXPECT_FALSE(element.needsLiveBlur(context));
+    EXPECT_TRUE(element.needsPrecomputeBlur(context));
 }

--- a/tests/render/TransformerList.cpp
+++ b/tests/render/TransformerList.cpp
@@ -8,7 +8,7 @@ class CTestDamageTransformer : public Render::IWindowTransformer {
         ;
     }
 
-    virtual Render::SWindowTransformBuffer transform(const Render::SWindowTransformBuffer& in, const Render::SWindowTransformContext& context) {
+    virtual Render::SWindowTransformBuffer transform(Render::CRenderingContext&, const Render::SWindowTransformBuffer& in, const Render::SWindowTransformContext& context) {
         (void)context;
         return in;
     }
@@ -41,7 +41,7 @@ class CTestRegionTransformer : public Render::IWindowTransformer {
         ;
     }
 
-    virtual Render::SWindowTransformBuffer transform(const Render::SWindowTransformBuffer& in, const Render::SWindowTransformContext& context) {
+    virtual Render::SWindowTransformBuffer transform(Render::CRenderingContext&, const Render::SWindowTransformBuffer& in, const Render::SWindowTransformContext& context) {
         (void)context;
         return in;
     }


### PR DESCRIPTION
overview.

plugins can override the default overview via one api entry point.

以上です

todo:
- [x] window matches should focus the candidate upon close
- [x] input box is weird when hidden I think
- [x] workspace suggestions from typing numbers could be better
- [ ] wiki
- [x] gesture
- [x] expand filters into filter modes
- [x] allow to pass a default filter in the dispatcher
- [x] allow binding keys to nav in overview
- [x] find a better way to hook keys
- [x] allow creating a new workspace if it makes sense

future:
 - integrate hyprlauncher?
 
<img width="2533" height="1370" alt="image" src="https://github.com/user-attachments/assets/bd0a2371-5534-426e-841a-631b6d485a08" />
