### PR TITLE
Decouple pointer focus from layer-surface `keyboard_interactivity`

### DIFF
--- a/src/config/lua/objects/LuaLayerSurface.cpp
+++ b/src/config/lua/objects/LuaLayerSurface.cpp
@@ -67,8 +67,8 @@ static int layerSurfaceIndex(lua_State* L) {
         lua_pushboolean(L, ls->mapped());
     else if (key == "layer")
         lua_pushinteger(L, sc<lua_Integer>(ls->m_layer));
-    else if (key == "interactivity")
-        lua_pushinteger(L, sc<lua_Integer>(ls->m_interactivity));
+    else if (key == "keyboard_interactivity")
+        lua_pushinteger(L, sc<lua_Integer>(ls->m_keyboardInteractivity));
     else if (key == "above_fullscreen")
         lua_pushboolean(L, sc<bool>(ls->m_flags & Desktop::View::LAYER_FLAG_ABOVE_FULLSCREEN));
     else

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -108,7 +108,7 @@ void CFocusState::rawWindowFocus(PHLWINDOW pWindow, eFocusReason reason, SP<CWLS
             return;
         }
 
-        if (!g_pInputManager->m_exclusiveLSes.empty()) {
+        if (!g_pInputManager->m_exclusiveKeyboardLSes.empty()) {
             Log::logger->log(Log::DEBUG, "Refusing a keyboard focus to a window because of an exclusive ls");
             return;
         }

--- a/src/desktop/state/ViewHitTester.cpp
+++ b/src/desktop/state/ViewHitTester.cpp
@@ -325,23 +325,6 @@ SP<CWLSurfaceResource> CViewHitTester::layerPopupSurfaceAt(const Vector2D& pos, 
     return nullptr;
 }
 
-SP<CWLSurfaceResource> CViewHitTester::layerPopupSurfaceAt(const Vector2D& pos, const std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound) const {
-    for (auto const& ls : *layerSurfaces | std::views::reverse) {
-        if (!ls->mapped() || !ls->acceptsInput())
-            continue;
-
-        auto SURFACEAT = ls->popupHead()->at(pos, true);
-
-        if (SURFACEAT) {
-            *layerFound    = ls.lock();
-            *surfaceCoords = pos - SURFACEAT->coordsGlobal();
-            return SURFACEAT->wlSurface()->resource();
-        }
-    }
-
-    return nullptr;
-}
-
 SP<CWLSurfaceResource> CViewHitTester::layerSurfaceAt(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound,
                                                       bool aboveLockscreen) const {
     for (auto const& ls : *layerSurfaces | std::views::reverse) {

--- a/src/desktop/state/ViewHitTester.hpp
+++ b/src/desktop/state/ViewHitTester.hpp
@@ -23,7 +23,6 @@ namespace Desktop {
         SP<CWLSurfaceResource> windowSurfaceAt(const Vector2D& pos, PHLWINDOW window, Vector2D& surfaceLocal) const;
         Vector2D               surfaceLocalAt(const Vector2D& pos, PHLWINDOW window, SP<CWLSurfaceResource> surface) const;
         SP<CWLSurfaceResource> layerPopupSurfaceAt(const Vector2D& pos, PHLMONITOR monitor, Vector2D* surfaceCoords, PHLLS* layerFound) const;
-        SP<CWLSurfaceResource> layerPopupSurfaceAt(const Vector2D& pos, const std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound) const;
         SP<CWLSurfaceResource> layerSurfaceAt(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* surfaceCoords, PHLLS* layerFound,
                                               bool aboveLockscreen = false) const;
 

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -214,6 +214,9 @@ void CLayerSurface::onMap() {
         const auto LOCAL = g_pInputManager->getMouseCoordsInternal() - Vector2D(m_geometry.x + PMONITOR->m_position.x, m_geometry.y + PMONITOR->m_position.y);
         g_pSeatManager->setPointerFocus(m_wlSurface->resource(), LOCAL);
         g_pInputManager->m_emptyFocusCursorSet = false;
+    } else {
+        // update pointer focus
+        g_pInputManager->simulateMouseMovement();
     }
 
     m_position = Vector2D(m_geometry.x, m_geometry.y);

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -193,31 +193,27 @@ void CLayerSurface::onMap() {
 
     m_wlSurface->resource()->enter(PMONITOR->m_self.lock());
 
-    const bool ISEXCLUSIVE = m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+    const bool KEYBOARD_EXCLUSIVE = m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
 
-    if (ISEXCLUSIVE)
+    if (KEYBOARD_EXCLUSIVE)
         g_pInputManager->m_exclusiveLSes.push_back(m_self);
 
-    const bool GRABSFOCUS = ISEXCLUSIVE ||
+    const bool GRABS_KEYBOARD = KEYBOARD_EXCLUSIVE ||
         (m_layerSurface->m_current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE &&
          // don't focus if constrained
          (g_pSeatManager->m_mouse.expired() || !g_pInputManager->isConstrained()));
 
-    if (GRABSFOCUS) {
+    if (GRABS_KEYBOARD) {
         // TODO: use the new superb really very cool grab
         if (g_pSeatManager->m_seatGrab && !g_pSeatManager->m_seatGrab->accepts(m_wlSurface->resource()))
             g_pSeatManager->setGrab(nullptr);
 
         g_pInputManager->releaseAllMouseButtons();
         Desktop::focusState()->rawSurfaceFocus(m_wlSurface->resource());
-
-        const auto LOCAL = g_pInputManager->getMouseCoordsInternal() - Vector2D(m_geometry.x + PMONITOR->m_position.x, m_geometry.y + PMONITOR->m_position.y);
-        g_pSeatManager->setPointerFocus(m_wlSurface->resource(), LOCAL);
-        g_pInputManager->m_emptyFocusCursorSet = false;
-    } else {
-        // update pointer focus
-        g_pInputManager->simulateMouseMovement();
     }
+
+    // update pointer focus
+    g_pInputManager->simulateMouseMovement();
 
     m_position = Vector2D(m_geometry.x, m_geometry.y);
 
@@ -395,12 +391,12 @@ void CLayerSurface::onCommit() {
                 },
                 nullptr);
         }
-        const bool WASEXCLUSIVE = m_interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
-        const bool ISEXCLUSIVE  = m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+        const bool WAS_KEYBOARD_EXCLUSIVE = m_interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+        const bool KEYBOARD_EXCLUSIVE     = m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
 
-        if (!WASEXCLUSIVE && ISEXCLUSIVE)
+        if (!WAS_KEYBOARD_EXCLUSIVE && KEYBOARD_EXCLUSIVE)
             g_pInputManager->m_exclusiveLSes.push_back(m_self);
-        else if (WASEXCLUSIVE && !ISEXCLUSIVE)
+        else if (WAS_KEYBOARD_EXCLUSIVE && !KEYBOARD_EXCLUSIVE)
             std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) { return !other || other == m_self; });
 
         // if the surface was focused and interactive but now isn't, refocus
@@ -409,17 +405,13 @@ void CLayerSurface::onCommit() {
             // so unfocus the surface here.
             Desktop::focusState()->rawSurfaceFocus(nullptr);
             g_pInputManager->refocusLastWindow(m_monitor.lock());
-        } else if (WASLASTFOCUS && WASEXCLUSIVE && m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND) {
+        } else if (WASLASTFOCUS && WAS_KEYBOARD_EXCLUSIVE && m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND) {
             g_pInputManager->simulateMouseMovement();
-        } else if (!WASEXCLUSIVE && ISEXCLUSIVE) {
+        } else if (!WAS_KEYBOARD_EXCLUSIVE && KEYBOARD_EXCLUSIVE) {
             // if now exclusive and not previously
             g_pSeatManager->setGrab(nullptr);
             g_pInputManager->releaseAllMouseButtons();
             Desktop::focusState()->rawSurfaceFocus(m_wlSurface->resource());
-
-            const auto LOCAL = g_pInputManager->getMouseCoordsInternal() - Vector2D(m_geometry.x + PMONITOR->m_position.x, m_geometry.y + PMONITOR->m_position.y);
-            g_pSeatManager->setPointerFocus(m_wlSurface->resource(), LOCAL);
-            g_pInputManager->m_emptyFocusCursorSet = false;
         }
     }
 

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -173,8 +173,8 @@ void CLayerSurface::onDestroy() {
 void CLayerSurface::onMap() {
     Log::logger->log(Log::DEBUG, "LayerSurface {:x} mapped", rc<uintptr_t>(m_layerSurface.get()));
 
-    m_mapped        = true;
-    m_interactivity = m_layerSurface->m_current.interactivity;
+    m_mapped                = true;
+    m_keyboardInteractivity = m_layerSurface->m_current.keyboardInteractivity;
     m_flags |= LAYER_FLAG_ABOVE_FULLSCREEN;
 
     m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_ALL);
@@ -193,13 +193,13 @@ void CLayerSurface::onMap() {
 
     m_wlSurface->resource()->enter(PMONITOR->m_self.lock());
 
-    const bool KEYBOARD_EXCLUSIVE = m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+    const bool KEYBOARD_EXCLUSIVE = m_layerSurface->m_current.keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
 
     if (KEYBOARD_EXCLUSIVE)
-        g_pInputManager->m_exclusiveLSes.push_back(m_self);
+        g_pInputManager->m_exclusiveKeyboardLSes.push_back(m_self);
 
     const bool GRABS_KEYBOARD = KEYBOARD_EXCLUSIVE ||
-        (m_layerSurface->m_current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE &&
+        (m_layerSurface->m_current.keyboardInteractivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE &&
          // don't focus if constrained
          (g_pSeatManager->m_mouse.expired() || !g_pInputManager->isConstrained()));
 
@@ -237,7 +237,7 @@ void CLayerSurface::onUnmap() {
     IPC::Socket2::sock()->postEvent({.event = "closelayer", .data = m_layerSurface->m_layerNamespace});
     Event::bus()->m_events.layer.closed.emit(m_self.lock());
 
-    std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) { return !other || other == m_self; });
+    std::erase_if(g_pInputManager->m_exclusiveKeyboardLSes, [this](const auto& other) { return !other || other == m_self; });
 
     if (!m_monitor) {
         Log::logger->log(Log::WARN, "Layersurface unmapping on invalid monitor (removed?) ignoring.");
@@ -379,7 +379,7 @@ void CLayerSurface::onCommit() {
             m_realSize->setValueAndWarp(m_geometry.size());
     }
 
-    if (m_mapped && (m_layerSurface->m_current.committed & CLayerShellResource::eCommittedState::STATE_INTERACTIVITY)) {
+    if (m_mapped && (m_layerSurface->m_current.committed & CLayerShellResource::eCommittedState::STATE_KEYBOARD_INTERACTIVITY)) {
         bool WASLASTFOCUS = false;
         m_layerSurface->m_surface->breadthfirst(
             [&WASLASTFOCUS](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) { WASLASTFOCUS = WASLASTFOCUS || g_pSeatManager->m_state.keyboardFocus == surf; },
@@ -391,21 +391,21 @@ void CLayerSurface::onCommit() {
                 },
                 nullptr);
         }
-        const bool WAS_KEYBOARD_EXCLUSIVE = m_interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
-        const bool KEYBOARD_EXCLUSIVE     = m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+        const bool WAS_KEYBOARD_EXCLUSIVE = m_keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+        const bool KEYBOARD_EXCLUSIVE     = m_layerSurface->m_current.keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
 
         if (!WAS_KEYBOARD_EXCLUSIVE && KEYBOARD_EXCLUSIVE)
-            g_pInputManager->m_exclusiveLSes.push_back(m_self);
+            g_pInputManager->m_exclusiveKeyboardLSes.push_back(m_self);
         else if (WAS_KEYBOARD_EXCLUSIVE && !KEYBOARD_EXCLUSIVE)
-            std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) { return !other || other == m_self; });
+            std::erase_if(g_pInputManager->m_exclusiveKeyboardLSes, [this](const auto& other) { return !other || other == m_self; });
 
         // if the surface was focused and interactive but now isn't, refocus
-        if (WASLASTFOCUS && m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {
+        if (WASLASTFOCUS && m_layerSurface->m_current.keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {
             // moveMouseUnified won't focus non interactive layers but it won't unfocus them either,
             // so unfocus the surface here.
             Desktop::focusState()->rawSurfaceFocus(nullptr);
             g_pInputManager->refocusLastWindow(m_monitor.lock());
-        } else if (WASLASTFOCUS && WAS_KEYBOARD_EXCLUSIVE && m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND) {
+        } else if (WASLASTFOCUS && WAS_KEYBOARD_EXCLUSIVE && m_layerSurface->m_current.keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND) {
             g_pInputManager->simulateMouseMovement();
         } else if (!WAS_KEYBOARD_EXCLUSIVE && KEYBOARD_EXCLUSIVE) {
             // if now exclusive and not previously
@@ -415,7 +415,7 @@ void CLayerSurface::onCommit() {
         }
     }
 
-    m_interactivity = m_layerSurface->m_current.interactivity;
+    m_keyboardInteractivity = m_layerSurface->m_current.keyboardInteractivity;
 
     g_pHyprRenderer->damageSurface(m_wlSurface->resource(), m_position.x, m_position.y);
 

--- a/src/desktop/view/LayerSurface.hpp
+++ b/src/desktop/view/LayerSurface.hpp
@@ -58,7 +58,7 @@ namespace Desktop::View {
         LayerFlags                                                m_flags = LAYER_FLAG_ABOVE_FULLSCREEN;
 
         // the header providing the enum type cannot be imported here
-        int                                     m_interactivity = 0;
+        int                                     m_keyboardInteractivity = 0;
 
         uint32_t                                m_layer = 0;
 

--- a/src/desktop/view/WLSurface.cpp
+++ b/src/desktop/view/WLSurface.cpp
@@ -206,7 +206,7 @@ bool CWLSurface::keyboardFocusable() const {
     if (m_view->type() == VIEW_TYPE_WINDOW || m_view->type() == VIEW_TYPE_SUBSURFACE || m_view->type() == VIEW_TYPE_POPUP)
         return true;
     if (const auto LS = CLayerSurface::fromView(m_view.lock()); LS && LS->m_layerSurface)
-        return LS->m_layerSurface->m_current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
+        return LS->m_layerSurface->m_current.keyboardInteractivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
     return false;
 }
 

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1434,7 +1434,7 @@ void CWindow::mapWindow() {
     // check LS focus grab
     const auto PFORCEFOCUS  = Desktop::viewState()->query().forceFocus().runWindow();
     const auto PLSFROMFOCUS = Desktop::viewState()->query().type(VIEW_TYPE_LAYER_SURFACE).surface(Desktop::focusState()->surface()).runLayer();
-    if (PLSFROMFOCUS && PLSFROMFOCUS->m_layerSurface->m_current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE)
+    if (PLSFROMFOCUS && PLSFROMFOCUS->m_layerSurface->m_current.keyboardInteractivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE)
         m_state |= WINDOW_STATE_NO_INITIAL_FOCUS;
 
     // emit the hook event here after basic stuff has been initialized

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -729,7 +729,7 @@ void CSeatManager::setGrab(SP<CSeatGrab> grab) {
 
         m_seatGrab.reset();
 
-        if (parentLayer && parentLayer->m_layerSurface->m_current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {
+        if (parentLayer && parentLayer->m_layerSurface->m_current.keyboardInteractivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {
             Desktop::focusState()->rawSurfaceFocus(parentLayer->wlSurface()->resource());
         } else {
             static auto PFOLLOWMOUSE = CConfigValue<Config::INTEGER>("input:follow_mouse");
@@ -766,7 +766,7 @@ void CSeatManager::setGrab(SP<CSeatGrab> grab) {
         }
 
         if (!refocus && layer)
-            refocus = layer->m_interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
+            refocus = layer->m_keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
 
         if (refocus) {
             auto candidate = Desktop::focusState()->window();

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -626,7 +626,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     if (!refocus && Desktop::focusState()->surface()) {
         const auto PLS = Desktop::viewState()->query().type(Desktop::View::VIEW_TYPE_LAYER_SURFACE).surface(Desktop::focusState()->surface()).runLayer();
 
-        if (PLS && PLS->m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)
+        if (PLS && PLS->m_layerSurface->m_current.keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)
             allowKeyboardRefocus = false;
     }
 
@@ -718,8 +718,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
             Pointer::Cursor::overrideController->unsetOverride(Pointer::Cursor::CURSOR_OVERRIDE_WINDOW_EDGE);
         }
 
-        if (pFoundLayerSurface && (pFoundLayerSurface->m_layerSurface->m_current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) && FOLLOWMOUSE != 3 &&
-            (allowKeyboardRefocus || pFoundLayerSurface->m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)) {
+        if (pFoundLayerSurface && (pFoundLayerSurface->m_layerSurface->m_current.keyboardInteractivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) && FOLLOWMOUSE != 3 &&
+            (allowKeyboardRefocus || pFoundLayerSurface->m_layerSurface->m_current.keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)) {
             Desktop::focusState()->rawSurfaceFocus(foundSurface);
         }
 
@@ -1833,7 +1833,7 @@ void CInputManager::refocus(std::optional<Vector2D> overridePos) {
 }
 
 bool CInputManager::refocusLastWindow(PHLMONITOR pMonitor) {
-    if (!m_exclusiveLSes.empty()) {
+    if (!m_exclusiveKeyboardLSes.empty()) {
         Log::logger->log(Log::DEBUG, "CInputManager::refocusLastWindow: ignoring, exclusive LS present.");
         return false;
     }
@@ -1853,14 +1853,14 @@ bool CInputManager::refocusLastWindow(PHLMONITOR pMonitor) {
     if (!foundSurface) {
         foundSurface = Desktop::viewState()->hitTest().layerSurfaceAt(g_pInputManager->getMouseCoordsInternal(), &pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
                                                                       &surfaceCoords, &pFoundLayerSurface);
-        if (pFoundLayerSurface && pFoundLayerSurface->m_interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND)
+        if (pFoundLayerSurface && pFoundLayerSurface->m_keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND)
             foundSurface = nullptr;
     }
 
     if (!foundSurface) {
         foundSurface = Desktop::viewState()->hitTest().layerSurfaceAt(g_pInputManager->getMouseCoordsInternal(), &pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
                                                                       &surfaceCoords, &pFoundLayerSurface);
-        if (pFoundLayerSurface && pFoundLayerSurface->m_interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND)
+        if (pFoundLayerSurface && pFoundLayerSurface->m_keyboardInteractivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND)
             foundSurface = nullptr;
     }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -452,20 +452,6 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
         return;
     }
 
-    // forced above all
-    if (!g_pInputManager->m_exclusiveLSes.empty() && !PROTO::data->dndActive()) {
-        if (!foundSurface)
-            foundSurface = Desktop::viewState()->hitTest().layerPopupSurfaceAt(mouseCoords, &g_pInputManager->m_exclusiveLSes, &surfaceCoords, &pFoundLayerSurface);
-
-        if (!foundSurface)
-            foundSurface = Desktop::viewState()->hitTest().layerSurfaceAt(mouseCoords, &g_pInputManager->m_exclusiveLSes, &surfaceCoords, &pFoundLayerSurface);
-
-        if (!foundSurface) {
-            foundSurface = (*g_pInputManager->m_exclusiveLSes.begin())->wlSurface()->resource();
-            surfacePos   = (*g_pInputManager->m_exclusiveLSes.begin())->position(Desktop::View::IGeometric::GEOMETRIC_GOAL);
-        }
-    }
-
     if (!foundSurface)
         foundSurface = Desktop::viewState()->hitTest().layerPopupSurfaceAt(mouseCoords, PMONITOR, &surfaceCoords, &pFoundLayerSurface);
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -173,7 +173,7 @@ class CInputManager {
     std::list<SSwitchDevice> m_switches;
 
     // Exclusive layer surfaces
-    std::vector<PHLLSREF> m_exclusiveLSes;
+    std::vector<PHLLSREF> m_exclusiveKeyboardLSes;
 
     // constraints
     std::vector<WP<CPointerConstraint>> m_constraints;

--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -7,13 +7,13 @@
 #include "../output/Monitor.hpp"
 
 void CLayerShellResource::SState::reset() {
-    anchor        = 0;
-    exclusive     = 0;
-    interactivity = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
-    layer         = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
-    exclusiveEdge = sc<zwlrLayerSurfaceV1Anchor>(0);
-    desiredSize   = {};
-    margin        = {0, 0, 0, 0};
+    anchor                = 0;
+    exclusive             = 0;
+    keyboardInteractivity = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
+    layer                 = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+    exclusiveEdge         = sc<zwlrLayerSurfaceV1Anchor>(0);
+    desiredSize           = {};
+    margin                = {0, 0, 0, 0};
 }
 
 CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<CWLSurfaceResource> surf_, std::string namespace_, PHLMONITOR pMonitor,
@@ -113,8 +113,8 @@ CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<C
             return;
         }
 
-        markPending(STATE_INTERACTIVITY);
-        m_pending.interactivity = kbi;
+        markPending(STATE_KEYBOARD_INTERACTIVITY);
+        m_pending.keyboardInteractivity = kbi;
     });
 
     m_resource->setGetPopup([this](CZwlrLayerSurfaceV1* r, wl_resource* popup_) {

--- a/src/protocols/LayerShell.hpp
+++ b/src/protocols/LayerShell.hpp
@@ -34,13 +34,13 @@ class CLayerShellResource {
     void sendClosed();
 
     enum eCommittedState : uint8_t {
-        STATE_SIZE          = (1 << 0),
-        STATE_ANCHOR        = (1 << 1),
-        STATE_EXCLUSIVE     = (1 << 2),
-        STATE_MARGIN        = (1 << 3),
-        STATE_INTERACTIVITY = (1 << 4),
-        STATE_LAYER         = (1 << 5),
-        STATE_EDGE          = (1 << 6),
+        STATE_SIZE                   = (1 << 0),
+        STATE_ANCHOR                 = (1 << 1),
+        STATE_EXCLUSIVE              = (1 << 2),
+        STATE_MARGIN                 = (1 << 3),
+        STATE_KEYBOARD_INTERACTIVITY = (1 << 4),
+        STATE_LAYER                  = (1 << 5),
+        STATE_EDGE                   = (1 << 6),
     };
 
     struct {
@@ -55,10 +55,10 @@ class CLayerShellResource {
         uint32_t                                anchor    = 0;
         int32_t                                 exclusive = 0;
         Vector2D                                desiredSize;
-        zwlrLayerSurfaceV1KeyboardInteractivity interactivity = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
-        zwlrLayerShellV1Layer                   layer         = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
-        zwlrLayerSurfaceV1Anchor                exclusiveEdge = sc<zwlrLayerSurfaceV1Anchor>(0);
-        uint32_t                                committed     = 0;
+        zwlrLayerSurfaceV1KeyboardInteractivity keyboardInteractivity = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
+        zwlrLayerShellV1Layer                   layer                 = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+        zwlrLayerSurfaceV1Anchor                exclusiveEdge         = sc<zwlrLayerSurfaceV1Anchor>(0);
+        uint32_t                                committed             = 0;
 
         struct {
             double left = 0, right = 0, top = 0, bottom = 0;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?


[zwlr_layer_surface_v1::set_keyboard_interactivity](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:request:set_keyboard_interactivity)'s description states:

> Layer surfaces receive pointer, touch, and tablet events normally. If you do not want to receive them, set the input region on your surface to an empty region.

Layer surfaces currently treat [`keyboard_interactivity`](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:enum:keyboard_interactivity)  also as *pointer*-interactivity. Mainly:
- `onMap()` also forces pointer focus, not just keyboard focus, onto newly mapped `exclusive` (`keyboard_interactivity==exclusive`) layer-surfaces
- `mouseMoveUnified()` overrides pointer focus of any normal-focus-priority surfaces in favor of `exclusive` layer-surfaces, including workarounds for said behavior

Before this patch, that resulted in things like:
- If multiple `exclusive` surfaces were mapped, e.g. multi-output [slurp](https://github.com/emersion/slurp), pointer focus was always forced onto the most-recently-mapped surface, along with the keyboard. In other words, you might have to move your mouse after slurp launches to refresh the focus to the layer-surface your mouse is actually placed on, if the last-mapped surface didn't happen to be the one your cursor is currently on.
  - *Keyboard* focus target is explicitly ["implementation-defined"](https://wayland.app/protocols/wlr-layer-shell-unstable-v1#:~:text=implementation%2D%20defined) in that scenario, so that part is fine.
- If there are **any** `exclusive` layer-surfaces mapped **anywhere**, on any output, your pointer will never be able to click or focus anything else.
  - Can be seen with basically any launcher (tofi, rofi, ...)

I also added a `simulateMouseMovement` call in onMap() to refocus the pointer. Programs like slurp were previously only accidentally grabbing pointer focus automatically at launch (i.e. without moving the mouse), due to having `exclusive` keyboard-interactivity. So this lets them grab focus automatically again, and at the same time fixing the pointer focus bug mentioned earlier with multiple `exclusive` surfaces.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


I did not 100% finish investigating all the possible edge-case side-effects that the `simulateMouseMovement` call might introduce, but I was looking through a lot of the focus-related code in general, and it seems to already used it other places for virtually the exact same purpose, including the layer-surface's `onUnmap()`.

Someone who is more familiar with it should probably sanity-check the usage either way, though.


Other things:

- Lua config entry updated from `interactivity` to `keyboard_interactivity`
- https://github.com/hyprwm/Hyprland/commit/4072160677b574772a72d54445dbbca7fb4dcbc1: bugfix for some of the removed code, just for the record, in case the PR doesn't go through as is


#### Is it ready for merging, or does it need work?

Ready.