### PR TITLE
pointer: colour-manage the hardware cursor buffer

### DIFF
--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -621,9 +621,14 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
 
     RBO->bind();
 
+    // the cursor plane is blended after the FB is encoded into the output's colour space,
+    // so tag it - otherwise a raw sRGB cursor gets reinterpreted there, blinding on PQ
+    const auto FB = RBO->getFB();
+    FB->setImageDescription(state->monitor->m_imageDescription);
+
     CRegion damageRegion = {0, 0, INT_MAX, INT_MAX};
-    g_pHyprRenderer->beginFullFakeRender(state->monitor.lock(), damageRegion, RBO->getFB());
-    g_pHyprRenderer->m_renderData.fbSize = RBO->getFB()->m_size;
+    g_pHyprRenderer->beginFullFakeRender(state->monitor.lock(), damageRegion, FB);
+    g_pHyprRenderer->m_renderData.fbSize = FB->m_size;
     g_pHyprRenderer->setProjectionType(Render::RPT_FB);
     g_pHyprRenderer->m_renderData.transformDamage = true;
     g_pHyprRenderer->startRenderPass();


### PR DESCRIPTION
Describe your PR, what does it fix/add?

Fixes  #14419. 
We make the cursor use the output colour space, preventing the cursor from blinding people with HDR displays.

[wlroots does the same](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/5190).

Anything you want to mention?

- quantisation might be an issue: HDR's 8 bit repr ranges more and by converting I think we are using a smaller range, so slightly worse techincally, BUT:
  - nobody should be able to  see the difference anyways
  - that's is kinda stupid considering the cursor was broken with it.
 
- This logs CM: FIXME no framebuffer texture at trace level, because the cursor's framebuffer is backed by a renderbuffer rather than a texture. The framebuffer's own image description is set anyways, and that's what the renderer reads. The texture copy only matters for framebuffers that get read back.

- tested on a main (52b368f1) build; the visual before/after was confirmed on v0.56.2
- single machine: Intel Arrow Lake, xe, eDP HDR10 OLED

Ready or needs work?
I have built it and am running it, so ready imho.

LLMs were used to do a whole bunch of triaging and to write the patch, I have built it, smell checked it, and ensured it works in a live system.