### PR TITLE
monitor: damage the monitor when the output image description changes

### DIFF
--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -652,6 +652,8 @@ void CMonitor::applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdr
         if (PROTO::colorManagement)
             PROTO::colorManagement->onMonitorImageDescriptionChanged(m_self);
         m_blurFBDirty = true;
+        // the output's colour transform changed, so everything already composited is stale
+        g_pHyprRenderer->damageMonitor(m_self.lock());
     }
 }
 


### PR DESCRIPTION
Describe your PR, what does it fix/add?

applyCMType() swaps the output's image description and marks the blur FB dirty, but never damages the monitor. Anything already composited under the old colour transform therefore stays on screen until something else happens to damage it - most visibly a faint grey wash over transparent surfaces (at least on my quickshell shell) for about half a second after leaving HDR, until they repaint for an unrelated reason.

This was masked until recently: HDR transitions used to cause a ~1s blank (full modeset + panel power cycle) that force-repainted everything. It only becomes visible once transitions are fast (which it becomes on another pr I'll send soon) .

Anything you want to mention?

Tested on main (52b368f1): with a fullscreen HDR surface driving cm_auto_hdr, leaving HDR (connector HDR_OUTPUT_METADATA eotf 2 ->  0) leaves transparent layer-shell surfaces clean. Triggered by exiting fullscreen rather than switching workspace, since a workspace switch forces a full repaint and would hide the bug. Single machine: Intel Arrow Lake, xe, eDP HDR10 OLED.

Is it ready for merging, or does it need work?

Built and running here, so ready imho.