### PR TITLE
ipc: emit fullscreenv2 with window address and mode

### DIFF
--- a/src/managers/fullscreen/FullscreenController.cpp
+++ b/src/managers/fullscreen/FullscreenController.cpp
@@ -480,6 +480,7 @@ void CFullscreenController::setWindowFullscreenModeInternal(const PHLWINDOW wind
                                                                                          Layout::RECALCULATE_REASON_TOGGLE_LAYOUT_HANDLED_FULLSCREEN);
 
     IPC::Socket2::sock()->postEvent({.event = "fullscreen", .data = std::to_string(sc<int>(mode) != FSMODE_NONE)});
+    IPC::Socket2::sock()->postEvent({.event = "fullscreenv2", .data = std::format("{:x},{}", rc<uintptr_t>(window.get()), sc<int>(mode))});
     Event::bus()->m_events.window.fullscreen.emit(window);
 
     window->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The existing `fullscreen>>0/1` socket2 event is the same for maximize and real fullscreen. Keep that event for compatibility and add `fullscreenv2>>address,mode`, where `mode` is `0` (none), `1` (maximized), or `2` (fullscreen).

Resolves #10472

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is an additive IPC event. `fullscreen>>` is unchanged.

Wiki: new socket2 event (`fullscreenv2`) should be documented.

#### Is it ready for merging, or does it need work?

Ready.