### PR TITLE
protocols: validate xdg-activation serials before focusing

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -502,6 +502,8 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<String>("misc:swallow_regex", "The class regex to be used for windows that should be swallowed.", STRVAL_EMPTY),
         MS<String>("misc:swallow_exception_regex", "The title regex to be used for windows that should not be swallowed.", STRVAL_EMPTY),
         MS<Bool>("misc:focus_on_activate", "Whether Hyprland should focus an app that requests to be focused.", false),
+        MS<Bool>("misc:validate_xdg_activation_serial", "Reject xdg-activation requests with a missing or invalid serial. Disable to restore the previous unvalidated behavior.",
+                 true),
         MS<Bool>("misc:mouse_move_focuses_monitor", "Whether mouse moving into a different monitor should focus it", true),
         MS<Bool>("misc:allow_session_lock_restore", "if true, will allow you to restart a lockscreen app in case it crashes.", false),
         MS<Bool>("misc:session_lock_xray", "keep rendering workspaces below your lockscreen", false),

--- a/src/protocols/XDGActivation.cpp
+++ b/src/protocols/XDGActivation.cpp
@@ -1,7 +1,10 @@
 #include "XDGActivation.hpp"
 #include "../managers/TokenManager.hpp"
+#include "../managers/SeatManager.hpp"
 #include "../Compositor.hpp"
+#include "../config/ConfigValue.hpp"
 #include "core/Compositor.hpp"
+#include "core/Seat.hpp"
 #include <algorithm>
 
 CXDGActivationToken::CXDGActivationToken(SP<CXdgActivationTokenV1> resource_) : m_resource(resource_) {
@@ -11,7 +14,11 @@ CXDGActivationToken::CXDGActivationToken(SP<CXdgActivationTokenV1> resource_) : 
     m_resource->setDestroy([this](CXdgActivationTokenV1* r) { PROTO::activation->destroyToken(this); });
     m_resource->setOnDestroy([this](CXdgActivationTokenV1* r) { PROTO::activation->destroyToken(this); });
 
-    m_resource->setSetSerial([this](CXdgActivationTokenV1* r, uint32_t serial_, wl_resource* seat) { m_serial = serial_; });
+    m_resource->setSetSerial([this](CXdgActivationTokenV1* r, uint32_t serial_, wl_resource* seat) {
+        m_serial    = serial_;
+        m_serialSet = true;
+        m_seat      = CWLSeatResource::fromResource(seat);
+    });
 
     m_resource->setSetAppId([this](CXdgActivationTokenV1* r, const char* appid) { m_appID = appid; });
 
@@ -31,7 +38,13 @@ CXDGActivationToken::CXDGActivationToken(SP<CXdgActivationTokenV1> resource_) : 
 
         m_resource->sendDone(m_token.c_str());
 
-        PROTO::activation->m_sentTokens.push_back({m_token, m_resource->client()});
+        PROTO::activation->m_sentTokens.push_back({
+            .token     = m_token,
+            .client    = m_resource->client(),
+            .serial    = m_serial,
+            .serialSet = m_serialSet,
+            .seat      = m_seat,
+        });
 
         auto count = std::ranges::count_if(PROTO::activation->m_sentTokens, [this](const auto& other) { return other.client == m_resource->client(); });
 
@@ -72,6 +85,17 @@ void CXDGActivationProtocol::bindManager(wl_client* client, void* data, uint32_t
         if UNLIKELY (TOKEN == m_sentTokens.end()) {
             LOGM(Log::WARN, "activate event for non-existent token {}??", token);
             return;
+        }
+
+        static auto PVALIDATE = CConfigValue<Config::INTEGER>("misc:validate_xdg_activation_serial");
+
+        if (*PVALIDATE) {
+            const auto SEAT = TOKEN->seat.lock();
+            if UNLIKELY (!TOKEN->serialSet || !SEAT || !g_pSeatManager->serialValid(SEAT, TOKEN->serial, false)) {
+                LOGM(Log::WARN, "activate event for token {} rejected: missing or invalid serial", token);
+                m_sentTokens.erase(TOKEN);
+                return;
+            }
         }
 
         // remove token. It's been now spent.

--- a/src/protocols/XDGActivation.hpp
+++ b/src/protocols/XDGActivation.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include "WaylandProtocol.hpp"
 #include "xdg-activation-v1.hpp"
+#include "core/Seat.hpp"
 
 class CXDGActivationToken {
   public:
@@ -16,6 +17,8 @@ class CXDGActivationToken {
     SP<CXdgActivationTokenV1> m_resource;
 
     uint32_t                  m_serial    = 0;
+    bool                      m_serialSet = false;
+    WP<CWLSeatResource>       m_seat;
     std::string               m_appID     = "";
     bool                      m_committed = false;
 
@@ -36,8 +39,11 @@ class CXDGActivationProtocol : public IWaylandProtocol {
     void onGetToken(CXdgActivationV1* pMgr, uint32_t id);
 
     struct SSentToken {
-        std::string token;
-        wl_client*  client = nullptr; // READ-ONLY: can be dead
+        std::string         token;
+        wl_client*          client    = nullptr; // READ-ONLY: can be dead
+        uint32_t            serial    = 0;
+        bool                serialSet = false;
+        WP<CWLSeatResource> seat;
     };
     std::vector<SSentToken> m_sentTokens;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

xdg-activation currently accepts any committed token, so clients can steal focus without a valid input serial. Tokens now store the `set_serial` seat/serial and, by default, `activate` is ignored unless that serial is present and still in the seat's recent serial store.

`misc:validate_xdg_activation_serial` defaults to `true`. Set it to `false` to restore the previous unvalidated behavior.

Resolves #15692

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is a behavior change for apps that request activation without a valid serial. The config option is there so users can opt out.

Wiki PR needed for the new `misc:validate_xdg_activation_serial` option.

#### Is it ready for merging, or does it need work?

Ready.