### PR TITLE
config/lua: report silent bind and dispatcher mistakes

### DIFF
--- a/src/config/lua/bindings/LuaBindingsDispatcherUtils.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatcherUtils.cpp
@@ -4,6 +4,7 @@ using namespace Config::Lua::Bindings;
 
 static constexpr const char* DISPATCHER_MT = "HL.Dispatcher";
 static char                  DISPATCHER_TABLES_REGISTRY_KEY;
+static char                  DISPATCHER_FACTORIES_REGISTRY_KEY;
 
 namespace {
     struct SDispatcherRef {
@@ -95,11 +96,50 @@ static int dispatcherFactory(lua_State* L) {
     return nresults;
 }
 
+static void markDispatcherFactory(lua_State* L) {
+    lua_pushlightuserdata(L, &DISPATCHER_FACTORIES_REGISTRY_KEY);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        lua_newtable(L);
+        lua_pushlightuserdata(L, &DISPATCHER_FACTORIES_REGISTRY_KEY);
+        lua_pushvalue(L, -2);
+        lua_rawset(L, LUA_REGISTRYINDEX);
+    }
+
+    lua_pushvalue(L, -2);
+    lua_pushboolean(L, true);
+    lua_rawset(L, -3);
+    lua_pop(L, 1);
+}
+
+bool Internal::isDispatcherFactory(lua_State* L, int idx) {
+    if (!lua_isfunction(L, idx))
+        return false;
+
+    idx = lua_absindex(L, idx);
+    lua_pushlightuserdata(L, &DISPATCHER_FACTORIES_REGISTRY_KEY);
+    lua_rawget(L, LUA_REGISTRYINDEX);
+
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        return false;
+    }
+
+    lua_pushvalue(L, idx);
+    lua_rawget(L, -2);
+    const bool result = lua_toboolean(L, -1);
+    lua_pop(L, 2);
+    return result;
+}
+
 void Internal::setFn(lua_State* L, const char* name, lua_CFunction fn) {
     if (isDispatcherTable(L, -1)) {
         lua_pushcfunction(L, fn);
         lua_pushstring(L, name);
         lua_pushcclosure(L, dispatcherFactory, 2);
+        markDispatcherFactory(L);
     } else
         lua_pushcfunction(L, fn);
 

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -234,6 +234,9 @@ static int dsp_releaseInputCapture(lua_State* L) {
 }
 
 static int hlExecCmd(lua_State* L) {
+    if (lua_gettop(L) > 2)
+        return Internal::configError(L, "exec_cmd: too many arguments (expected command and optional rule table, got {})", lua_gettop(L));
+
     const auto proc = Check::string(L, 1);
 
     if (!proc)
@@ -253,6 +256,9 @@ static int hlExecCmd(lua_State* L) {
 }
 
 static int hlExecRaw(lua_State* L) {
+    if (lua_gettop(L) > 1)
+        return Internal::configError(L, "exec_raw: too many arguments (expected a command string, got {})", lua_gettop(L));
+
     auto proc = Check::string(L, 1);
     if (!proc)
         return Internal::configError(L, std::format("exec_raw: bad argument 1: {}", proc.error()));

--- a/src/config/lua/bindings/LuaBindingsInternal.hpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.hpp
@@ -188,6 +188,7 @@ namespace Config::Lua::Bindings::Internal {
     void markDispatcherTable(lua_State* L);
     int  wrapDispatcher(lua_State* L);
     bool pushDispatcherFunction(lua_State* L, int idx);
+    bool isDispatcherFactory(lua_State* L, int idx);
 
     template <typename T>
     SParseError parseTableField(lua_State* L, int tableIdx, const char* field, T& parser) {

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -18,6 +18,9 @@
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/string/VarList.hpp>
 
+#include <cctype>
+#include <unordered_set>
+
 using namespace Config;
 using namespace Config::Lua;
 using namespace Config::Lua::Bindings;
@@ -30,14 +33,20 @@ extern "C" {
 }
 
 static std::expected<std::vector<std::string>, std::string> parseKeyString(std::string_view value) {
-    CVarList2                list(value, 0, '+', true);
-    std::vector<std::string> keys;
+    CVarList2                       list(value, 0, '+', true);
+    std::vector<std::string>        keys;
+    std::unordered_set<std::string> seen;
     keys.reserve(list.size());
 
     for (const auto& entry : list) {
         auto key = Hyprutils::String::trim(entry);
         if (key.empty())
             return std::unexpected("Empty key in key list");
+
+        std::string normalized = key;
+        std::ranges::transform(normalized, normalized.begin(), [](unsigned char c) { return std::toupper(c); });
+        if (!seen.insert(std::move(normalized)).second)
+            return std::unexpected(std::format("Repeated key '{}' in bind", key));
 
         keys.emplace_back(std::move(key));
     }
@@ -82,6 +91,9 @@ static int hlBind(lua_State* L) {
 
     const std::string handler = luaL_tolstring(L, 2, nullptr);
     lua_pop(L, 1);
+
+    if (Internal::isDispatcherFactory(L, 2))
+        return Internal::configError(L, "hl.bind: dispatcher factory was not called (e.g. hl.dsp.exec_raw instead of hl.dsp.exec_raw(\"...\"))");
 
     if (!Internal::pushDispatcherFunction(L, 2))
         return Internal::configError(L, "hl.bind: dispatcher must be a dispatcher (e.g. hl.dsp.window.close()) or a lua function");
@@ -333,6 +345,9 @@ static int hlClearCrashedLockscreen(lua_State* L) {
 }
 
 static int hlDispatch(lua_State* L) {
+    if (Internal::isDispatcherFactory(L, 1))
+        return Internal::configError(L, "hl.dispatch: dispatcher factory was not called (e.g. hl.dsp.window.close instead of hl.dsp.window.close())");
+
     if (!Internal::pushDispatcherFunction(L, 1))
         return Internal::configError(L, "hl.dispatch: expected a dispatcher (e.g. hl.dsp.window.close())");
 

--- a/src/keybinds/Bind.cpp
+++ b/src/keybinds/Bind.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cctype>
 #include <format>
+#include <unordered_set>
 
 using namespace Input;
 using namespace Keybinds;
@@ -88,13 +89,17 @@ std::expected<CBind, std::string> CBind::make(std::vector<std::string>&& keys, B
     if (!ret.m_callback)
         return std::unexpected("Bad callback");
 
-    bool   finishedMods = false;
-    size_t externalKeys = 0;
-    size_t ordinaryKeys = 0;
+    bool                            finishedMods = false;
+    size_t                          externalKeys = 0;
+    size_t                          ordinaryKeys = 0;
+    std::unordered_set<std::string> seenKeys;
 
     for (const auto& k : keys) {
         std::string normalized = k;
         std::ranges::transform(normalized, normalized.begin(), [](unsigned char c) { return std::toupper(c); });
+
+        if (!seenKeys.insert(normalized).second)
+            return std::unexpected(std::format("Repeated key '{}' in bind", k));
 
         if (const auto MODIFIER = modifierFromString(normalized)) {
             if (finishedMods)

--- a/tests/keybinds/Bind.cpp
+++ b/tests/keybinds/Bind.cpp
@@ -229,6 +229,19 @@ TEST(Keybinds, ModifierReleaseBindIncludesTriggerModifier) {
               BIND_MATCH_FULL);
 }
 
+TEST(Keybinds, RejectsRepeatedKeys) {
+    auto result = makeBind({"A", "A", "A"});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().find("Repeated key"), std::string::npos);
+
+    result = makeBind({"SUPER", "SUPER", "K"});
+    ASSERT_FALSE(result.has_value());
+    EXPECT_NE(result.error().find("Repeated key"), std::string::npos);
+
+    result = makeBind({"a", "A"});
+    ASSERT_FALSE(result.has_value());
+}
+
 TEST(Keybinds, CatchAllContextHonorsSubmapAndModifiers) {
     auto result = CBind::make({"SUPER", "catchall"}, BIND_FLAG_CATCH_ALL, [] { return SBindResult{}; }, {.metadata = {.submap = "resize"}});
     ASSERT_TRUE(result.has_value());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Some lua mistakes currently fail silently:

- repeating keys in a bind (`A + A + A`)
- binding/dispatching a factory without calling it (`hl.dsp.exec_raw` instead of `hl.dsp.exec_raw("...")`)
- extra arguments to `hl.dsp.exec_raw` / `hl.dsp.exec_cmd` (e.g. `hl.dsp.exec_raw("...", { float = true })`)

These now produce config errors. Unit test coverage for repeated bind keys is included.

Resolves #15871

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Configs that currently contain these mistakes will start reporting errors on reload.

#### Is it ready for merging, or does it need work?

Ready.