### PR TITLE
ipc: emit anr socket2 events with pid

### DIFF
--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -10,6 +10,7 @@
 #include "../config/ConfigValue.hpp"
 #include "../i18n/Engine.hpp"
 #include "../event/EventBus.hpp"
+#include "../ipc/s2/S2.hpp"
 
 using namespace Hyprutils::OS;
 
@@ -100,6 +101,7 @@ void CANRManager::onTick() {
 
         if (data->missedResponses >= *PANRTHRESHOLD) {
             if (!data->isRunning() && !data->dialogSaidWait) {
+                IPC::Socket2::sock()->postEvent({.event = "anr", .data = std::format("{},1", data->pid)});
                 data->runDialog(firstWindow->metadata().title(), firstWindow->metadata().appID(), data->pid);
 
                 for (const auto& w : Desktop::windowState()->windows()) {
@@ -136,9 +138,14 @@ void CANRManager::onResponse(Desktop::View::SBackendClientID clientID) {
 }
 
 void CANRManager::onResponse(SP<CANRManager::SANRData> data) {
+    const bool WAS_ANR = isNotResponding(data) || data->isRunning();
+
     data->missedResponses = 0;
     if (data->isRunning())
         data->killDialog();
+
+    if (WAS_ANR)
+        IPC::Socket2::sock()->postEvent({.event = "anr", .data = std::format("{},0", data->pid)});
 }
 
 bool CANRManager::isNotResponding(PHLWINDOW pWindow) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Emit a socket2 event when an app is not responding and when it recovers:

- `anr>>pid,1` when the ANR dialog is shown
- `anr>>pid,0` when the app starts responding again

Resolves #10611

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

There is a stale draft PR (#11211) for a similar event. This is a smaller, independent implementation using the existing ANR manager.

Wiki: new socket2 event (`anr`) should be documented.

#### Is it ready for merging, or does it need work?

Ready.