### PR TITLE
input-capture: use libeis fd backend

### DIFF
--- a/src/managers/input/Eis.cpp
+++ b/src/managers/input/Eis.cpp
@@ -19,29 +19,21 @@ static const char* getClientName(eis_client* client) {
     return name ? name : "<unnamed>";
 }
 
-CEis::CEis(std::string socketName) {
-    Log::logger->log(Log::INFO, "[EIS] Init socket: {}", socketName);
-
-    const char* xdg = getenv("XDG_RUNTIME_DIR");
-    if (xdg)
-        m_socketPath = std::format("{}/{}", xdg, socketName);
-
-    if (m_socketPath.empty()) {
-        Log::logger->log(Log::ERR, "[EIS] Socket path is empty");
-        return;
-    }
-
+CEis::CEis() {
     m_eisCtx = eis_new(nullptr);
     if (!m_eisCtx) {
         Log::logger->log(Log::ERR, "[EIS] Cannot create eis context");
         return;
     }
 
-    if (eis_setup_backend_socket(m_eisCtx, m_socketPath.c_str())) {
-        Log::logger->log(Log::ERR, "[EIS] Cannot init eis socket on {}", m_socketPath);
+    if (eis_setup_backend_fd(m_eisCtx)) {
+        Log::logger->log(Log::ERR, "[EIS] Cannot init eis fd backend");
+        eis_unref(m_eisCtx);
+        m_eisCtx = nullptr;
         return;
     }
-    Log::logger->log(Log::INFO, "[EIS] Listening on {}", m_socketPath);
+
+    Log::logger->log(Log::INFO, "[EIS] fd backend ready");
 
     m_eventSource = wl_event_loop_add_fd(
         g_pCompositor->m_wlEventLoop, eis_get_fd(m_eisCtx), WL_EVENT_READABLE, [](int fd, uint32_t mask, void* data) { return ((CEis*)data)->pollEvents(); }, this);

--- a/src/managers/input/Eis.hpp
+++ b/src/managers/input/Eis.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
 #include <libeis.h>
-#include <string>
 #include <wayland-server-core.h>
 
 /*
- * Responsible to creating a socket for input communication
+ * EIS context for input capture. Uses libeis's fd backend so a private
+ * socket can be passed to the portal client via sendEisFd.
  */
 class CEis {
   public:
-    CEis(std::string socketPath);
+    CEis();
     ~CEis();
 
     void startEmulating(int activationId);
@@ -28,10 +28,6 @@ class CEis {
     void sendPointerFrame();
 
     int  getFileDescriptor();
-
-    //
-
-    std::string m_socketPath;
 
   private:
     struct SKeymap {

--- a/src/protocols/InputCapture.cpp
+++ b/src/protocols/InputCapture.cpp
@@ -25,8 +25,6 @@
 #include <optional>
 #include <string>
 
-static int eisCounter = 0;
-
 CInputCaptureResource::CInputCaptureResource(SP<CHyprlandInputCaptureV1> resource_, std::string handle) : m_sessionId(handle), m_resource(resource_) {
     if UNLIKELY (!good())
         return;
@@ -41,7 +39,7 @@ CInputCaptureResource::CInputCaptureResource(SP<CHyprlandInputCaptureV1> resourc
     m_resource->setRelease([this](CHyprlandInputCaptureV1* r, uint32_t activationId, double x, double y) { onRelease(activationId, x, y); });
     m_resource->setClearBarriers([this](CHyprlandInputCaptureV1* r) { onClearBarriers(); });
 
-    m_eis = makeUnique<CEis>(std::format("eis-{}", eisCounter++));
+    m_eis = makeUnique<CEis>();
 
     const int EISFD = m_eis->getFileDescriptor();
     if (EISFD >= 0)


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

CEis set up a socket backend, then getFileDescriptor() called
eis_backend_fd_add_client(), which asserts eis->backend. If socket
setup failed, that abort killed the compositor (SIGABRT) while
creating an input-capture session.

Use eis_setup_backend_fd() to match sendEisFd, and drop the context
on setup failure so getFileDescriptor() returns -1 instead of aborting.

This fixes a compatibility issue with lan-mouse that was resulting in a
consistent crash.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
An AI assistant (Grok Build) was used to generate the fix, but was reviewed prior to
submission.  Tested locally to confirm the patch was successful.

#### Is it ready for merging, or does it need work?
Ready for merging.

