### PR TITLE
config: Add `misc.suppress_initial_maximize_requests`

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -529,6 +529,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<String>("misc:bell_sound", "path to custom wav/ogg system bell. `none` or an empty string mute it. `default` uses the system's current one.", "default"),
         MS<Int>("misc:new_float_force_onscreen", "whether new floating windows must be placed fully/partially on-screen", 2),
         MS<Int>("misc:float_force_onscreen", "whether existing floating windows must remain fully/partially on-screen", 0),
+        MS<Bool>("misc:suppress_initial_maximize_requests", "whether to ignore requests from a window to be maximised when it is first created", true),
 
         /*
          * binds:

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -846,6 +846,8 @@ void CWindow::requestClientFullscreen(const SClientFullscreenRequest& request) {
     }
 
     if (request.maximized.has_value() && !SUPPRESSION.maximize) {
+        static auto SUPPRESS_INITIAL_MAXIMIZE = CConfigValue<Config::BOOL>("misc:suppress_initial_maximize_requests");
+
         if (m_isMapped) {
             if (!BACKEND_REQUEST || !m_fullscreenPolicy->consumeExpectedMaximizeEcho(request.maximized.value())) {
                 const auto WINDOW       = m_self.lock();
@@ -855,10 +857,12 @@ void CWindow::requestClientFullscreen(const SClientFullscreenRequest& request) {
                 else if (CLIENT_STATE == Fullscreen::FSMODE_MAXIMIZED)
                     Fullscreen::controller()->setFullscreenMode(WINDOW, std::nullopt, Fullscreen::FSMODE_NONE);
             }
-        } else if (request.maximized.value())
-            m_fullscreenPolicy->setPendingClientRequest(Fullscreen::FSMODE_MAXIMIZED);
-        else
-            m_fullscreenPolicy->clearPendingClientMode(Fullscreen::FSMODE_MAXIMIZED);
+        } else if (!(*SUPPRESS_INITIAL_MAXIMIZE)) {
+            if (request.maximized.value())
+                m_fullscreenPolicy->setPendingClientRequest(Fullscreen::FSMODE_MAXIMIZED);
+            else
+                m_fullscreenPolicy->clearPendingClientMode(Fullscreen::FSMODE_MAXIMIZED);
+        }
     }
 }
 


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

Fixes #15901
Allows restoring previous behaviour that was changed by #15779 

I chose `true` as the default value because that was the behaviour until recently