### PR TITLE
window_rules: add `mapped` match

### DIFF
--- a/src/desktop/rule/Rule.cpp
+++ b/src/desktop/rule/Rule.cpp
@@ -42,6 +42,7 @@ constexpr auto MATCH_PROP_STRINGS =
         {RULE_PROP_CONTENT, "content"},                                    //
         {RULE_PROP_XDG_TAG, "xdg_tag"},                                    //
         {RULE_PROP_NAMESPACE, "namespace"},                                //
+        {RULE_PROP_MAPPED, "mapped"},                                      //
     }));
 
 constexpr auto RULE_ENGINES =
@@ -69,6 +70,7 @@ constexpr auto RULE_ENGINES =
         {RULE_PROP_NAMESPACE, RULE_MATCH_ENGINE_REGEX},              //
         {RULE_PROP_EXEC_TOKEN, RULE_MATCH_ENGINE_REGEX},             //
         {RULE_PROP_EXEC_PID, RULE_MATCH_ENGINE_INT},                 //
+        {RULE_PROP_MAPPED, RULE_MATCH_ENGINE_BOOL},                  //
     }));
 
 std::span<const std::string_view> Rule::allMatchPropStrings() {

--- a/src/desktop/rule/Rule.hpp
+++ b/src/desktop/rule/Rule.hpp
@@ -32,6 +32,7 @@ namespace Desktop::Rule {
         RULE_PROP_NAMESPACE                = (1 << 17),
         RULE_PROP_EXEC_TOKEN               = (1 << 18),
         RULE_PROP_EXEC_PID                 = (1 << 19),
+        RULE_PROP_MAPPED                   = (1 << 20),
 
         RULE_PROP_ALL = std::numeric_limits<std::underlying_type_t<eRuleProperty>>::max(),
     };

--- a/src/desktop/rule/windowRule/WindowRule.cpp
+++ b/src/desktop/rule/windowRule/WindowRule.cpp
@@ -458,6 +458,10 @@ bool CWindowRule::matches(PHLWINDOW w, bool allowEnvLookup) {
                 if (const auto TAG = w->backend().metadata().tag; !TAG.has_value() || !engine->match(*TAG))
                     return false;
                 break;
+            case RULE_PROP_MAPPED:
+                if (!engine->match(w->mapped()))
+                    return false;
+                break;
 
             case RULE_PROP_EXEC_TOKEN:
                 if (!allowEnvLookup)

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
@@ -556,7 +556,7 @@ void CWindowRuleApplicator::recheckStaticRules() {
 }
 
 void CWindowRuleApplicator::propertiesChanged(std::underlying_type_t<eRuleProperty> props) {
-    if (!m_window || !m_window->mapped() || m_window->isHidden())
+    if (!m_window)
         return;
 
     bool                                                        needsRelayout         = false;
@@ -588,6 +588,9 @@ void CWindowRuleApplicator::propertiesChanged(std::underlying_type_t<eRuleProper
         const auto RES = applyDynamicRule(wr);
         needsRelayout  = needsRelayout || RES.needsRelayout;
     }
+
+    if (!m_window->mapped() || m_window->isHidden())
+        return;
 
     m_window->updateWindowData();
     m_window->presentation().updateDecorations();

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -119,6 +119,7 @@ void CWindow::initialize() {
     m_presentation->initialize();
 
     m_target = Layout::CWindowTarget::create(SELF);
+    m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_MAPPED);
 
     if (const auto SURFACE = m_backend->surface())
         wlSurface()->assign(SURFACE, SELF);
@@ -1621,6 +1622,8 @@ void CWindow::unmapWindow() {
 
     // do this after onWindowRemoved because otherwise it'll think the window is invalid
     m_isMapped = false;
+
+    m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_MAPPED);
 
     // refocus on a new window if needed
     if (wasLastWindow) {


### PR DESCRIPTION
# DOESN'T WORK RN BECAUSE `suppress_event` IS A STATIC EFFECT

Fixes https://github.com/hyprwm/Hyprland/discussions/15901
Allows restoring previous behaviour that was changed by https://github.com/hyprwm/Hyprland/pull/15779 like this:

```lua
hl.window_rule({
  match = {
    mapped = false,
  },
  suppress_event = "maximize"
});
```