### PR TITLE
input: use logical monitor size for eis regions

### DIFF
--- a/src/managers/input/Eis.cpp
+++ b/src/managers/input/Eis.cpp
@@ -171,7 +171,7 @@ void CEis::ensurePointer() {
         eis_region* r = eis_device_new_region(pointer);
 
         eis_region_set_offset(r, o->m_position.x, o->m_position.y);
-        eis_region_set_size(r, o->m_pixelSize.x, o->m_pixelSize.y);
+        eis_region_set_size(r, o->m_size.x, o->m_size.y);
         eis_region_set_physical_scale(r, o->m_scale);
         eis_region_add(r);
         eis_region_unref(r);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The EIS manager used the raw framebuffer size to advertise regions, which means monitors with scaling factor != 1 or output transformation were assigned regions that didn't match and messed up things like input capture. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I used Claude Code to find the source of the bug starting from Deskflow in debug mode. I then tested the fix to ensure it worked, and had a few rounds with claude to understand if the initial `m_pixelSize` was an oversight or a need for other parts (-> most likely an oversight).

#### Is it ready for merging, or does it need work?
Ready to merge

