### PR TITLE
decoration/groupbar: fix crash when group returns no match

### DIFF
--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -488,6 +488,9 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, const IPo
 
     PHLWINDOW pWindow = m_window->grouping().group()->fromIndex(WINDOWINDEX);
 
+    if (!pWindow)
+        return true;
+
     if (pWindow != m_window)
         pWindow->grouping().group()->setCurrent(pWindow);
 


### PR DESCRIPTION
ref #13853


