### PR TITLE
Fix some master layout window-drag bugs

### DIFF
--- a/hyprtester/src/tests/main/master.cpp
+++ b/hyprtester/src/tests/main/master.cpp
@@ -912,3 +912,104 @@ TEST_CASE(masterCenterDropAtCursor) {
     CALL_SUBTEST(expectCenterDrop, "R", false, "R", "M", "L");
     CALL_SUBTEST(expectCenterDrop, "R", true, "L", "M", "R");
 }
+
+// In a non-centered master layout with three windows w1/w2/w3, return their
+// classes ordered: { master, top slave, bottom slave }.
+static std::array<std::string, 3> detectTripleArrangement(const std::array<std::string, 3> &classes) {
+    std::vector<std::pair<std::pair<int, int>, std::string>> wins;
+    for (auto const& cls : classes) {
+        getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'class:{}' }})", cls));
+        const auto at = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+        const auto comma = at.find(',');
+        const auto x = std::stoi(at.substr(0, comma));
+        const auto y = std::stoi(at.substr(comma + 1));
+        wins.emplace_back(std::pair(x, y), cls);
+    }
+    std::ranges::sort(wins,
+            [&](std::pair<int, int> w1, std::pair<int, int> w2){ return (w1.first < w2.first) || (w1.second < w2.second); },
+            &std::pair<std::pair<int, int>, std::string>::first);
+    NLog::log("{}DEBUG: Window list is {},{},{}", Colors::BLUE, wins[0], wins[1], wins[2]);
+    return {wins[0].second, wins[1].second, wins[2].second};
+}
+
+// Create three windows, and drags `pick` to where `place` was before the drag
+// started. Assert that windows are in their expected locations afterwards.
+// `pick` and `place` are numbers from 1 to 3, with 1 representing the master
+// window, and 2/3 being the upper/lower windows in the stack, respectively.
+SUBTEST(expectTripleDragSwap, const uint pick, const uint place, const uint exp1, const uint exp2, const uint exp3) {
+    // start from a fresh set of three windows
+    if (!Tests::killAllWindows())
+        FAIL_TEST("Could not clear windows{}", "");
+
+    const std::array<std::string, 3> CLASSES = {"w1", "w2", "w3"};
+    for (auto const& win : CLASSES) {
+        SPAWN_KITTY(win);
+    }
+    Tests::waitUntilWindowsN(3);
+
+    const auto INITIAL = detectTripleArrangement(CLASSES);
+
+    double DROPX, DROPY;
+    {
+        getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'class:{}' }})", INITIAL[place - 1]));
+        const auto at = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+        const auto comma = at.find(',');
+        DROPX = std::stoi(at.substr(0, comma));
+        DROPY = std::stoi(at.substr(comma + 1));
+    }
+
+    NLog::log("{}Dragging window {} and dropping it in position {} ({},{})", Colors::YELLOW, pick, place, DROPX, DROPY);
+    OK(getFromSocket(std::format("/eval hl.plugin.test.drag_window('{}', {}, {})", INITIAL[pick - 1], DROPX, DROPY)));
+
+    const auto FINAL = detectTripleArrangement(CLASSES);
+    EXPECT(FINAL[0], INITIAL[exp1 - 1]);
+    EXPECT(FINAL[1], INITIAL[exp2 - 1]);
+    EXPECT(FINAL[2], INITIAL[exp3 - 1]);
+}
+
+TEST_CASE(masterDropAtCursor) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'master' } })"));
+    OK(getFromSocket("/eval hl.config({ master = { drop_at_cursor = true } })"));
+
+    NLog::log("{}Testing master window drag with new_status=slave", Colors::GREEN);
+    OK(getFromSocket("/eval hl.config({ master = { new_status = 'slave' } })"));
+    CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
+    CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
+    NLog::log("{}...and again with new_on_top", Colors::GREEN);
+    OK(getFromSocket("/eval hl.config({ master = { new_on_top = true } })"));
+    CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
+    CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
+    OK(getFromSocket("/eval hl.config({ master = { new_on_top = false } })"));
+
+    NLog::log("{}Testing master window drag with new_status=master", Colors::GREEN);
+    OK(getFromSocket("/eval hl.config({ master = { new_status = 'master' } })"));
+    CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
+    CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
+    NLog::log("{}...and again with new_on_top", Colors::GREEN);
+    OK(getFromSocket("/eval hl.config({ master = { new_on_top = true } })"));
+    CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
+    CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
+    OK(getFromSocket("/eval hl.config({ master = { new_on_top = false } })"));
+
+    NLog::log("{}Testing master window drag with new_status=inherit", Colors::GREEN);
+    OK(getFromSocket("/eval hl.config({ master = { new_status = 'inherit' } })"));
+    CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
+    CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
+    NLog::log("{}...and again with new_on_top", Colors::GREEN);
+    OK(getFromSocket("/eval hl.config({ master = { new_on_top = true } })"));
+    CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
+    CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
+    OK(getFromSocket("/eval hl.config({ master = { new_on_top = false } })"));
+}

--- a/hyprtester/src/tests/main/master.cpp
+++ b/hyprtester/src/tests/main/master.cpp
@@ -915,20 +915,19 @@ TEST_CASE(masterCenterDropAtCursor) {
 
 // In a non-centered master layout with three windows w1/w2/w3, return their
 // classes ordered: { master, top slave, bottom slave }.
-static std::array<std::string, 3> detectTripleArrangement(const std::array<std::string, 3> &classes) {
+static std::array<std::string, 3> detectTripleArrangement(const std::array<std::string, 3>& classes) {
     std::vector<std::pair<std::pair<int, int>, std::string>> wins;
     for (auto const& cls : classes) {
         getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'class:{}' }})", cls));
-        const auto at = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+        const auto at    = Tests::getAttribute(getFromSocket("/activewindow"), "at");
         const auto comma = at.find(',');
-        const auto x = std::stoi(at.substr(0, comma));
-        const auto y = std::stoi(at.substr(comma + 1));
+        const auto x     = std::stoi(at.substr(0, comma));
+        const auto y     = std::stoi(at.substr(comma + 1));
         wins.emplace_back(std::pair(x, y), cls);
     }
-    std::ranges::sort(wins,
-            [&](std::pair<int, int> w1, std::pair<int, int> w2){ return (w1.first < w2.first) || (w1.second < w2.second); },
-            &std::pair<std::pair<int, int>, std::string>::first);
-    NLog::log("{}DEBUG: Window list is {},{},{}", Colors::BLUE, wins[0], wins[1], wins[2]);
+    std::ranges::sort(
+        wins, [&](std::pair<int, int> w1, std::pair<int, int> w2) { return (w1.first < w2.first) || (w1.second < w2.second); },
+        &std::pair<std::pair<int, int>, std::string>::first);
     return {wins[0].second, wins[1].second, wins[2].second};
 }
 
@@ -948,14 +947,13 @@ SUBTEST(expectTripleDragSwap, const uint pick, const uint place, const uint exp1
     Tests::waitUntilWindowsN(3);
 
     const auto INITIAL = detectTripleArrangement(CLASSES);
-
-    double DROPX, DROPY;
+    double     DROPX, DROPY;
     {
         getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'class:{}' }})", INITIAL[place - 1]));
-        const auto at = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+        const auto at    = Tests::getAttribute(getFromSocket("/activewindow"), "at");
         const auto comma = at.find(',');
-        DROPX = std::stoi(at.substr(0, comma));
-        DROPY = std::stoi(at.substr(comma + 1));
+        DROPX            = std::stoi(at.substr(0, comma));
+        DROPY            = std::stoi(at.substr(comma + 1));
     }
 
     NLog::log("{}Dragging window {} and dropping it in position {} ({},{})", Colors::YELLOW, pick, place, DROPX, DROPY);

--- a/hyprtester/src/tests/main/master.cpp
+++ b/hyprtester/src/tests/main/master.cpp
@@ -973,7 +973,7 @@ TEST_CASE(masterDropAtCursor) {
     OK(getFromSocket("/eval hl.config({ master = { new_status = 'slave' } })"));
     CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
     CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
-    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 1, 2);
     CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
     NLog::log("{}...and again with new_on_top", Colors::GREEN);
     OK(getFromSocket("/eval hl.config({ master = { new_on_top = true } })"));
@@ -993,7 +993,7 @@ TEST_CASE(masterDropAtCursor) {
     OK(getFromSocket("/eval hl.config({ master = { new_on_top = true } })"));
     CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
     CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
-    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 1, 2);
     CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
     OK(getFromSocket("/eval hl.config({ master = { new_on_top = false } })"));
 
@@ -1007,7 +1007,7 @@ TEST_CASE(masterDropAtCursor) {
     OK(getFromSocket("/eval hl.config({ master = { new_on_top = true } })"));
     CALL_SUBTEST(expectTripleDragSwap, 1, 2, 2, 1, 3);
     CALL_SUBTEST(expectTripleDragSwap, 1, 3, 2, 3, 1);
-    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 2, 1);
+    CALL_SUBTEST(expectTripleDragSwap, 3, 1, 3, 1, 2);
     CALL_SUBTEST(expectTripleDragSwap, 3, 2, 1, 3, 2);
     OK(getFromSocket("/eval hl.config({ master = { new_on_top = false } })"));
 }

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -99,7 +99,7 @@ void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
     if (*PDROPATCURSOR && DRAGMOVE) {
         if (CENTERED) {
             if (const auto PMASTER = getMasterNode(); PMASTER) {
-                const CBox MBOX = PMASTER->pTarget->position();
+                const auto MBOX = CBox{PMASTER->position, PMASTER->size};
                 if (MOUSECOORDS.x >= MBOX.x && MOUSECOORDS.x <= MBOX.x + MBOX.w)
                     forceDropAsMaster = true;
                 else {
@@ -117,7 +117,7 @@ void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
                         if (nd->isMaster)
                             continue;
                         const bool ndRight = (slavesNo % 2 == 0) == FIRSTSIDERIGHT;
-                        if (ndRight == DROPRIGHT && MOUSECOORDS.y > nd->pTarget->position().middle().y)
+                        if (ndRight == DROPRIGHT && MOUSECOORDS.y > CBox{nd->position, nd->size}.middle().y)
                             ++slot;
                         ++slavesNo;
                     }
@@ -149,7 +149,7 @@ void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
             const std::size_t srcIndex = sc<std::size_t>(std::distance(v.begin(), NODEIT));
 
             for (std::size_t i = 0; i < v.size(); ++i) {
-                const CBox box = v[i]->pTarget->position();
+                const auto box = CBox{v[i]->position, v[i]->size};
                 if (!box.containsPoint(MOUSECOORDS))
                     continue;
 
@@ -190,7 +190,7 @@ void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
             // make it the master only if the cursor is on the master side of the screen
             for (auto const& nd : m_masterNodesData) {
                 if (nd->isMaster) {
-                    const auto MIDDLE = nd->pTarget->position().middle();
+                    const auto MIDDLE = CBox{nd->position, nd->size}.middle();
                     switch (orientation) {
                         case ORIENTATION_LEFT:
                         case ORIENTATION_CENTER:

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -65,7 +65,7 @@ void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
     }
 
     const bool BNEWBEFOREACTIVE = *PNEWONACTIVE == "before";
-    const bool BNEWISMASTER     = dragOntoMaster || *PNEWSTATUS == "master";
+    const bool BNEWISMASTER     = dragOntoMaster || (!DRAGMOVE && *PNEWSTATUS == "master");
 
     const auto PNODE = [&]() -> SP<SMasterNodeData> {
         if (*PNEWONACTIVE != "none" && !BNEWISMASTER) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes two bugs with window dragging in the master layout:
- `new_status = "master"` is incorrectly respected even while dragging, so windows can only be dropped as the new master
- With `new_on_top = true`, `drop_at_cursor = true` is ignored and always places the new window on top of the stack

Refs: #15920, #14830

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Are these too edge-case-y, or do we want tests?

#### Is it ready for merging, or does it need work?

Ready, except for maybe those tests