### PR TITLE
seat: resend keyboard mods after keymap updates

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -178,6 +178,10 @@ void CSeatManager::updateActiveKeyboardData() {
         PROTO::seat->updateRepeatInfo(m_keyboard->m_repeatRate, m_keyboard->m_repeatDelay);
     PROTO::seat->updateKeymap();
     PROTO::inputCapture->updateKeymap();
+
+    // wl_keyboard.keymap resets the client's xkb state: follow up with current mods
+    if (m_keyboard)
+        sendKeyboardMods(m_keyboard->m_modifiersState.depressed, m_keyboard->m_modifiersState.latched, m_keyboard->m_modifiersState.locked, m_keyboard->m_modifiersState.group);
 }
 
 void CSeatManager::setKeyboardFocus(SP<CWLSurfaceResource> surf) {


### PR DESCRIPTION
#### Describe your PR, what does it do:

`wl_keyboard.keymap` resets the receiving client's xkb state, but `CSeatManager::updateActiveKeyboardData()` sends only the keymap and repeat info. The focused client is left with all modifiers cleared until the next real modifier change.

This desyncs locked modifiers whenever keyboards are recreated while a surface holds keyboard focus — most visibly on resume from suspend with `numlock_by_default = true` and a session-lock surface focused: the compositor state and the keyboard LED say numlock is on, but the lock screen believes it is off, so numpad digits arrive as KP_Home/KP_End/etc. and the password field stays empty. It takes two NumLock presses to resync (the first press only aligns the two states by turning numlock off, the second turns it on).

Fix: after pushing keymaps to clients, resend the active keyboard's modifier state to the keyboard-focus holder.

Verified on 0.56.2 (Arch, Omarchy): before the patch, numpad is dead at the lock screen after every suspend/resume; after it, numpad input works immediately. Fixes the root cause behind basecamp/omarchy#3224 and the symptoms in hyprwm/hyprlock#371.