### PR TITLE
Config: Fix misspelling of `damping` as `dampening` for spring animations

### DIFF
--- a/example/hyprland.lua
+++ b/example/hyprland.lua
@@ -140,7 +140,7 @@ hl.curve("almostLinear",   { type = "bezier", points = { {0.5, 0.5},   {0.75, 1}
 hl.curve("quick",          { type = "bezier", points = { {0.15, 0},    {0.1, 1}     } })
 
 -- Default springs
-hl.curve("easy",           { type = "spring", mass = 1, stiffness = 238.1191, dampening = 24.21279333 })
+hl.curve("easy",           { type = "spring", mass = 1, stiffness = 238.1191, damping = 24.21279333 })
 
 hl.animation({ leaf = "global",        enabled = true,  speed = 10,   bezier = "default" })
 hl.animation({ leaf = "border",        enabled = true,  speed = 5.39, bezier = "easeOutQuint" })

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -358,6 +358,11 @@ static int hlCurve(lua_State* L) {
             CScopeGuard x([L] { lua_pop(L, 1); });
 
             lua_getfield(L, 2, "damping");
+            if (lua_isnil(L, -1)) {
+                lua_pop(L, 1);
+                // Old typo form, please add a deprecation notice if you ever plan on removing these
+                lua_getfield(L, 2, "dampening");
+            }
 
             if (!lua_isnumber(L, -1))
                 return Internal::configError(L, std::format("hl.curve(\"{}\"): damping expects a number", name));

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -357,15 +357,15 @@ static int hlCurve(lua_State* L) {
         {
             CScopeGuard x([L] { lua_pop(L, 1); });
 
-            lua_getfield(L, 2, "dampening");
+            lua_getfield(L, 2, "damping");
 
             if (!lua_isnumber(L, -1))
-                return Internal::configError(L, std::format("hl.curve(\"{}\"): dampening expects a number", name));
+                return Internal::configError(L, std::format("hl.curve(\"{}\"): damping expects a number", name));
 
             curve.damping = lua_tonumber(L, -1);
 
             if (curve.damping <= 0.5F)
-                return Internal::configError(L, std::format("hl.curve(\"{}\"): dampening expects a number >= 0.5", name));
+                return Internal::configError(L, std::format("hl.curve(\"{}\"): damping expects a number >= 0.5", name));
         }
 
         {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It's damping for springs. It's not a mere misspelling but a different term entirely so this should be fixed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It IS a breaking change...

#### Is it ready for merging, or does it need work?

Separate wiki MR for this will be made, then wiki rewrite MR will catch up with that; so we maintain a clear history of changes before rewrite is merged

- [x] Wiki MR