### PR TITLE
Cleaner incremental builds with the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,24 @@ BUILDDIR ?= ./build
 CMAKE_BUILD_TYPE := Release
 CMAKE_ARGS = -DCMAKE_BUILD_TYPE:STRING=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX:STRING=$(PREFIX)
 CMAKE_BUILDTYPE_FILE = $(BUILDDIR)/cmake_last_build_type
+CMAKE_GENERATE_CMD = cmake -Wno-unused-cli $(CMAKE_ARGS) -S . -B $(BUILDDIR)
 
+.DEFAULT: stub
 .PHONY: stub cmake_smartbuild release debug nopch clear all install uninstall pluginenv installheaders man asan format-check format-fix test
 
 stub:
 	@echo "Do not run $(MAKE) directly without any arguments. Please refer to the wiki on how to compile Hyprland."
 
-cmake_smartbuild:
+# Regenerate when CMakeLists have changed
+$(CMAKE_BUILDTYPE_FILE): $(shell find -type f -name CMakeLists.txt -not -path '*/_deps/*')
+	echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > $(CMAKE_BUILDTYPE_FILE)
+	$(CMAKE_GENERATE_CMD)
+
+# Regenerate when CMake options have changed, then build
+cmake_smartbuild: $(CMAKE_BUILDTYPE_FILE)
 	read lastbuild < $(CMAKE_BUILDTYPE_FILE) && test "$$lastbuild" = "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" || { \
 		echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > $(CMAKE_BUILDTYPE_FILE); \
-		cmake -Wno-unused-cli $(CMAKE_ARGS) -S . -B $(BUILDDIR); \
+		$(CMAKE_GENERATE_CMD); \
 	}
 	cmake --build $(BUILDDIR) --config $(CMAKE_BUILD_TYPE) --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
@@ -98,7 +106,7 @@ asan: cmake_smartbuild
 	@echo "Wayland done"
 
 	patch -p1 < ./scripts/hyprlandStaticAsan.diff
-	cmake -Wno-unused-cli $(CMAKE_ARGS) -DWITH_ASAN:STRING=True -DUSE_TRACY:STRING=False -DUSE_TRACY_GPU:STRING=False -S . -B $(BUILDDIR)
+	$(CMAKE_GENERATE_CMD) -DWITH_ASAN:STRING=True -DUSE_TRACY:STRING=False -DUSE_TRACY_GPU:STRING=False
 	cmake --build $(BUILDDIR) --config $(CMAKE_BUILD_TYPE) --target all
 	@echo "Hyprland done"
 

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,26 @@
 PREFIX = /usr/local
+CMAKE_BUILD_TYPE := Release
+CMAKE_ARGS = -DCMAKE_BUILD_TYPE:STRING=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX:STRING=$(PREFIX)
+CMAKE_BUILDTYPE_FILE = ./build/cmake_last_build_type
 
 stub:
 	@echo "Do not run $(MAKE) directly without any arguments. Please refer to the wiki on how to compile Hyprland."
 
-release:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -S . -B ./build
-	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+cmake_smartbuild:
+	read lastbuild < $(CMAKE_BUILDTYPE_FILE) && test "$$lastbuild" = "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" || { \
+		echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > $(CMAKE_BUILDTYPE_FILE); \
+		cmake -Wno-unused-cli $(CMAKE_ARGS) -S . -B ./build; \
+	}
+	cmake --build ./build --config $(CMAKE_BUILD_TYPE) --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
-debug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DTESTS=true -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -S . -B ./build
-	cmake --build ./build --config Debug --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+release: cmake_smartbuild
 
-nopch:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON -S . -B ./build
-	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+debug: CMAKE_BUILD_TYPE := Debug
+debug: CMAKE_ARGS += -DTESTS=true
+debug: cmake_smartbuild
+
+nopch: CMAKE_ARGS += -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
+nopch: cmake_smartbuild
 
 clear:
 	rm -rf build
@@ -24,7 +31,7 @@ all:
 	$(MAKE) clear
 	$(MAKE) release
 
-install:
+install: cmake_smartbuild
 	cmake --install ./build
 
 uninstall:
@@ -34,7 +41,7 @@ pluginenv:
 	@echo -en "$(MAKE) pluginenv has been deprecated.\nPlease run $(MAKE) all && sudo $(MAKE) installheaders\n"
 	@exit 1
 
-installheaders:
+installheaders: cmake_smartbuild
 	@if [ ! -f ./src/version.h ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
 	# remove previous headers from hyprpm's dir
@@ -43,7 +50,7 @@ installheaders:
 	mkdir -p ${PREFIX}/include/hyprland/protocols
 	mkdir -p ${PREFIX}/share/pkgconfig
 
-	cmake --build ./build --config Release --target generate-protocol-headers
+	cmake --build ./build --config $(CMAKE_BUILD_TYPE) --target generate-protocol-headers
 
 	find src -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.inc' \) -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
 	cp ./protocols/*.h* ${PREFIX}/include/hyprland/protocols
@@ -70,7 +77,8 @@ man:
 		--from rst \
 		--to man > ./docs/hyprctl.1
 
-asan:
+asan: CMAKE_BUILD_TYPE := Debug
+asan: cmake_smartbuild
 	@echo -en "!!WARNING!!\nOnly run this in the TTY.\n"
 	@pidof Hyprland > /dev/null && echo -ne "Refusing to run with Hyprland running.\n" || echo ""
 	@pidof Hyprland > /dev/null && exit 1 || echo ""
@@ -88,8 +96,8 @@ asan:
 	@echo "Wayland done"
 
 	patch -p1 < ./scripts/hyprlandStaticAsan.diff
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DWITH_ASAN:STRING=True -DUSE_TRACY:STRING=False -DUSE_TRACY_GPU:STRING=False -S . -B ./build
-	cmake --build ./build --config Debug --target all
+	cmake -Wno-unused-cli $(CMAKE_ARGS) -DWITH_ASAN:STRING=True -DUSE_TRACY:STRING=False -DUSE_TRACY_GPU:STRING=False -S . -B ./build
+	cmake --build ./build --config $(CMAKE_BUILD_TYPE) --target all
 	@echo "Hyprland done"
 
 	ASAN_OPTIONS="detect_odr_violation=0,log_path=asan.log" HYPRLAND_NO_CRASHREPORTER=1 ./build/Hyprland -c ~/.config/hypr/hyprland.lua
@@ -108,6 +116,5 @@ format-fix:
 		! -path "hyprtester/protocols/*" \
 		| xargs clang-format -i
 
-test:
-	$(MAKE) debug
+test: debug
 	./build/hyprtester/hyprtester -c hyprtester/test.lua -b ./build/Hyprland -p hyprtester/plugin/hyprtestplugin.so $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,14 @@ stub:
 
 # Regenerate when CMakeLists have changed
 $(CMAKE_BUILDTYPE_FILE): $(shell find -type f -name CMakeLists.txt -not -path '*/_deps/*')
-	echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > $(CMAKE_BUILDTYPE_FILE)
+	if [ ! -d "$(BUILDDIR)" ]; then mkdir "$(BUILDDIR)"; fi
+	echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > "$(CMAKE_BUILDTYPE_FILE)"
 	$(CMAKE_GENERATE_CMD)
 
 # Regenerate when CMake options have changed, then build
 cmake_smartbuild: $(CMAKE_BUILDTYPE_FILE)
-	read lastbuild < $(CMAKE_BUILDTYPE_FILE) && test "$$lastbuild" = "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" || { \
-		echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > $(CMAKE_BUILDTYPE_FILE); \
+	read lastbuild < "$(CMAKE_BUILDTYPE_FILE)" && test "$$lastbuild" = "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" || { \
+		echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > "$(CMAKE_BUILDTYPE_FILE)"; \
 		$(CMAKE_GENERATE_CMD); \
 	}
 	cmake --build $(BUILDDIR) --config $(CMAKE_BUILD_TYPE) --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-PREFIX = /usr/local
+PREFIX ?= /usr/local
+BUILDDIR ?= ./build
 CMAKE_BUILD_TYPE := Release
 CMAKE_ARGS = -DCMAKE_BUILD_TYPE:STRING=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX:STRING=$(PREFIX)
-CMAKE_BUILDTYPE_FILE = ./build/cmake_last_build_type
+CMAKE_BUILDTYPE_FILE = $(BUILDDIR)/cmake_last_build_type
+
+.PHONY: stub cmake_smartbuild release debug nopch clear all install uninstall pluginenv installheaders man asan format-check format-fix test
 
 stub:
 	@echo "Do not run $(MAKE) directly without any arguments. Please refer to the wiki on how to compile Hyprland."
@@ -9,9 +12,9 @@ stub:
 cmake_smartbuild:
 	read lastbuild < $(CMAKE_BUILDTYPE_FILE) && test "$$lastbuild" = "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" || { \
 		echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > $(CMAKE_BUILDTYPE_FILE); \
-		cmake -Wno-unused-cli $(CMAKE_ARGS) -S . -B ./build; \
+		cmake -Wno-unused-cli $(CMAKE_ARGS) -S . -B $(BUILDDIR); \
 	}
-	cmake --build ./build --config $(CMAKE_BUILD_TYPE) --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+	cmake --build $(BUILDDIR) --config $(CMAKE_BUILD_TYPE) --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 release: cmake_smartbuild
 
@@ -32,10 +35,10 @@ all:
 	$(MAKE) release
 
 install: cmake_smartbuild
-	cmake --install ./build
+	cmake --install $(BUILDDIR)
 
 uninstall:
-	xargs rm < ./build/install_manifest.txt
+	xargs rm < $(BUILDDIR)/install_manifest.txt
 
 pluginenv:
 	@echo -en "$(MAKE) pluginenv has been deprecated.\nPlease run $(MAKE) all && sudo $(MAKE) installheaders\n"
@@ -50,12 +53,12 @@ installheaders: cmake_smartbuild
 	mkdir -p ${PREFIX}/include/hyprland/protocols
 	mkdir -p ${PREFIX}/share/pkgconfig
 
-	cmake --build ./build --config $(CMAKE_BUILD_TYPE) --target generate-protocol-headers
+	cmake --build $(BUILDDIR) --config $(CMAKE_BUILD_TYPE) --target generate-protocol-headers
 
 	find src -type f \( -name '*.hpp' -o -name '*.h' -o -name '*.inc' \) -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
 	cp ./protocols/*.h* ${PREFIX}/include/hyprland/protocols
-	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
-	if [ -d /usr/share/pkgconfig ]; then cp ./build/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
+	cp $(BUILDDIR)/hyprland.pc ${PREFIX}/share/pkgconfig
+	if [ -d /usr/share/pkgconfig ]; then cp $(BUILDDIR)/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
 
 	chmod -R 755 ${PREFIX}/include/hyprland
 	chmod 755 ${PREFIX}/share/pkgconfig
@@ -80,8 +83,7 @@ man:
 asan: CMAKE_BUILD_TYPE := Debug
 asan: cmake_smartbuild
 	@echo -en "!!WARNING!!\nOnly run this in the TTY.\n"
-	@pidof Hyprland > /dev/null && echo -ne "Refusing to run with Hyprland running.\n" || echo ""
-	@pidof Hyprland > /dev/null && exit 1 || echo ""
+	@if pidof Hyprland > /dev/null; then echo -ne "Refusing to run with Hyprland running.\n"; exit 1; fi
 
 	rm -rf ./wayland
 	#git reset --hard
@@ -96,11 +98,11 @@ asan: cmake_smartbuild
 	@echo "Wayland done"
 
 	patch -p1 < ./scripts/hyprlandStaticAsan.diff
-	cmake -Wno-unused-cli $(CMAKE_ARGS) -DWITH_ASAN:STRING=True -DUSE_TRACY:STRING=False -DUSE_TRACY_GPU:STRING=False -S . -B ./build
-	cmake --build ./build --config $(CMAKE_BUILD_TYPE) --target all
+	cmake -Wno-unused-cli $(CMAKE_ARGS) -DWITH_ASAN:STRING=True -DUSE_TRACY:STRING=False -DUSE_TRACY_GPU:STRING=False -S . -B $(BUILDDIR)
+	cmake --build $(BUILDDIR) --config $(CMAKE_BUILD_TYPE) --target all
 	@echo "Hyprland done"
 
-	ASAN_OPTIONS="detect_odr_violation=0,log_path=asan.log" HYPRLAND_NO_CRASHREPORTER=1 ./build/Hyprland -c ~/.config/hypr/hyprland.lua
+	ASAN_OPTIONS="detect_odr_violation=0,log_path=asan.log" HYPRLAND_NO_CRASHREPORTER=1 $(BUILDDIR)/Hyprland -c ~/.config/hypr/hyprland.lua
 
 format-check:
 	@find src hyprctl hyprpm start tests hyprtester -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
@@ -117,4 +119,4 @@ format-fix:
 		| xargs clang-format -i
 
 test: debug
-	./build/hyprtester/hyprtester -c hyprtester/test.lua -b ./build/Hyprland -p hyprtester/plugin/hyprtestplugin.so $(TESTS)
+	$(BUILDDIR)/hyprtester/hyprtester -c hyprtester/test.lua -b $(BUILDDIR)/Hyprland -p hyprtester/plugin/hyprtestplugin.so $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ stub:
 
 # Regenerate when CMakeLists have changed
 $(CMAKE_BUILDTYPE_FILE): $(shell find -type f -name CMakeLists.txt -not -path '*/_deps/*')
-	if [ ! -d "$(BUILDDIR)" ]; then mkdir "$(BUILDDIR)"; fi
+	mkdir -p "$(BUILDDIR)"
 	echo "$(CMAKE_BUILD_TYPE)+$(CMAKE_ARGS)" > "$(CMAKE_BUILDTYPE_FILE)"
 	$(CMAKE_GENERATE_CMD)
 

--- a/hyprctl/CMakeLists.txt
+++ b/hyprctl/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
 
 pkg_check_modules(hyprctl_deps REQUIRED IMPORTED_TARGET hyprutils>=0.2.4 hyprwire re2 readline)
 
-file(GLOB_RECURSE HYPRCTL_SRCFILES CONFIGURE_DEPENDS "src/*.cpp" "hw-protocols/*.cpp" "include/*.hpp")
+file(GLOB_RECURSE HYPRCTL_SRCFILES CONFIGURE_DEPENDS "src/*.cpp" "include/*.hpp")
 
 add_executable(hyprctl ${HYPRCTL_SRCFILES})
 set_target_properties(hyprctl PROPERTIES CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The Makefile now does semi-intelligent saving and checking of the options used during CMake's generation phase, so it only regenerates when options have actually changed. Previously, it'd regenerate no matter what, which took some extra time and led to unnecessary recompilation during the build phase.

Also cleaned up some minor stuff, mainly using a customizable `$(BUILDDIR)` rather than hard-coding `./build` everywhere.

Thanks @Aqa-Ib for pointing out that this was building extra stuff compared to VSCode/raw CMake!

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not really. Should just result in cleaner compiles via `make debug`/`make release`/etc.

#### Is it ready for merging, or does it need work?

Should be ready, but testing is appreciated since this would be a pretty bad thing to break