### PR TITLE
config/events: add config.unload event

### DIFF
--- a/hyprtester/src/tests/main/lua_config.cpp
+++ b/hyprtester/src/tests/main/lua_config.cpp
@@ -44,10 +44,11 @@ TEST_CASE(luaSpecialWorkspaceDeactivationEventNil) {
 }
 
 TEST_CASE(luaEventConfigUnload) {
-    std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt");
+    std::error_code ec;
+    std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt", ec);
     OK(getFromSocket("/eval luaEventConfigUnload = 'luaEventConfigUnload'; hl.on('config.unload', function() os.execute('echo -n '..tostring(luaEventConfigUnload)..' > "
                      "/tmp/hyprtester-luaEventConfigUnload.txt') end)"));
     OK(getFromSocket("/reload"));
     EXPECT(Hyprutils::File::readFileAsString("/tmp/hyprtester-luaEventConfigUnload.txt").value_or("error"), "luaEventConfigUnload");
-    std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt");
+    std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt", ec);
 }

--- a/hyprtester/src/tests/main/lua_config.cpp
+++ b/hyprtester/src/tests/main/lua_config.cpp
@@ -3,6 +3,7 @@
 #include "../../hyprctlCompat.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
+#include <hyprutils/os/File.hpp>
 
 using namespace Hyprutils::Utils;
 
@@ -39,4 +40,12 @@ TEST_CASE(luaSpecialWorkspaceDeactivationEventNil) {
     ASSERT(getFromSocket("/repl _G.hyprtester_special_active_event_count"), "2");
     ASSERT(getFromSocket("/repl _G.hyprtester_special_active_workspace_type"), "nil");
     ASSERT(getFromSocket("/repl _G.hyprtester_special_active_monitor_type"), "userdata");
+}
+
+TEST_CASE(luaEventConfigUnload) {
+    OK(getFromSocket("/eval luaEventConfigUnload = 'luaEventConfigUnload'; hl.on('config.unload', function() os.execute('echo -n '..tostring(luaEventConfigUnload)..' > "
+                     "/tmp/hyprtester-luaEventConfigUnload.txt') end)"));
+    OK(getFromSocket("/reload"));
+    EXPECT(Hyprutils::File::readFileAsString("/tmp/hyprtester-luaEventConfigUnload.txt").value_or("error"), "luaEventConfigUnload");
+    std::remove("/tmp/hyprtester-luaEventConfigUnload.txt");
 }

--- a/hyprtester/src/tests/main/lua_config.cpp
+++ b/hyprtester/src/tests/main/lua_config.cpp
@@ -2,6 +2,7 @@
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
 
+#include <filesystem>
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <hyprutils/os/File.hpp>
 
@@ -43,9 +44,10 @@ TEST_CASE(luaSpecialWorkspaceDeactivationEventNil) {
 }
 
 TEST_CASE(luaEventConfigUnload) {
+    std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt");
     OK(getFromSocket("/eval luaEventConfigUnload = 'luaEventConfigUnload'; hl.on('config.unload', function() os.execute('echo -n '..tostring(luaEventConfigUnload)..' > "
                      "/tmp/hyprtester-luaEventConfigUnload.txt') end)"));
     OK(getFromSocket("/reload"));
     EXPECT(Hyprutils::File::readFileAsString("/tmp/hyprtester-luaEventConfigUnload.txt").value_or("error"), "luaEventConfigUnload");
-    std::remove("/tmp/hyprtester-luaEventConfigUnload.txt");
+    std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt");
 }

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -151,6 +151,7 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
     }));
 
     m_listeners.push_back(bus()->m_events.config.reloaded.listen([this] { dispatch("config.reloaded", 0, [](lua_State* L) {}); }));
+    m_listeners.push_back(bus()->m_events.config.preReload.listen([this] { dispatch("config.unload", 0, [](lua_State* L) {}); }));
     m_listeners.push_back(bus()->m_events.config.props_refreshed.listen(
         [this](const bool execdAsScheduled) { dispatch("config.props_refreshed", 1, [&](lua_State* L) { lua_pushboolean(L, sc<lua_Integer>(execdAsScheduled)); }); }));
 
@@ -165,7 +166,10 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
     }));
 
     m_listeners.push_back(bus()->m_events.start.listen([this]() { dispatch("hyprland.start", 0, [](lua_State* L) {}); }));
-    m_listeners.push_back(bus()->m_events.exit.listen([this]() { dispatch("hyprland.shutdown", 0, [](lua_State* L) {}); }));
+    m_listeners.push_back(bus()->m_events.exit.listen([this]() {
+        dispatch("config.unload", 0, [](lua_State* L) {});
+        dispatch("hyprland.shutdown", 0, [](lua_State* L) {});
+    }));
 
     m_listeners.push_back(bus()->m_events.pluginEventAdded.listen([this](SP<Event::CEventBus::CCustomEvent> event) {
         auto ret = addCustomEvent(event);
@@ -294,6 +298,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "workspace.move_to_monitor",
         "config.reloaded",
         "config.props_refreshed",
+        "config.unload",
         "keybinds.submap",
         "screenshare.state",
         "hyprland.start",


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a Lua config.unload event that fires just before reloading (or shutdown), needed for advanced things like closing file handles and sockets before they are probably just lost and leaked, but also if user wants to save current lua state somehow.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

There were traces of this thing already in the event bus but it didn't actually do anything, now it does.

#### Is it ready for merging, or does it need work?

Ready. https://github.com/hyprwm/hyprland-wiki/pull/1638

