### PR TITLE
dnd: accumulate drag icon offset instead of overwriting it

### DIFF
--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -577,9 +577,17 @@ void CWLDataDeviceProtocol::initiateDrag(WP<CWLDataSourceResource> currentSource
     m_dnd.currentSource = currentSource;
     m_dnd.originSurface = origin;
     m_dnd.dndSurface    = dragSurface;
+    m_dnd.iconOffset    = {};
     if (dragSurface) {
         m_dnd.dndSurfaceDestroy = dragSurface->m_events.destroy.listen([this] { abortDrag(); });
         m_dnd.dndSurfaceCommit  = dragSurface->m_events.commit.listen([this] {
+            // wl_surface.offset (and the dx,dy of wl_surface.attach) move the icon
+            // relative to where it already is. Accumulate, don't overwrite: a client
+            // that sets a hotspot once and then keeps drawing frames with a (0, 0)
+            // delta must keep that hotspot.
+            if (m_dnd.dndSurface->m_current.updated.bits.offset)
+                m_dnd.iconOffset += m_dnd.dndSurface->m_current.offset;
+
             if (m_dnd.dndSurface->m_current.texture && !m_dnd.dndSurface->m_mapped) {
                 m_dnd.dndSurface->map();
                 return;
@@ -714,6 +722,7 @@ void CWLDataDeviceProtocol::updateDrag() {
 
 void CWLDataDeviceProtocol::cleanupDndState(bool resetDevice, bool resetSource, bool simulateInput) {
     m_dnd.dndSurface.reset();
+    m_dnd.iconOffset = {};
     m_dnd.dndSurfaceCommit.reset();
     m_dnd.dndSurfaceDestroy.reset();
     m_dnd.mouseButton.reset();
@@ -834,7 +843,7 @@ void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, const Time::steady_tp
 
     Vector2D   surfacePos = POS;
 
-    surfacePos += m_dnd.dndSurface->m_current.offset;
+    surfacePos += m_dnd.iconOffset;
 
     CBox                         box = CBox{surfacePos, m_dnd.dndSurface->m_current.size}.translate(-pMonitor->m_position).scale(pMonitor->m_scale).round();
 

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -174,6 +174,10 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
         WP<CWLSurfaceResource>  dndSurface;
         WP<CWLSurfaceResource>  originSurface;
         std::optional<Vector2D> touchPos;
+        // Accumulated wl_surface.offset / wl_surface.attach dx,dy of the drag icon.
+        // Per spec these are deltas relative to the icon's current position, so they
+        // must be summed across commits rather than treated as an absolute offset.
+        Vector2D                iconOffset;
         bool                    overriddenCursor = false;
         CHyprSignalListener     dndSurfaceDestroy;
         CHyprSignalListener     dndSurfaceCommit;


### PR DESCRIPTION
### Describe your PR, what does it fix/add?

`wl_surface.offset` (and the `dx,dy` of `wl_surface.attach`) move a surface **relative** to
its current position. For a drag icon they therefore have to be accumulated across commits.

`renderDND` used `m_current.offset` directly, which holds only the latest commit's delta:

```cpp
surfacePos += m_dnd.dndSurface->m_current.offset;
```

and `setAttach` overwrites that value on every attach:

```cpp
m_pending.updated.bits.offset = true;
m_pending.offset = {x, y};
```

So a client that sets a hotspot once and then draws any further frame with a `(0, 0)`
delta — which means "stay put" — had its hotspot replaced with zero, and the icon snapped
to top-left-at-cursor for the rest of the drag. Chromium does exactly this, 3 ms after
`start_drag`:

```
wl_data_device#6.start_drag(wl_data_source#78, wl_surface#36, wl_surface#80, 5578)
wl_surface#80.attach(wl_buffer#91, -197, -134)   <- hotspot
wl_surface#80.commit()
wl_surface#80.attach(wl_buffer#93, 0, 0)         <- 3ms later, zero delta
wl_surface#80.commit()
      ... 20+ further attach(<buf>, 0, 0) + commit() for the rest of the drag
```

This is the remaining half of #9892 / #9895: that PR made the offset apply at all, but it
applies only the latest delta rather than the running sum.

Fix: accumulate into `m_dnd.iconOffset`, guarded on `updated.bits.offset` so commits that
carry no attach/offset are not double-counted (`m_current.offset` persists across commits),
and reset it in `initiateDrag` and `cleanupDndState`.

Discussion with full trace and measurements: https://github.com/hyprwm/Hyprland/discussions/16007

### Is it ready for merging, or does it need work?

Ready for review.

Built on v0.56.2 (patch applies unchanged to `main`) and verified by measurement rather
than by eye: Chromium ran under `WAYLAND_DEBUG=1` inside a nested session so the requested
hotspot was known exactly, while `hyprctl cursorpos` and `grim` were sampled together
during the drag. Expected icon top-left `cursor - (195, 133)`:

| frame | cursor | predicted TL | measured TL | error |
|---|---|---|---|---|
| 3 | (1265,905) | (1070,772) | (1072,773) | +2,+1 |
| 4 | (1267,905) | (1072,772) | (1073,773) | +1,+1 |
| 5 | (1267,905) | (1072,772) | (1073,773) | +1,+1 |
| 6 | (1267,905) | (1072,772) | (1073,773) | +1,+1 |

On the static-cursor frames the bottom-right corner lands on the predicted pixel exactly;
the +1 on top-left is the measurement's colour threshold dropping the antialiased outer
row of the marker. Unpatched, the top-left renders at the cursor itself.

Two limits worth knowing: this was measured at **monitor scale 1** (on a fractionally
scaled output `.scale(...).round()` still quantises to whole device pixels), and with one
client. GTK4/Nautilus sends an explicit `wl_surface.offset(0, 0)` and never exercises this
path, so it looks identical there for an unrelated reason.
