### PR TITLE
keybinds: Per-device submaps

### DIFF
--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -789,6 +789,41 @@ SUBTEST(perDeviceKeybind) {
     EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
+SUBTEST(perDeviceSubmap) {
+    NLog::log("{}Testing per-device submaps", Colors::GREEN);
+
+    const auto press = [this](const uint32_t key, const uint32_t mod = 0) {
+        // +8 because udev -> XKB keycode.
+        OK(getFromSocket(pluginKeybindCmd(true, mod, key + 8)));
+        OK(getFromSocket(pluginKeybindCmd(false, mod, key + 8)));
+    };
+
+    NLog::log("{}Testing per-device submaps - Matching device name", Colors::MAGENTA);
+
+    OK(getFromSocket("/eval hl.bind('SUPER + y', hl.dsp.submap('keyboard-submap'))"));
+    press(KEY_Y, MOD_META);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "keyboard-submap");
+    press(KEY_P);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "default");
+    OK(getFromSocket("/eval hl.unbind('SUPER + y')"));
+
+    NLog::log("{}Testing per-device submaps - Matching device tag", Colors::MAGENTA);
+
+    OK(getFromSocket("/eval hl.bind('SUPER + y', hl.dsp.submap('tag-submap'))"));
+    press(KEY_Y, MOD_META);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "tag-submap");
+    press(KEY_P);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "default");
+    OK(getFromSocket("/eval hl.unbind('SUPER + y')"));
+
+    NLog::log("{}Testing per-device submaps - Non-matching device tag", Colors::MAGENTA);
+
+    OK(getFromSocket("/eval hl.bind('SUPER + y', hl.dsp.submap('hidden-tag-submap'))"));
+    press(KEY_Y, MOD_META);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "default");
+    OK(getFromSocket("/eval hl.unbind('SUPER + y')"));
+}
+
 SUBTEST(unbind) {
     NLog::log("{}Testing unbind behavior", Colors::GREEN);
 
@@ -824,6 +859,7 @@ TEST_CASE(keybinds) {
     CALL_SUBTEST(shortcutRepeat);
     CALL_SUBTEST(shortcutRepeatKeyRelease);
     CALL_SUBTEST(submap);
+    CALL_SUBTEST(perDeviceSubmap);
     CALL_SUBTEST(submapMouseBinds);
     CALL_SUBTEST(submapUniversal);
     CALL_SUBTEST(bindsAfterScroll);

--- a/hyprtester/test.lua
+++ b/hyprtester/test.lua
@@ -215,6 +215,10 @@ hl.bind("XF86AudioPause", hl.dsp.exec_cmd("playerctl play-pause"), { locked = tr
 hl.bind("XF86AudioPlay", hl.dsp.exec_cmd("playerctl play-pause"), { locked = true })
 hl.bind("XF86AudioPrev", hl.dsp.exec_cmd("playerctl previous"), { locked = true })
 
+local keyboard_device = { inclusive = true, list = { "test-keyboard-1" } }
+local available_device_tag = { inclusive = true, list = { "test-tag" } }
+local hidden_device_tag = { inclusive = true, list = { "hidden-tag" } }
+
 hl.bind(mainMod .. " + u", hl.dsp.submap("submap1"))
 
 hl.define_submap("submap1", function()
@@ -234,6 +238,18 @@ end)
 hl.define_submap("submap3", "reset", function()
     hl.bind("o", hl.dsp.exec_cmd(terminal))
 end)
+
+hl.define_submap("keyboard-submap", function()
+    hl.bind("p", hl.dsp.submap("reset"))
+end, { device = keyboard_device })
+
+hl.define_submap("tag-submap", function()
+    hl.bind("p", hl.dsp.submap("reset"))
+end, { device = available_device_tag })
+
+hl.define_submap("hidden-tag-submap", function()
+    hl.bind("p", hl.dsp.submap("reset"))
+end, { device = hidden_device_tag })
 
 hl.window_rule({
     name = "suppress-maximize-events",

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -209,24 +209,15 @@ static int hlBind(lua_State* L) {
         flags |= drag ? Keybinds::BIND_FLAG_DRAG : 0;
 
         lua_getfield(L, optsIdx, "device");
-        if (lua_istable(L, -1)) {
-            lua_getfield(L, -1, "inclusive");
-            const bool INCLUSIVE = lua_isnil(L, -1) ? true : lua_toboolean(L, -1);
-            flags |= INCLUSIVE ? Keybinds::BIND_FLAG_DEVICE_INCLUSIVE : 0;
-            lua_pop(L, 1);
 
-            lua_getfield(L, -1, "list");
-            if (lua_istable(L, -1)) {
-                lua_pushnil(L);
-                while (lua_next(L, -2)) {
-                    if (lua_isstring(L, -1))
-                        args.devices.emplace(lua_tostring(L, -1));
-                    lua_pop(L, 1);
-                }
-            }
-            lua_pop(L, 1);
-        }
+        auto devices = parseDeviceList(L, -1);
+        if (!devices)
+            return Internal::configError(L, std::format("hl.bind: {}", devices.error()));
+
+        args.devices = std::move(*devices);
+        flags |= args.devices.inclusive() ? Keybinds::BIND_FLAG_DEVICE_INCLUSIVE : 0;
         flags |= getBool("allow_input_capture") ? Keybinds::BIND_FLAG_ALLOW_INPUT_CAPTURE : 0;
+
         lua_pop(L, 1);
     }
 

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -48,6 +48,28 @@ static std::expected<std::vector<std::string>, std::string> parseKeyString(std::
     return keys;
 }
 
+static std::expected<Keybinds::CDeviceList, std::string> parseDeviceList(lua_State* L, int idx) {
+    bool                 inclusive = false;
+    Keybinds::DeviceList devices;
+
+    if (lua_istable(L, idx)) {
+        lua_getfield(L, idx, "inclusive");
+        inclusive = lua_isnil(L, -1) || lua_toboolean(L, -1);
+        lua_pop(L, 1);
+
+        lua_getfield(L, idx, "list");
+        lua_pushnil(L);
+        while (lua_next(L, -2)) {
+            if (auto device_name = Check::string(L, -1); device_name)
+                devices.emplace(*device_name);
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+    }
+
+    return Keybinds::CDeviceList(inclusive, std::move(devices));
+}
+
 class CLuaBindRef {
   public:
     CLuaBindRef(SP<SLuaStateLifetime> lifetime, int ref) : m_lifetime(std::move(lifetime)), m_ref(ref) {
@@ -256,23 +278,12 @@ static int hlDefineSubmap(lua_State* L) {
             return Internal::configError(L, "define_submap: last argument must be a table");
 
         lua_getfield(L, optsIdx, "device");
-
-        if (lua_istable(L, -1)) {
-            lua_getfield(L, -1, "inclusive");
-            args.device.setInclusive(lua_isnil(L, -1) || lua_toboolean(L, -1));
-            lua_pop(L, 1);
-
-            lua_getfield(L, -1, "list");
-            lua_pushnil(L);
-            while (lua_next(L, -2)) {
-                if (auto device_name = Check::string(L, -1); device_name)
-                    args.device.add(*device_name);
-                lua_pop(L, 1);
-            }
-            lua_pop(L, 1);
-        }
-
+        auto device = parseDeviceList(L, -1);
+        if (!device)
+            return Internal::configError(L, std::format("define_submap: {}", device.error()));
         lua_pop(L, 1);
+
+        args.device = std::move(*device);
     }
 
     Keybinds::CSubmap submap = Keybinds::CSubmap(*name, std::move(args));

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -259,14 +259,14 @@ static int hlDefineSubmap(lua_State* L) {
 
         if (lua_istable(L, -1)) {
             lua_getfield(L, -1, "inclusive");
-            args.inclusive = lua_isnil(L, -1) || lua_toboolean(L, -1);
+            args.device.setInclusive(lua_isnil(L, -1) || lua_toboolean(L, -1));
             lua_pop(L, 1);
 
             lua_getfield(L, -1, "list");
             lua_pushnil(L);
             while (lua_next(L, -2)) {
                 if (auto device_name = Check::string(L, -1); device_name)
-                    args.devices.emplace(*device_name);
+                    args.device.add(*device_name);
                 lua_pop(L, 1);
             }
             lua_pop(L, 1);
@@ -275,7 +275,7 @@ static int hlDefineSubmap(lua_State* L) {
         lua_pop(L, 1);
     }
 
-    Keybinds::CSubmap submap = Keybinds::CSubmap(*name, args);
+    Keybinds::CSubmap submap = Keybinds::CSubmap(*name, std::move(args));
     const auto        SUBMAP = Keybinds::mgr()->addSubmap(std::move(submap));
 
     luaL_checktype(L, fnIdx, LUA_TFUNCTION);

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -258,14 +258,18 @@ static int hlDefineSubmap(lua_State* L) {
         lua_getfield(L, optsIdx, "device");
 
         if (lua_istable(L, -1)) {
-            // Let's start with something simple for now...
-            lua_pushnil(L);
+            lua_getfield(L, -1, "inclusive");
+            args.inclusive = lua_isnil(L, -1) || lua_toboolean(L, -1);
+            lua_pop(L, 1);
 
+            lua_getfield(L, -1, "list");
+            lua_pushnil(L);
             while (lua_next(L, -2)) {
                 if (auto device_name = Check::string(L, -1); device_name)
                     args.devices.emplace(*device_name);
                 lua_pop(L, 1);
             }
+            lua_pop(L, 1);
         }
 
         lua_pop(L, 1);

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -13,6 +13,7 @@
 #include "../../../plugins/PluginSystem.hpp"
 #include "keybinds/Manager.hpp"
 #include "keybinds/Resolver.hpp"
+#include "keybinds/Submap.hpp"
 
 #include <hyprutils/string/Numeric.hpp>
 #include <hyprutils/string/String.hpp>
@@ -247,11 +248,37 @@ static int hlDefineSubmap(lua_State* L) {
         fnIdx = 3;
     }
 
+    const int             optsIdx = fnIdx + 1;
+    Keybinds::SSubmapArgs args;
+
+    if (lua_gettop(L) >= optsIdx) {
+        if (!lua_istable(L, optsIdx))
+            return Internal::configError(L, "define_submap: last argument must be a table");
+
+        lua_getfield(L, optsIdx, "device");
+
+        if (lua_istable(L, -1)) {
+            // Let's start with something simple for now...
+            lua_pushnil(L);
+
+            while (lua_next(L, -2)) {
+                if (auto device_name = Check::string(L, -1); device_name)
+                    args.devices.emplace(*device_name);
+                lua_pop(L, 1);
+            }
+        }
+
+        lua_pop(L, 1);
+    }
+
+    Keybinds::CSubmap submap = Keybinds::CSubmap(*name, args);
+    const auto        SUBMAP = Keybinds::mgr()->addSubmap(std::move(submap));
+
     luaL_checktype(L, fnIdx, LUA_TFUNCTION);
 
     std::string prev          = mgr->m_currentSubmap;
     std::string prevReset     = mgr->m_currentSubmapReset;
-    mgr->m_currentSubmap      = *name;
+    mgr->m_currentSubmap      = SUBMAP->name();
     mgr->m_currentSubmapReset = reset;
 
     lua_pushvalue(L, fnIdx);

--- a/src/config/lua/objects/LuaKeybind.cpp
+++ b/src/config/lua/objects/LuaKeybind.cpp
@@ -14,7 +14,7 @@ static Keybinds::PBind       getKeybindFromUserdata(lua_State* L) {
 static void pushDeviceList(lua_State* L, const Keybinds::CBind& keybind) {
     lua_newtable(L);
     int i = 1;
-    for (const auto& device : keybind.devices()) {
+    for (const auto& device : keybind.devices().devices()) {
         lua_pushstring(L, device.c_str());
         lua_rawseti(L, -2, i++);
     }

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1692,10 +1692,16 @@ ActionResult Actions::setSubmap(const std::string& submap) {
         return {};
     }
 
-    if (Keybinds::mgr()->registry().hasSubmap(submap)) {
+    const auto device = Config::Actions::state()->m_lastDevice;
+
+    if (Keybinds::mgr()->registry().findSubmap(submap, device)) {
         Config::Actions::state()->m_currentSubmap = submap;
         IPC::Socket2::sock()->postEvent({.event = "submap", .data = submap});
         Event::bus()->m_events.keybinds.submap.emit(submap);
+        return {};
+    }
+
+    if (Keybinds::mgr()->registry().hasSubmap(submap)) {
         return {};
     }
 

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -120,7 +120,7 @@ namespace Config::Actions {
         uint32_t    m_lastMouseCode       = 0;  // last mouse button code, 0 if last was keyboard
         uint32_t    m_timeLastMs          = 0;  // timestamp of last key/mouse event
         std::string m_currentSubmap       = ""; // current keybind submap name
-        SP<IHID>    m_lastDevice;               // device used to press last keycode
+        WP<IHID>    m_lastDevice;               // device used to press last keycode
     };
 
     UP<CActionState>& state();

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -120,7 +120,7 @@ namespace Config::Actions {
         uint32_t    m_lastMouseCode       = 0;  // last mouse button code, 0 if last was keyboard
         uint32_t    m_timeLastMs          = 0;  // timestamp of last key/mouse event
         std::string m_currentSubmap       = ""; // current keybind submap name
-        WP<IHID>    m_lastDevice;               // device used to press last keycode
+        SP<IHID>    m_lastDevice;               // device used to press last keycode
     };
 
     UP<CActionState>& state();

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -6,6 +6,7 @@
 
 #include "../../../desktop/DesktopTypes.hpp"
 #include "../../../desktop/Workspace.hpp"
+#include "../../../devices/IHID.hpp"
 #include "../../../input/Keys.hpp"
 #include "../../../helpers/math/Direction.hpp"
 #include "../ConfigErrors.hpp"
@@ -119,6 +120,7 @@ namespace Config::Actions {
         uint32_t    m_lastMouseCode       = 0;  // last mouse button code, 0 if last was keyboard
         uint32_t    m_timeLastMs          = 0;  // timestamp of last key/mouse event
         std::string m_currentSubmap       = ""; // current keybind submap name
+        WP<IHID>    m_lastDevice;               // device used to press last keycode
     };
 
     UP<CActionState>& state();

--- a/src/keybinds/Bind.cpp
+++ b/src/keybinds/Bind.cpp
@@ -79,6 +79,8 @@ static eBindMatch matchKeySets(const std::vector<const CKey*>& bound, const std:
 
 // NOLINTNEXTLINE SHUT THE FUCK UP CLANG TIDY
 std::expected<CBind, std::string> CBind::make(std::vector<std::string>&& keys, BindFlags flags, BindCallback&& callback, SExtraBindArgs&& args) {
+    flags |= args.devices.inclusive() ? Keybinds::BIND_FLAG_DEVICE_INCLUSIVE : 0;
+
     CBind ret;
     ret.m_devices  = std::move(args.devices);
     ret.m_metadata = std::move(args.metadata);
@@ -139,11 +141,7 @@ std::expected<CBind, std::string> CBind::make(std::vector<std::string>&& keys, B
 }
 
 bool CBind::matchesDevice(SP<IHID> dev) const {
-    if (!dev)
-        return !(m_flags & BIND_FLAG_DEVICE_INCLUSIVE);
-
-    const bool LISTED = m_devices.contains(dev->m_hlName) || std::ranges::any_of(dev->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
-    return (m_flags & BIND_FLAG_DEVICE_INCLUSIVE) ? LISTED : !LISTED;
+    return m_devices.contains(dev);
 }
 
 eBindMatch CBind::matches(const SBindEventContext& ctx) const {
@@ -352,7 +350,7 @@ std::span<const std::string> CBind::keyNames() const {
     return m_keyNames;
 }
 
-const std::unordered_set<std::string>& CBind::devices() const {
+const CDeviceList& CBind::devices() const {
     return m_devices;
 }
 

--- a/src/keybinds/Bind.hpp
+++ b/src/keybinds/Bind.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <optional>
 
+#include "DeviceList.hpp"
 #include "Key.hpp"
 
 #include "../devices/IHID.hpp"
@@ -29,6 +30,11 @@ namespace Keybinds {
         BIND_FLAG_DRAG                = (1 << 10),
         BIND_FLAG_SUBMAP_UNIVERSAL    = (1 << 11),
         BIND_FLAG_ALLOW_INPUT_CAPTURE = (1 << 12),
+        // NOTE: inclusive device list metadata handling has been moved to the
+        //       dedicated Keybinds::CDeviceList class that now composes Bind's
+        //       m_devices attribute. let's keep the flag around for now to not
+        //       introduce breaking changes just yet, but we might consider
+        //       removing it eventually
         BIND_FLAG_DEVICE_INCLUSIVE    = (1 << 13),
         BIND_FLAG_CATCH_ALL           = (1 << 14),
         BIND_FLAG_MOUSE               = (1 << 15),
@@ -46,8 +52,8 @@ namespace Keybinds {
     };
 
     struct SExtraBindArgs {
-        std::unordered_set<std::string> devices;
-        SBindMetadata                   metadata;
+        CDeviceList   devices;
+        SBindMetadata metadata;
     };
 
     enum eBindFollowUp : uint8_t {
@@ -84,41 +90,41 @@ namespace Keybinds {
       public:
         static std::expected<CBind, std::string> make(std::vector<std::string>&& keys, BindFlags flags, BindCallback&& callback, SExtraBindArgs&& args = {});
 
-        CBind(CBind&&) noexcept                                        = default;
-        CBind& operator=(CBind&&) noexcept                             = default;
-        CBind(const CBind&)                                            = delete;
-        CBind&                                 operator=(const CBind&) = delete;
+        CBind(CBind&&) noexcept                              = default;
+        CBind& operator=(CBind&&) noexcept                   = default;
+        CBind(const CBind&)                                  = delete;
+        CBind&                       operator=(const CBind&) = delete;
 
-        eBindMatch                             matches(const SBindEventContext& ctx = {}) const;
-        bool                                   matchesContext(const SBindEventContext& ctx) const;
-        SBindResult                            invoke() const;
-        bool                                   enabled() const;
-        void                                   setEnabled(bool x);
-        bool                                   hasFlag(eBindFlags flag) const;
-        BindFlags                              flags() const;
-        Input::ModifierMask                    modifierMask() const;
-        size_t                                 chordSize() const;
-        bool                                   containsKey(const SResolvedKey& key) const;
-        bool                                   isFullyHeld(const SBindEventContext& ctx) const;
-        bool                                   isSubChordOf(const CBind& other, const SBindEventContext& ctx) const;
-        bool                                   isOrderedPrefixOf(const CBind& other, const SBindEventContext& ctx) const;
-        std::span<const CKey>                  keys() const;
-        std::span<const std::string>           keyNames() const;
-        const std::unordered_set<std::string>& devices() const;
-        const SBindMetadata&                   metadata() const;
+        eBindMatch                   matches(const SBindEventContext& ctx = {}) const;
+        bool                         matchesContext(const SBindEventContext& ctx) const;
+        SBindResult                  invoke() const;
+        bool                         enabled() const;
+        void                         setEnabled(bool x);
+        bool                         hasFlag(eBindFlags flag) const;
+        BindFlags                    flags() const;
+        Input::ModifierMask          modifierMask() const;
+        size_t                       chordSize() const;
+        bool                         containsKey(const SResolvedKey& key) const;
+        bool                         isFullyHeld(const SBindEventContext& ctx) const;
+        bool                         isSubChordOf(const CBind& other, const SBindEventContext& ctx) const;
+        bool                         isOrderedPrefixOf(const CBind& other, const SBindEventContext& ctx) const;
+        std::span<const CKey>        keys() const;
+        std::span<const std::string> keyNames() const;
+        const CDeviceList&           devices() const;
+        const SBindMetadata&         metadata() const;
 
       private:
         CBind() = default;
 
-        bool                            matchesDevice(SP<IHID> dev) const;
+        bool                     matchesDevice(SP<IHID> dev) const;
 
-        BindCallback                    m_callback;
-        BindFlags                       m_flags   = 0;
-        Input::ModifierMask             m_modmask = Input::HL_MODIFIER_NONE;
-        std::vector<CKey>               m_keys;
-        std::vector<std::string>        m_keyNames;
-        std::unordered_set<std::string> m_devices;
-        SBindMetadata                   m_metadata;
-        bool                            m_enabled = true;
+        BindCallback             m_callback;
+        BindFlags                m_flags   = 0;
+        Input::ModifierMask      m_modmask = Input::HL_MODIFIER_NONE;
+        std::vector<CKey>        m_keys;
+        std::vector<std::string> m_keyNames;
+        CDeviceList              m_devices;
+        SBindMetadata            m_metadata;
+        bool                     m_enabled = true;
     };
 };

--- a/src/keybinds/DeviceList.cpp
+++ b/src/keybinds/DeviceList.cpp
@@ -25,3 +25,12 @@ bool CDeviceList::contains(const std::string& device) const {
 
     return LISTED == m_inclusive;
 };
+
+bool CDeviceList::contains(WP<IHID> device) const {
+    if (!device)
+        return !m_inclusive;
+
+    const bool LISTED = m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
+
+    return LISTED == m_inclusive;
+}

--- a/src/keybinds/DeviceList.cpp
+++ b/src/keybinds/DeviceList.cpp
@@ -1,0 +1,27 @@
+#include "DeviceList.hpp"
+
+using namespace Keybinds;
+
+CDeviceList::CDeviceList(bool inclusive, DeviceList&& devices) : m_inclusive(inclusive), m_devices(std::move(devices)) {};
+
+bool CDeviceList::inclusive() const {
+    return m_inclusive;
+}
+
+const DeviceList& CDeviceList::devices() const {
+    return m_devices;
+};
+
+void CDeviceList::setInclusive(bool value) {
+    m_inclusive = value;
+};
+
+void CDeviceList::add(std::string& device) {
+    m_devices.emplace(std::move(device));
+}
+
+bool CDeviceList::contains(const std::string& device) const {
+    const bool LISTED = m_devices.contains(device);
+
+    return LISTED == m_inclusive;
+};

--- a/src/keybinds/DeviceList.hpp
+++ b/src/keybinds/DeviceList.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+namespace Keybinds {
+
+    using DeviceList = std::unordered_set<std::string>;
+
+    class CDeviceList {
+      public:
+        CDeviceList(bool inclusive, DeviceList&& devices);
+        CDeviceList() = default;
+
+        CDeviceList(CDeviceList&&) noexcept             = default;
+        CDeviceList& operator=(CDeviceList&&) noexcept  = default;
+        CDeviceList(CDeviceList&)                       = delete;
+        CDeviceList&      operator=(const CDeviceList&) = delete;
+
+        void              setInclusive(bool value);
+        void              add(std::string& device);
+        bool              contains(const std::string& device) const;
+
+        bool              inclusive() const;
+        const DeviceList& devices() const;
+
+      private:
+        bool       m_inclusive = false;
+        DeviceList m_devices;
+    };
+}

--- a/src/keybinds/DeviceList.hpp
+++ b/src/keybinds/DeviceList.hpp
@@ -3,6 +3,9 @@
 #include <string>
 #include <unordered_set>
 
+#include "../devices/IHID.hpp"
+#include "../helpers/memory/Memory.hpp"
+
 namespace Keybinds {
 
     using DeviceList = std::unordered_set<std::string>;
@@ -20,6 +23,7 @@ namespace Keybinds {
         void              setInclusive(bool value);
         void              add(std::string& device);
         bool              contains(const std::string& device) const;
+        bool              contains(WP<IHID> device) const;
 
         bool              inclusive() const;
         const DeviceList& devices() const;

--- a/src/keybinds/Manager.cpp
+++ b/src/keybinds/Manager.cpp
@@ -635,7 +635,7 @@ void CKeybindManager::invokeReleaseCallbacks(std::vector<SPendingRelease>&& rele
         state.m_lastCode              = release.actionCode;
         state.m_lastMouseCode         = release.actionMouseCode;
         state.m_timeLastMs            = release.actionTimeMs;
-        state.m_lastDevice            = release.device;
+        state.m_lastDevice            = release.device.lock();
         Hyprutils::Utils::CScopeGuard guard([&state, PREVIOUS_CODE, PREVIOUS_MOUSECODE, PREVIOUS_TIME, PREVIOUS_DEVICE] {
             state.m_lastCode      = PREVIOUS_CODE;
             state.m_lastMouseCode = PREVIOUS_MOUSECODE;

--- a/src/keybinds/Manager.cpp
+++ b/src/keybinds/Manager.cpp
@@ -224,6 +224,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> keyboard) {
     Config::Actions::state()->m_timeLastMs    = KEY_EVENT.timeMs;
     Config::Actions::state()->m_lastCode      = KEYCODE;
     Config::Actions::state()->m_lastMouseCode = 0;
+    Config::Actions::state()->m_lastDevice    = keyboard;
 
     const bool DRAG_WAS_ACTIVE = g_layoutManager->endDragTarget();
     cancelTimedBinds();
@@ -354,6 +355,7 @@ bool CKeybindManager::onMouseEvent(const IPointer::SButtonEvent& event, SP<IPoin
     Config::Actions::state()->m_lastMouseCode = event.button;
     Config::Actions::state()->m_lastCode      = 0;
     Config::Actions::state()->m_timeLastMs    = event.timeMs;
+    Config::Actions::state()->m_lastDevice    = pointer;
 
     const bool DRAG_WAS_ACTIVE = captured ? false : g_layoutManager->endDragTarget();
     cancelTimedBinds();
@@ -629,13 +631,16 @@ void CKeybindManager::invokeReleaseCallbacks(std::vector<SPendingRelease>&& rele
         const auto PREVIOUS_CODE      = state.m_lastCode;
         const auto PREVIOUS_MOUSECODE = state.m_lastMouseCode;
         const auto PREVIOUS_TIME      = state.m_timeLastMs;
+        const auto PREVIOUS_DEVICE    = state.m_lastDevice;
         state.m_lastCode              = release.actionCode;
         state.m_lastMouseCode         = release.actionMouseCode;
         state.m_timeLastMs            = release.actionTimeMs;
-        Hyprutils::Utils::CScopeGuard guard([&state, PREVIOUS_CODE, PREVIOUS_MOUSECODE, PREVIOUS_TIME] {
+        state.m_lastDevice            = release.device;
+        Hyprutils::Utils::CScopeGuard guard([&state, PREVIOUS_CODE, PREVIOUS_MOUSECODE, PREVIOUS_TIME, PREVIOUS_DEVICE] {
             state.m_lastCode      = PREVIOUS_CODE;
             state.m_lastMouseCode = PREVIOUS_MOUSECODE;
             state.m_timeLastMs    = PREVIOUS_TIME;
+            state.m_lastDevice    = PREVIOUS_DEVICE;
         });
         invokeBind(release.bind, false, m_inputState.find(release.key, release.device.lock()));
     }

--- a/src/keybinds/Manager.cpp
+++ b/src/keybinds/Manager.cpp
@@ -635,7 +635,7 @@ void CKeybindManager::invokeReleaseCallbacks(std::vector<SPendingRelease>&& rele
         state.m_lastCode              = release.actionCode;
         state.m_lastMouseCode         = release.actionMouseCode;
         state.m_timeLastMs            = release.actionTimeMs;
-        state.m_lastDevice            = release.device.lock();
+        state.m_lastDevice            = release.device;
         Hyprutils::Utils::CScopeGuard guard([&state, PREVIOUS_CODE, PREVIOUS_MOUSECODE, PREVIOUS_TIME, PREVIOUS_DEVICE] {
             state.m_lastCode      = PREVIOUS_CODE;
             state.m_lastMouseCode = PREVIOUS_MOUSECODE;

--- a/src/keybinds/Manager.cpp
+++ b/src/keybinds/Manager.cpp
@@ -145,6 +145,10 @@ PBind CKeybindManager::addBind(CBind&& bind) {
     return m_registry.add(std::move(bind));
 }
 
+PSubmap CKeybindManager::addSubmap(CSubmap&& submap) {
+    return m_registry.addSubmap(std::move(submap));
+};
+
 bool CKeybindManager::removeBind(const PBind& bind) {
     cancelTimedBinds();
     invokeReleaseCallbacks(m_inputState.takeReleaseCallbacks(bind));

--- a/src/keybinds/Manager.hpp
+++ b/src/keybinds/Manager.hpp
@@ -2,6 +2,7 @@
 
 #include "InputState.hpp"
 #include "Registry.hpp"
+#include "Submap.hpp"
 
 #include "../devices/IPointer.hpp"
 #include "../helpers/time/Timer.hpp"
@@ -20,6 +21,7 @@ namespace Keybinds {
         ~CKeybindManager();
 
         PBind              addBind(CBind&& bind);
+        PSubmap            addSubmap(CSubmap&& submap);
         bool               removeBind(const PBind& bind);
         size_t             removeBinds(std::string_view displayKey);
         void               clearBinds();

--- a/src/keybinds/Registry.cpp
+++ b/src/keybinds/Registry.cpp
@@ -2,12 +2,19 @@
 
 #include <algorithm>
 #include <cctype>
+#include <span>
 
 using namespace Keybinds;
 
 PBind CRegistry::add(CBind&& bind) {
     auto result = makeShared<CBind>(std::move(bind));
     m_binds.emplace_back(result);
+    return result;
+}
+
+PSubmap CRegistry::addSubmap(CSubmap&& submap) {
+    auto result = makeShared<CSubmap>(std::move(submap));
+    m_submaps.emplace_back(result);
     return result;
 }
 
@@ -32,10 +39,15 @@ std::vector<PBind> CRegistry::findByDisplayKey(std::string_view displayKey) cons
 
 void CRegistry::clear() {
     m_binds.clear();
+    m_submaps.clear();
 }
 
 std::span<const PBind> CRegistry::binds() const {
     return m_binds;
+}
+
+std::span<const PSubmap> CRegistry::submaps() const {
+    return m_submaps;
 }
 
 bool CRegistry::contains(const PBind& bind) const {
@@ -50,8 +62,18 @@ size_t CRegistry::size() const {
     return m_binds.size();
 }
 
+// this should use the new submap vector once it proves its worth
 bool CRegistry::hasSubmap(std::string_view submap) const {
     return std::ranges::any_of(m_binds, [submap](const auto& bind) { return bind->metadata().submap == submap; });
+}
+
+std::optional<PSubmap> CRegistry::findSubmap(std::string_view submap, const SP<IHID> device) const {
+    const auto result = std::ranges::find_if(m_submaps, [submap, device](const auto& s) { return s->name() == submap && s->matchesDevice(device); });
+
+    if (result == m_submaps.end())
+        return std::nullopt;
+
+    return *result;
 }
 
 PBind CRegistry::findShortcutConflict(xkb_keysym_t keysym, Input::ModifierMask modifiers, xkb_state* xkbState) const {

--- a/src/keybinds/Registry.cpp
+++ b/src/keybinds/Registry.cpp
@@ -67,7 +67,7 @@ bool CRegistry::hasSubmap(std::string_view submap) const {
     return std::ranges::any_of(m_binds, [submap](const auto& bind) { return bind->metadata().submap == submap; });
 }
 
-std::optional<PSubmap> CRegistry::findSubmap(std::string_view submap, const SP<IHID> device) const {
+std::optional<PSubmap> CRegistry::findSubmap(std::string_view submap, const WP<IHID> device) const {
     const auto result = std::ranges::find_if(m_submaps, [submap, device](const auto& s) { return s->name() == submap && s->matchesDevice(device); });
 
     if (result == m_submaps.end())

--- a/src/keybinds/Registry.hpp
+++ b/src/keybinds/Registry.hpp
@@ -27,7 +27,7 @@ namespace Keybinds {
         bool                     empty() const;
         size_t                   size() const;
         bool                     hasSubmap(std::string_view submap) const;
-        std::optional<PSubmap>   findSubmap(std::string_view submap, const WP<IHID> device) const;
+        std::optional<PSubmap>   findSubmap(std::string_view submap, const SP<IHID> device) const;
         PBind                    findShortcutConflict(xkb_keysym_t keysym, Input::ModifierMask modifiers, xkb_state* xkbState = nullptr) const;
 
       private:

--- a/src/keybinds/Registry.hpp
+++ b/src/keybinds/Registry.hpp
@@ -27,7 +27,7 @@ namespace Keybinds {
         bool                     empty() const;
         size_t                   size() const;
         bool                     hasSubmap(std::string_view submap) const;
-        std::optional<PSubmap>   findSubmap(std::string_view submap, const SP<IHID> device) const;
+        std::optional<PSubmap>   findSubmap(std::string_view submap, const WP<IHID> device) const;
         PBind                    findShortcutConflict(xkb_keysym_t keysym, Input::ModifierMask modifiers, xkb_state* xkbState = nullptr) const;
 
       private:

--- a/src/keybinds/Registry.hpp
+++ b/src/keybinds/Registry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Bind.hpp"
+#include "Submap.hpp"
 
 #include <span>
 #include <string_view>
@@ -8,26 +9,31 @@
 
 namespace Keybinds {
 
-    using PBind = SP<CBind>;
+    using PBind   = SP<CBind>;
+    using PSubmap = SP<CSubmap>;
 
     class CRegistry {
       public:
-        PBind                  add(CBind&& bind);
-        bool                   remove(const PBind& bind);
-        size_t                 removeByDisplayKey(std::string_view displayKey);
-        std::vector<PBind>     findByDisplayKey(std::string_view displayKey) const;
-        void                   clear();
+        PBind                    add(CBind&& bind);
+        PSubmap                  addSubmap(CSubmap&& submap);
+        bool                     remove(const PBind& bind);
+        size_t                   removeByDisplayKey(std::string_view displayKey);
+        std::vector<PBind>       findByDisplayKey(std::string_view displayKey) const;
+        void                     clear();
 
-        std::span<const PBind> binds() const;
-        bool                   contains(const PBind& bind) const;
-        bool                   empty() const;
-        size_t                 size() const;
-        bool                   hasSubmap(std::string_view submap) const;
-        PBind                  findShortcutConflict(xkb_keysym_t keysym, Input::ModifierMask modifiers, xkb_state* xkbState = nullptr) const;
+        std::span<const PBind>   binds() const;
+        std::span<const PSubmap> submaps() const;
+        bool                     contains(const PBind& bind) const;
+        bool                     empty() const;
+        size_t                   size() const;
+        bool                     hasSubmap(std::string_view submap) const;
+        std::optional<PSubmap>   findSubmap(std::string_view submap, const SP<IHID> device) const;
+        PBind                    findShortcutConflict(xkb_keysym_t keysym, Input::ModifierMask modifiers, xkb_state* xkbState = nullptr) const;
 
       private:
-        static std::string normalizeDisplayKey(std::string_view displayKey);
+        static std::string   normalizeDisplayKey(std::string_view displayKey);
 
-        std::vector<PBind> m_binds;
+        std::vector<PBind>   m_binds;
+        std::vector<PSubmap> m_submaps;
     };
 }

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -13,7 +13,7 @@ const std::unordered_set<std::string>& CSubmap::devices() const {
     return m_devices;
 }
 
-bool CSubmap::matchesDevice(SP<IHID> device) {
+bool CSubmap::matchesDevice(WP<IHID> device) {
     if (m_devices.empty() || !device) {
         return true;
     }

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -17,7 +17,7 @@ const std::unordered_set<std::string>& CSubmap::devices() const {
     return m_devices;
 }
 
-bool CSubmap::matchesDevice(SP<IHID> device) const {
+bool CSubmap::matchesDevice(WP<IHID> device) {
     if (!device)
         return !m_inclusive;
 

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -1,27 +1,22 @@
 #include "Submap.hpp"
+
 #include <algorithm>
 
 using namespace Keybinds;
 
-CSubmap::CSubmap(std::string& name, SSubmapArgs args) : m_name(std::move(name)), m_devices(std::move(args.devices)), m_inclusive(args.inclusive) {};
+CSubmap::CSubmap(std::string& name, SSubmapArgs&& args) : m_name(std::move(name)), m_devices(std::move(args.device)) {};
 
 std::string_view CSubmap::name() const {
     return m_name;
 }
 
-bool CSubmap::inclusive() const {
-    return m_inclusive;
-}
-
-const std::unordered_set<std::string>& CSubmap::devices() const {
+const CDeviceList& CSubmap::devices() const {
     return m_devices;
 }
 
-bool CSubmap::matchesDevice(WP<IHID> device) {
+bool CSubmap::matchesDevice(WP<IHID> device) const {
     if (!device)
-        return !m_inclusive;
+        return !m_devices.inclusive();
 
-    const bool LISTED = m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
-
-    return m_inclusive ? LISTED : !LISTED;
+    return m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
 }

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -1,0 +1,22 @@
+#include "Submap.hpp"
+#include <algorithm>
+
+using namespace Keybinds;
+
+CSubmap::CSubmap(std::string& name, SSubmapArgs metadata) : m_name(std::move(name)), m_devices(std::move(metadata.devices)) {};
+
+std::string_view CSubmap::name() const {
+    return m_name;
+}
+
+const std::unordered_set<std::string>& CSubmap::devices() const {
+    return m_devices;
+}
+
+bool CSubmap::matchesDevice(SP<IHID> device) {
+    if (!device) {
+        return true;
+    }
+
+    return m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
+}

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -14,7 +14,7 @@ const std::unordered_set<std::string>& CSubmap::devices() const {
 }
 
 bool CSubmap::matchesDevice(SP<IHID> device) {
-    if (!device) {
+    if (m_devices.empty() || !device) {
         return true;
     }
 

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -17,7 +17,7 @@ const std::unordered_set<std::string>& CSubmap::devices() const {
     return m_devices;
 }
 
-bool CSubmap::matchesDevice(WP<IHID> device) {
+bool CSubmap::matchesDevice(SP<IHID> device) const {
     if (!device)
         return !m_inclusive;
 

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -3,10 +3,14 @@
 
 using namespace Keybinds;
 
-CSubmap::CSubmap(std::string& name, SSubmapArgs metadata) : m_name(std::move(name)), m_devices(std::move(metadata.devices)) {};
+CSubmap::CSubmap(std::string& name, SSubmapArgs args) : m_name(std::move(name)), m_devices(std::move(args.devices)), m_inclusive(args.inclusive) {};
 
 std::string_view CSubmap::name() const {
     return m_name;
+}
+
+bool CSubmap::inclusive() const {
+    return m_inclusive;
 }
 
 const std::unordered_set<std::string>& CSubmap::devices() const {
@@ -14,9 +18,10 @@ const std::unordered_set<std::string>& CSubmap::devices() const {
 }
 
 bool CSubmap::matchesDevice(WP<IHID> device) {
-    if (m_devices.empty() || !device) {
-        return true;
-    }
+    if (!device)
+        return !m_inclusive;
 
-    return m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
+    const bool LISTED = m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
+
+    return m_inclusive ? LISTED : !LISTED;
 }

--- a/src/keybinds/Submap.cpp
+++ b/src/keybinds/Submap.cpp
@@ -15,8 +15,5 @@ const CDeviceList& CSubmap::devices() const {
 }
 
 bool CSubmap::matchesDevice(WP<IHID> device) const {
-    if (!device)
-        return !m_devices.inclusive();
-
-    return m_devices.contains(device->m_hlName) || std::ranges::any_of(device->m_deviceTags, [this](const auto& tag) { return m_devices.contains(tag); });
+    return m_devices.contains(device);
 }

--- a/src/keybinds/Submap.hpp
+++ b/src/keybinds/Submap.hpp
@@ -22,7 +22,7 @@ namespace Keybinds {
         CSubmap(const CSubmap&)                                    = delete;
         CSubmap&                               operator=(CSubmap&) = delete;
 
-        bool                                   matchesDevice(SP<IHID> device) const;
+        bool                                   matchesDevice(WP<IHID> device);
 
         std::string_view                       name() const;
         bool                                   inclusive() const;

--- a/src/keybinds/Submap.hpp
+++ b/src/keybinds/Submap.hpp
@@ -21,7 +21,7 @@ namespace Keybinds {
         CSubmap(const CSubmap&)                                    = delete;
         CSubmap&                               operator=(CSubmap&) = delete;
 
-        bool                                   matchesDevice(SP<IHID> device);
+        bool                                   matchesDevice(WP<IHID> device);
 
         std::string_view                       name() const;
         const std::unordered_set<std::string>& devices() const;

--- a/src/keybinds/Submap.hpp
+++ b/src/keybinds/Submap.hpp
@@ -2,36 +2,33 @@
 
 #include "devices/IHID.hpp"
 #include "helpers/memory/Memory.hpp"
-#include <unordered_set>
-#include <vector>
 #include <string>
+
+#include "DeviceList.hpp"
 
 namespace Keybinds {
 
     struct SSubmapArgs {
-        std::unordered_set<std::string> devices;
-        bool                            inclusive;
+        CDeviceList device;
     };
 
     class CSubmap {
       public:
-        CSubmap(std::string& name, SSubmapArgs args);
+        CSubmap(std::string& name, SSubmapArgs&& args);
 
-        CSubmap(CSubmap&&) noexcept                                = default;
-        CSubmap& operator=(CSubmap&&) noexcept                     = default;
-        CSubmap(const CSubmap&)                                    = delete;
-        CSubmap&                               operator=(CSubmap&) = delete;
+        CSubmap(CSubmap&&) noexcept            = default;
+        CSubmap& operator=(CSubmap&&) noexcept = default;
+        CSubmap(const CSubmap&)                = delete;
+        CSubmap&           operator=(CSubmap&) = delete;
 
-        bool                                   matchesDevice(WP<IHID> device);
+        bool               matchesDevice(WP<IHID> device) const;
 
-        std::string_view                       name() const;
-        bool                                   inclusive() const;
-        const std::unordered_set<std::string>& devices() const;
+        std::string_view   name() const;
+        const CDeviceList& devices() const;
 
       private:
-        std::string                     m_name;
-        std::unordered_set<std::string> m_devices;
-        bool                            m_inclusive;
+        std::string m_name;
+        CDeviceList m_devices;
     };
 
 }

--- a/src/keybinds/Submap.hpp
+++ b/src/keybinds/Submap.hpp
@@ -10,11 +10,12 @@ namespace Keybinds {
 
     struct SSubmapArgs {
         std::unordered_set<std::string> devices;
+        bool                            inclusive;
     };
 
     class CSubmap {
       public:
-        CSubmap(std::string& name, SSubmapArgs metadata);
+        CSubmap(std::string& name, SSubmapArgs args);
 
         CSubmap(CSubmap&&) noexcept                                = default;
         CSubmap& operator=(CSubmap&&) noexcept                     = default;
@@ -24,11 +25,13 @@ namespace Keybinds {
         bool                                   matchesDevice(WP<IHID> device);
 
         std::string_view                       name() const;
+        bool                                   inclusive() const;
         const std::unordered_set<std::string>& devices() const;
 
       private:
         std::string                     m_name;
         std::unordered_set<std::string> m_devices;
+        bool                            m_inclusive;
     };
 
 }

--- a/src/keybinds/Submap.hpp
+++ b/src/keybinds/Submap.hpp
@@ -22,7 +22,7 @@ namespace Keybinds {
         CSubmap(const CSubmap&)                                    = delete;
         CSubmap&                               operator=(CSubmap&) = delete;
 
-        bool                                   matchesDevice(WP<IHID> device);
+        bool                                   matchesDevice(SP<IHID> device) const;
 
         std::string_view                       name() const;
         bool                                   inclusive() const;

--- a/src/keybinds/Submap.hpp
+++ b/src/keybinds/Submap.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "devices/IHID.hpp"
+#include "helpers/memory/Memory.hpp"
+#include <unordered_set>
+#include <vector>
+#include <string>
+
+namespace Keybinds {
+
+    struct SSubmapArgs {
+        std::unordered_set<std::string> devices;
+    };
+
+    class CSubmap {
+      public:
+        CSubmap(std::string& name, SSubmapArgs metadata);
+
+        CSubmap(CSubmap&&) noexcept                                = default;
+        CSubmap& operator=(CSubmap&&) noexcept                     = default;
+        CSubmap(const CSubmap&)                                    = delete;
+        CSubmap&                               operator=(CSubmap&) = delete;
+
+        bool                                   matchesDevice(SP<IHID> device);
+
+        std::string_view                       name() const;
+        const std::unordered_set<std::string>& devices() const;
+
+      private:
+        std::string                     m_name;
+        std::unordered_set<std::string> m_devices;
+    };
+
+}

--- a/tests/config/lua/LuaObjectsBasic.cpp
+++ b/tests/config/lua/LuaObjectsBasic.cpp
@@ -141,7 +141,7 @@ TEST(ConfigLuaObjects, keybindExposesMetadataAndRemoveMethods) {
     const auto makeMetadataBind = [&] {
         return makeBind({"SUPER", "Q"}, FLAGS,
                         {
-                            .devices = {"kbd-a", "kbd-b"},
+                            .devices = { true, {"kbd-a", "kbd-b"} },
                             .metadata =
                                 {
                                     .displayKey  = "SUPER + Q",

--- a/tests/keybinds/Registry.cpp
+++ b/tests/keybinds/Registry.cpp
@@ -18,6 +18,10 @@ static CBind makeRegistryBind(std::string displayKey, std::string submap = {}) {
     return std::move(*result);
 }
 
+static CSubmap makeSubmap(std::string name, std::unordered_set<std::string> devices, const bool inclusive) {
+    return CSubmap(name, {.devices = devices, .inclusive = inclusive});
+};
+
 TEST(KeybindsRegistry, RemovesExactBind) {
     CRegistry  registry;
     const auto FIRST  = registry.add(makeRegistryBind("SUPER + K"));
@@ -45,6 +49,13 @@ TEST(KeybindsRegistry, FindsSubmap) {
 
     EXPECT_TRUE(registry.hasSubmap("resize"));
     EXPECT_FALSE(registry.hasSubmap("missing"));
+}
+
+TEST(KeybindsRegistry, FindsSubmapNewAPI) {
+    CRegistry registry;
+    registry.addSubmap(makeSubmap("example", {}, false));
+
+    EXPECT_TRUE(registry.findSubmap("example", nullptr));
 }
 
 TEST(KeybindsRegistry, FindsShortcutWithSidedModifier) {

--- a/tests/keybinds/Registry.cpp
+++ b/tests/keybinds/Registry.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "Utils.hpp"
+
 using namespace Keybinds;
 using namespace Input;
 
@@ -17,10 +19,6 @@ static CBind makeRegistryBind(std::string displayKey, std::string submap = {}) {
     EXPECT_TRUE(result.has_value());
     return std::move(*result);
 }
-
-static CSubmap makeSubmap(std::string name, std::unordered_set<std::string> devices, const bool inclusive) {
-    return CSubmap(name, {.devices = devices, .inclusive = inclusive});
-};
 
 TEST(KeybindsRegistry, RemovesExactBind) {
     CRegistry  registry;

--- a/tests/keybinds/Submap.cpp
+++ b/tests/keybinds/Submap.cpp
@@ -1,13 +1,10 @@
-#include "devices/Keyboard.hpp"
 #include <keybinds/Submap.hpp>
 
 #include <gtest/gtest.h>
 
-using namespace Keybinds;
+#include "Utils.hpp"
 
-static CSubmap makeSubmap(std::string name, std::unordered_set<std::string> devices, const bool inclusive) {
-    return CSubmap(name, {.devices = devices, .inclusive = inclusive});
-};
+using namespace Keybinds;
 
 // testing with actual devices requires being able to instantiate them
 // virtually :(

--- a/tests/keybinds/Submap.cpp
+++ b/tests/keybinds/Submap.cpp
@@ -13,11 +13,11 @@ static CSubmap makeSubmap(std::string name, std::unordered_set<std::string> devi
 // virtually :(
 
 TEST(KeybindsSubmap, MatchesEmptyDeviceWhenNotInclusive) {
-    const auto SUBMAP = makeSubmap("example", {"device_a", "device_b"}, false);
-    ASSERT_TRUE(SUBMAP.matchesDevice(nullptr));
+    auto submap = makeSubmap("example", {"device_a", "device_b"}, false);
+    ASSERT_TRUE(submap.matchesDevice(nullptr));
 }
 
 TEST(KeybindsSubmap, NoMatchesEmptyDeviceWhenInclusive) {
-    const auto SUBMAP = makeSubmap("example", {"device_a", "device_b"}, true);
-    ASSERT_FALSE(SUBMAP.matchesDevice(nullptr));
+    auto submap = makeSubmap("example", {"device_a", "device_b"}, true);
+    ASSERT_FALSE(submap.matchesDevice(nullptr));
 }

--- a/tests/keybinds/Submap.cpp
+++ b/tests/keybinds/Submap.cpp
@@ -1,20 +1,131 @@
+#include <devices/Keyboard.hpp>
+#include <helpers/memory/Memory.hpp>
 #include <keybinds/Submap.hpp>
 
+#include <aquamarine/input/Input.hpp>
 #include <gtest/gtest.h>
+#include <string>
+#include <string_view>
 
 #include "Utils.hpp"
 
 using namespace Keybinds;
 
-// testing with actual devices requires being able to instantiate them
-// virtually :(
+namespace {
+    class CTestKeyboard : public Aquamarine::IKeyboard {
+      public:
+        static SP<CTestKeyboard> make(std::string&& name) {
+            return SP<CTestKeyboard>{new CTestKeyboard(std::move(name))};
+        }
+
+        const std::string& getName() override {
+            return m_name;
+        }
+
+      private:
+        CTestKeyboard(std::string&& name) : m_name(std::move(name)) {};
+
+        std::string m_name;
+    };
+
+    struct STestDevice {
+        SP<CTestKeyboard> keyboard;
+        SP<CKeyboard>     ihid;
+        std::string_view  name;
+    };
+
+    inline STestDevice makeDevice(std::string_view device_name) {
+        std::string name{device_name};
+        auto        keyboard = CTestKeyboard::make(std::move(name));
+        auto        ihid     = SP<CKeyboard>(CKeyboard::create(std::move(keyboard)));
+
+        ihid->m_deviceName = device_name;
+        ihid->m_hlName     = device_name;
+
+        return {
+            .keyboard = std::move(keyboard),
+            .ihid     = std::move(ihid),
+            .name     = device_name,
+        };
+    }
+}
+
+TEST(KeybindsSubmap, MatchesDeviceWhenInclusive) {
+    std::string   device_name = "some-keyboard";
+    STestDevice   test_case   = makeDevice(device_name);
+    const CSubmap SUBMAP      = makeSubmap("test", {device_name}, true);
+
+    ASSERT_TRUE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, NoMatchesDeviceWhenNotInclusive) {
+    std::string   device_name = "some-keyboard";
+    STestDevice   test_case   = makeDevice(device_name);
+    const CSubmap SUBMAP      = makeSubmap("test", {device_name}, false);
+
+    ASSERT_FALSE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, NoMatchesOtherDeviceWhenInclusive) {
+    std::string   device_name = "some-keyboard";
+    STestDevice   test_case   = makeDevice(device_name);
+    const CSubmap SUBMAP      = makeSubmap("test", {"other-keyboard"}, true);
+
+    ASSERT_FALSE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, MatchesOtherDeviceWhenNotInclusive) {
+    std::string   device_name = "some-keyboard";
+    STestDevice   test_case   = makeDevice(device_name);
+    const CSubmap SUBMAP      = makeSubmap("test", {"other-keyboard"}, false);
+
+    ASSERT_TRUE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, MatchesTagWhenInclusive) {
+    std::string tag_name  = "some-tag";
+    STestDevice test_case = makeDevice("some-keyboard");
+
+    test_case.ihid->m_deviceTags.emplace(tag_name);
+
+    const CSubmap SUBMAP = makeSubmap("test", {tag_name}, true);
+
+    ASSERT_TRUE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, NoMatchesTagWhenNotInclusive) {
+    std::string tag_name  = "some-tag";
+    STestDevice test_case = makeDevice("some-keyboard");
+
+    test_case.ihid->m_deviceTags.emplace(tag_name);
+
+    const CSubmap SUBMAP = makeSubmap("test", {tag_name}, false);
+
+    ASSERT_FALSE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, NoMatchesDeviceWhenNoDevicesAndInclusive) {
+    std::string   device_name = "some-keyboard";
+    STestDevice   test_case   = makeDevice(device_name);
+    const CSubmap SUBMAP      = makeSubmap("test", {}, true);
+
+    ASSERT_FALSE(SUBMAP.matchesDevice(test_case.ihid));
+}
+
+TEST(KeybindsSubmap, MatchesDeviceWhenNoDevicesAndNotInclusive) {
+    std::string   device_name = "some-keyboard";
+    STestDevice   test_case   = makeDevice(device_name);
+    const CSubmap SUBMAP      = makeSubmap("test", {}, false);
+
+    ASSERT_TRUE(SUBMAP.matchesDevice(test_case.ihid));
+}
 
 TEST(KeybindsSubmap, MatchesEmptyDeviceWhenNotInclusive) {
-    auto submap = makeSubmap("example", {"device_a", "device_b"}, false);
-    ASSERT_TRUE(submap.matchesDevice(nullptr));
+    const CSubmap SUBMAP = makeSubmap("example", {"device_a", "device_b"}, false);
+    ASSERT_TRUE(SUBMAP.matchesDevice(nullptr));
 }
 
 TEST(KeybindsSubmap, NoMatchesEmptyDeviceWhenInclusive) {
-    auto submap = makeSubmap("example", {"device_a", "device_b"}, true);
-    ASSERT_FALSE(submap.matchesDevice(nullptr));
+    const CSubmap SUBMAP = makeSubmap("example", {"device_a", "device_b"}, true);
+    ASSERT_FALSE(SUBMAP.matchesDevice(nullptr));
 }

--- a/tests/keybinds/Submap.cpp
+++ b/tests/keybinds/Submap.cpp
@@ -1,0 +1,23 @@
+#include "devices/Keyboard.hpp"
+#include <keybinds/Submap.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace Keybinds;
+
+static CSubmap makeSubmap(std::string name, std::unordered_set<std::string> devices, const bool inclusive) {
+    return CSubmap(name, {.devices = devices, .inclusive = inclusive});
+};
+
+// testing with actual devices requires being able to instantiate them
+// virtually :(
+
+TEST(KeybindsSubmap, MatchesEmptyDeviceWhenNotInclusive) {
+    const auto SUBMAP = makeSubmap("example", {"device_a", "device_b"}, false);
+    ASSERT_TRUE(SUBMAP.matchesDevice(nullptr));
+}
+
+TEST(KeybindsSubmap, NoMatchesEmptyDeviceWhenInclusive) {
+    const auto SUBMAP = makeSubmap("example", {"device_a", "device_b"}, true);
+    ASSERT_FALSE(SUBMAP.matchesDevice(nullptr));
+}

--- a/tests/keybinds/Utils.hpp
+++ b/tests/keybinds/Utils.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <keybinds/Submap.hpp>
+
+inline Keybinds::CSubmap makeSubmap(std::string name, std::unordered_set<std::string>&& devices, const bool inclusive) {
+    Keybinds::SSubmapArgs args{.device = Keybinds::CDeviceList(inclusive, std::move(devices))};
+    return Keybinds::CSubmap(name, std::move(args));
+};


### PR DESCRIPTION
Closes #15640 

#### Describe your PR, what does it fix/add?

An implementation for per-device submap definitions. This PR thus proposes :

- A new optional parameter to `hl.define_submap` to accept metadata similar to what we do with `hl.bind`. So far, only the `device` key is handled.
- An architecture change promoting submaps to have their own data structure,  stored alongside `Keybinds::CBind`s in `Keybinds::CRegister`.

Just like bindings, if the submap has no device mapped to it, it becomes global. Otherwise, the submap will be set if and only if the last device used to press a key (in practice, the one that has the key pressed to trigger `hl.dsp.submap()`) is mapped by the submap.

Below is an example code snippet that can be added to an Hyprland test configuration to test the feature :

```lua
local mainMod = "ALT"

hl.on("keybinds.submap",
    function(submap)
        text = nil

        if submap == "" then
            text = "Returning to default"
        else
            text = "Enabling submap " .. submap
        end

        hl.notification.create({ text = text, timeout = 2500 })
    end
)

hl.bind(mainMod .. " + M", hl.dsp.submap("test"))

hl.define_submap("test",
    function()
        hl.bind(mainMod .. " + P",
            function()
                hl.notification.create({ text = "A special notification", timeout = 2000 })
            end
        )

        hl.bind(mainMod .. " + M", hl.dsp.submap("reset"))
    end,
    {
        device = {
            inclusive = true,
            list = { "wl_keyboard" }  -- or whatever is returned when running `hyprctl devices`
        }
    }
)

```


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

**`Keybinds::CSubset` Data Structure**

Right now (and if I understand correctly), we handle binds directly using two strings in `Keybinds::SBindMetadata` : `submap` and `submapReset`. When we want to check the submaps, we look for them in `CBind` objects directly (ex: [`Keybinds::CRegistry::hasSubmap`](https://github.com/hyprwm/Hyprland/blob/d10194c63b323e37c2ba5a4b954a7bbb12901e3b/src/keybinds/Registry.cpp#L54) ).

As we now allow metadata values for submaps which can be lead to evolve along with Hyprland's features, such an approach may not scale well on the long run. In order to handle device mappings, the PR thus introduces a dedicated data structure `Keybinds::CSubset` for submaps. The idea is to store them along with `Keybinds::CBind`s in the keybinds registry, where they are also reset when the keybinds are reset.

**`m_lastDevice` in `Config::Actions::CActionState`**

Changes I saved as commit `ddb4f88cbce700360f79f2bd2f1bf4dc49465604` gathers everything related to my current approach to pass on the current input device to the submap match search in `Config::Actions::setSubmap` : so far, I added a `SP<IHID> m_lastDevice` field to the global config action state, which I read during `setSubmap` .

I think there might be way, way better ways to do this other than straight up tracking the last device in the global action state. That being siad, I'm still very new to the codebase and this is the first option I have found. I kept this commit to at least have a functional first result, but please do tell if they are more efficient ways to pass around the input device across `Keybinds` callbacks.

**AI Usage**

As it is my first time working in Hyprland, I only relied on an AI model (Claude Sonnet in this case) for analysis purposes, in order to grasp an initial understanding of Hyprland's global structure and the project filesystem. Beyond that, I no longer used AI and favored understanding Hyprland's modules by reading the source code, testing its behavior using a debugger and checking out the documentation for the Lua C API. Moreover, I haven't used any AI while working on the feature itself.


#### Is it ready for merging, or does it need work?

The API and backend logic is ready and tested. The only missing part from the original feature request is to remove the global lock on submaps to allow multiple ones being active at the same time. Whether we implement it here or in a second PR is up to discussion.

The architecture change regarding `CSubmap` should also be approved before merging. If there is no problem with it, then we can change the existing logic to align it with the new API.