### PR TITLE
gestures/scrolling: add move invert option

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -493,6 +493,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Int>("gestures:close_max_timeout", "Timeout for closing windows with the close gesture, in ms.", 1000, {.min = 10, .max = 2000}),
         MS<Bool>("gestures:scrolling:move_snap_to_grid", "When releasing the scroll move gesture, whether it shoud try to snap to the grid.", true),
         MS<Bool>("gestures:scrolling:move_snap_cursor", "When releasing the scroll move gesture, whether it shoud snap the cursor to the newly focused window.", true),
+        MS<Bool>("gestures:scrolling:move_invert", "Whether to invert the scroll move gesture direction.", false),
         /*
          * group:
          */

--- a/src/managers/input/trackpad/gestures/ScrollMoveGesture.cpp
+++ b/src/managers/input/trackpad/gestures/ScrollMoveGesture.cpp
@@ -64,6 +64,8 @@ void CScrollMoveTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
 }
 
 void CScrollMoveTrackpadGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {
+    static auto PINVERT = CConfigValue<Config::BOOL>("gestures:scrolling:move_invert");
+
     if (!m_wasScrollingLayout)
         return;
 
@@ -71,7 +73,7 @@ void CScrollMoveTrackpadGesture::update(const ITrackpadGesture::STrackpadGesture
     if (!SCROLLING)
         return;
 
-    const float  DELTA   = deltaForUpdate(e);
+    const float  DELTA   = deltaForUpdate(e) * (*PINVERT ? -1.F : 1.F);
     const double PRIMARY = SCROLLING->primaryViewportSize();
 
     if (DELTA == 0.F || PRIMARY <= 0.0)


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Add a flag to invert the scroll-move gesture on the scrolling layout. 


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is a follow-up on https://github.com/hyprwm/Hyprland/pull/14952 where there was suggestions on how to proceed and the PR owner didn't have time to work on it for now, so I'm publishing an alternative PR pushing the invert flag.

Happy to do something else. This is a very small change and it was AI-assisted, but it does make sense and fit well in the original PR recommendation.

This was manually tested on a nested hyprland session with the invert config applyed and the scroll did invert as expected.


#### Is it ready for merging, or does it need work?

Ready for merging


