### PR TITLE
setcursor applies immediately now

### DIFF
--- a/src/pointer/cursor/CursorManager.cpp
+++ b/src/pointer/cursor/CursorManager.cpp
@@ -170,8 +170,9 @@ void CCursorManager::setAnimationTimer(const int& frame, const int& delay) {
 void CCursorManager::setCursorFromName(const std::string& name) {
 
     static auto PUSEHYPRCURSOR = CConfigValue<Config::INTEGER>("cursor:enable_hyprcursor");
+    m_lastCursorName           = name;
 
-    auto        setXCursor = [this](auto const& name) {
+    auto setXCursor = [this](auto const& name) {
         float scale = std::ceil(m_cursorScale);
 
         auto  xcursor = m_xcursor->getShape(name, m_size, m_cursorScale);
@@ -320,6 +321,8 @@ void CCursorManager::updateTheme() {
         m->m_forceFullFrames = 5;
         m->scheduleFrame(Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_SHAPE);
     }
+    if (m_ourBufferConnected)
+        setCursorFromName(m_lastCursorName);
 }
 
 bool CCursorManager::changeTheme(const std::string& name, const int size) {

--- a/src/pointer/cursor/CursorManager.hpp
+++ b/src/pointer/cursor/CursorManager.hpp
@@ -66,9 +66,10 @@ namespace Pointer::Cursor {
         UP<CXCursorManager>                m_xcursor;
         SP<SXCursors>                      m_currentXcursor;
 
-        std::string                        m_theme       = "";
-        int                                m_size        = 0;
-        float                              m_cursorScale = 1.0;
+        std::string                        m_lastCursorName = "left_ptr";
+        std::string                        m_theme          = "";
+        int                                m_size           = 0;
+        float                              m_cursorScale    = 1.0;
 
         Hyprcursor::SCursorStyleInfo       m_currentStyleInfo;
 


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Adds a call in updateTheme/CursorManager to immediately set the cursor after changing the buffer. Also saves previously set cursor name since CursorManager doesn't store it but it's needed to draw same cursor again. 

Issue I mean

https://github.com/user-attachments/assets/630d2527-5ea2-4d5f-9269-5b2508d7e991


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't like that I duplicated where current cursor name is stored but it's a simple enough fix and since it's set every time it's changed it should follow 1:1. Might drift if someone also changes default cursor shape everywhere else in code, though I don't see why that might happen. I don't think rewriting lots of stuff for this small bandaid is worth it.

I've checked this works:
- when cursor is not moving (especially on startup)
- when cursor is not default state
- when cursor is hijacked by some other app (krita)

#### Is it ready for merging, or does it need work?
Ready

