### PR TITLE
groups: fixes for groupbar:disable_when_only

### DIFF
--- a/hyprtester/src/tests/main/groups.cpp
+++ b/hyprtester/src/tests/main/groups.cpp
@@ -590,6 +590,49 @@ TEST_CASE(groups_disable_when_only) {
     ASSERT(Tests::windowCount(), 0);
 }
 
+TEST_CASE(groupbarDisableWhenOnlyDimensions) {
+    OK(getFromSocket("/eval hl.config({ group = { groupbar = { disable_when_only = true } } })"));
+    SPAWN_KITTY("kittenA");
+    OK(getFromSocket("/dispatch hl.dsp.group.toggle()"));
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "at: 22,22");
+        EXPECT_CONTAINS(str, "size: 1876,1036");
+    }
+
+    SPAWN_KITTY("kittenB");
+    // when `groupbar:disable_when_only = true` and adding a second member to the group, check if the first member got its groupbar by checking its dimensions.
+    {
+        auto clients  = getFromSocket("/clients");
+        auto classPos = clients.find("class: kittenA");
+        if (classPos == std::string::npos) {
+            FAIL_TEST("Could not find kittenA in clients output");
+        } else {
+            auto entryStart  = clients.rfind("Window ", classPos);
+            auto entryEnd    = clients.find("\n\n", classPos);
+            auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+            EXPECT_CONTAINS(windowEntry, "at: 22,43");
+            EXPECT_CONTAINS(windowEntry, "size: 1876,1015");
+        }
+    }
+
+    // also check the dimensions of the only member of the group after moving out the other member. It should have lost its groupbar and resized accordingly.
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ out_of_group = true })"));
+    {
+        auto clients  = getFromSocket("/clients");
+        auto classPos = clients.find("class: kittenA");
+        if (classPos == std::string::npos) {
+            FAIL_TEST("Could not find kittenA in clients output");
+        } else {
+            auto entryStart  = clients.rfind("Window ", classPos);
+            auto entryEnd    = clients.find("\n\n", classPos);
+            auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+            EXPECT_CONTAINS(windowEntry, "at: 22,22");
+            EXPECT_CONTAINS(windowEntry, "size: 931,1036");
+        }
+    }
+}
+
 TEST_CASE(autoGroupFloatedIntoTiled) {
     NLog::log("{}Test that we deny a new floated window getting auto-grouped into the focused tiled group.", Colors::GREEN);
 

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -263,13 +263,13 @@ void CGroup::remove(PHLWINDOW w, Math::eDirection dir, eRemoveFromGroupReason re
     // we do it after the above because switchTargets expects this to be a valid group
     m_windows.erase(m_windows.begin() + *idx);
 
-    // recalculate the remaning group member for groupbar:disable_when_only
+    // if groupbar:disable_when_only is enabled and there is only one group member left, we need to fix its size because it will lose its groupbar.
     static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
     if (*PDISABLE && m_windows.size() == 1) {
-        const auto REMAININGMEMBER = m_windows.at(0).lock();
-        const auto GROUPBAR        = REMAININGMEMBER->presentation().decoration(DECORATION_GROUPBAR);
-        GROUPBAR->updateWindow(REMAININGMEMBER);
-        g_pDecorationPositioner->forceRecalcFor(REMAININGMEMBER);
+        const auto REMAINING_MEMBER = m_windows.at(0).lock();
+        const auto GROUPBAR         = REMAINING_MEMBER->presentation().decoration(DECORATION_GROUPBAR);
+        GROUPBAR->updateWindow(REMAINING_MEMBER);
+        g_pDecorationPositioner->forceRecalcFor(REMAINING_MEMBER);
     }
 
     if (!m_windows.empty())

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -257,7 +257,8 @@ void CGroup::remove(PHLWINDOW w, Math::eDirection dir, eRemoveFromGroupReason re
     m_windows.erase(m_windows.begin() + *idx);
 
     // recalculate the remaning group member for groupbar:disable_when_only
-    if (m_windows.size() == 1) {
+    static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
+    if (*PDISABLE && m_windows.size() == 1) {
         const auto REMAININGMEMBER = m_windows.at(0).lock();
         const auto GROUPBAR = REMAININGMEMBER->presentation().decoration(DECORATION_GROUPBAR);
         GROUPBAR->updateWindow(REMAININGMEMBER);
@@ -380,12 +381,14 @@ SP<Layout::CWindowGroupTarget> CGroup::target() const {
 }
 
 void CGroup::applyWindowDecosAndUpdates(PHLWINDOW x) {
+    static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
     const auto GROUPBAR = makeShared<CHyprGroupBarDecoration>(x);
-    GROUPBAR->updateWindow(x);
+    if (*PDISABLE)
+      GROUPBAR->updateWindow(x);
     x->presentation().addDecoration(GROUPBAR);
 
     // when groupbar:disable_when_only = true, give the first member of the group its groupbar after adding the second member.
-    if (m_windows.size() == 2)
+    if (*PDISABLE && m_windows.size() == 2)
         g_pDecorationPositioner->forceRecalcFor(m_windows.at(0).lock());
 
     x->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_GROUP | Desktop::Rule::RULE_PROP_ON_WORKSPACE);

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -376,6 +376,10 @@ void CGroup::applyWindowDecosAndUpdates(PHLWINDOW x) {
     GROUPBAR->updateWindow(x);
     x->presentation().addDecoration(GROUPBAR);
 
+    // when groupbar:disable_when_only = true, give the first member of the group its groupbar after adding the second member.
+    if (m_windows.size() == 2)
+        g_pDecorationPositioner->forceRecalcFor(m_windows.at(0).lock());
+
     x->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_GROUP | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
     x->presentation().updateDecorations();
     x->presentation().refreshValues();

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -260,7 +260,7 @@ void CGroup::remove(PHLWINDOW w, Math::eDirection dir, eRemoveFromGroupReason re
     static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
     if (*PDISABLE && m_windows.size() == 1) {
         const auto REMAININGMEMBER = m_windows.at(0).lock();
-        const auto GROUPBAR = REMAININGMEMBER->presentation().decoration(DECORATION_GROUPBAR);
+        const auto GROUPBAR        = REMAININGMEMBER->presentation().decoration(DECORATION_GROUPBAR);
         GROUPBAR->updateWindow(REMAININGMEMBER);
         g_pDecorationPositioner->forceRecalcFor(REMAININGMEMBER);
     }
@@ -382,9 +382,9 @@ SP<Layout::CWindowGroupTarget> CGroup::target() const {
 
 void CGroup::applyWindowDecosAndUpdates(PHLWINDOW x) {
     static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
-    const auto GROUPBAR = makeShared<CHyprGroupBarDecoration>(x);
+    const auto  GROUPBAR = makeShared<CHyprGroupBarDecoration>(x);
     if (*PDISABLE)
-      GROUPBAR->updateWindow(x);
+        GROUPBAR->updateWindow(x);
     x->presentation().addDecoration(GROUPBAR);
 
     // when groupbar:disable_when_only = true, give the first member of the group its groupbar after adding the second member.

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -95,7 +95,9 @@ bool CGroup::has(PHLWINDOW w) const {
 }
 
 void CGroup::add(PHLWINDOW w, std::optional<size_t> index) {
-    static auto INSERT_AFTER_CURRENT = CConfigValue<Config::INTEGER>("group:insert_after_current");
+    static auto INSERT_AFTER_CURRENT          = CConfigValue<Config::INTEGER>("group:insert_after_current");
+    static auto PDISABLE                      = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
+    const auto  GROUPBAR_DISABLED_ONLY_MEMBER = (*PDISABLE && m_windows.size() == 1) ? m_windows.at(0).lock() : nullptr;
 
     if (w->grouping().group()) {
         if (w->grouping().group() == m_self)
@@ -152,6 +154,11 @@ void CGroup::add(PHLWINDOW w, std::optional<size_t> index) {
     }
 
     applyWindowDecosAndUpdates(w);
+
+    // when groupbar:disable_when_only = true, give the only member of the group its groupbar after adding the second member.
+    if (GROUPBAR_DISABLED_ONLY_MEMBER)
+        g_pDecorationPositioner->forceRecalcFor(GROUPBAR_DISABLED_ONLY_MEMBER);
+
     updateWindowVisibility();
 
     if (FS_INTERNAL_MODE != Fullscreen::FSMODE_NONE) {
@@ -386,10 +393,6 @@ void CGroup::applyWindowDecosAndUpdates(PHLWINDOW x) {
     if (*PDISABLE)
         GROUPBAR->updateWindow(x);
     x->presentation().addDecoration(GROUPBAR);
-
-    // when groupbar:disable_when_only = true, give the first member of the group its groupbar after adding the second member.
-    if (*PDISABLE && m_windows.size() == 2)
-        g_pDecorationPositioner->forceRecalcFor(m_windows.at(0).lock());
 
     x->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_GROUP | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
     x->presentation().updateDecorations();

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -256,6 +256,14 @@ void CGroup::remove(PHLWINDOW w, Math::eDirection dir, eRemoveFromGroupReason re
     // we do it after the above because switchTargets expects this to be a valid group
     m_windows.erase(m_windows.begin() + *idx);
 
+    // recalculate the remaning group member for groupbar:disable_when_only
+    if (m_windows.size() == 1) {
+        const auto REMAININGMEMBER = m_windows.at(0).lock();
+        const auto GROUPBAR = REMAININGMEMBER->presentation().decoration(DECORATION_GROUPBAR);
+        GROUPBAR->updateWindow(REMAININGMEMBER);
+        g_pDecorationPositioner->forceRecalcFor(REMAININGMEMBER);
+    }
+
     if (!m_windows.empty())
         updateWindowVisibility();
 

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -266,10 +266,11 @@ void CGroup::remove(PHLWINDOW w, Math::eDirection dir, eRemoveFromGroupReason re
     // if groupbar:disable_when_only is enabled and there is only one group member left, we need to fix its size because it will lose its groupbar.
     static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
     if (*PDISABLE && m_windows.size() == 1) {
-        const auto REMAINING_MEMBER = m_windows.at(0).lock();
-        const auto GROUPBAR         = REMAINING_MEMBER->presentation().decoration(DECORATION_GROUPBAR);
-        GROUPBAR->updateWindow(REMAINING_MEMBER);
-        g_pDecorationPositioner->forceRecalcFor(REMAINING_MEMBER);
+        if (const auto REMAINING_MEMBER = m_windows.at(0).lock()) {
+            const auto GROUPBAR = REMAINING_MEMBER->presentation().decoration(DECORATION_GROUPBAR);
+            GROUPBAR->updateWindow(REMAINING_MEMBER);
+            g_pDecorationPositioner->forceRecalcFor(REMAINING_MEMBER);
+        }
     }
 
     if (!m_windows.empty())

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -372,7 +372,9 @@ SP<Layout::CWindowGroupTarget> CGroup::target() const {
 }
 
 void CGroup::applyWindowDecosAndUpdates(PHLWINDOW x) {
-    x->presentation().addDecoration(makeShared<CHyprGroupBarDecoration>(x));
+    const auto GROUPBAR = makeShared<CHyprGroupBarDecoration>(x);
+    GROUPBAR->updateWindow(x);
+    x->presentation().addDecoration(GROUPBAR);
 
     x->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_GROUP | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
     x->presentation().updateDecorations();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes for `groupbar:disable_when_only`:
1. Fixes https://github.com/hyprwm/Hyprland/discussions/15820
2. Fixes the first member by giving it its groupbar after adding the second member, instead of giving it after being focused.
3. Fixes the remaining group member' size after removing other members from the group.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
AI disclosure: I used the clanker for debugging and for C++ stuff.

#### Is it ready for merging, or does it need work?
Tested and everything seems good now.
CC @feelamee @tekstryder
Cheers