### PR TITLE
transferfunction: add bt1886 as an sdr_eotf value

### DIFF
--- a/src/helpers/TransferFunction.cpp
+++ b/src/helpers/TransferFunction.cpp
@@ -9,7 +9,7 @@ using namespace NTransferFunction;
 
 static std::unordered_map<std::string, eTF> const table = {{"default", TF_DEFAULT}, {"0", TF_DEFAULT},       {"auto", TF_AUTO}, {"srgb", TF_SRGB},
                                                            {"3", TF_SRGB},          {"gamma22", TF_GAMMA22}, {"1", TF_GAMMA22}, {"gamma22force", TF_FORCED_GAMMA22},
-                                                           {"2", TF_FORCED_GAMMA22}};
+                                                           {"2", TF_FORCED_GAMMA22}, {"bt1886", TF_BT1886}};
 
 eTF                                               NTransferFunction::fromString(const std::string tfName) {
     auto it = table.find(tfName);

--- a/src/helpers/TransferFunction.hpp
+++ b/src/helpers/TransferFunction.hpp
@@ -10,6 +10,7 @@ namespace NTransferFunction {
         TF_SRGB           = 2,
         TF_GAMMA22        = 3,
         TF_FORCED_GAMMA22 = 4,
+        TF_BT1886         = 5,
     };
 
     eTF         fromString(const std::string tfName);

--- a/src/helpers/cm/ColorManagement.cpp
+++ b/src/helpers/cm/ColorManagement.cpp
@@ -533,6 +533,7 @@ PImageDescription NColorManagement::getDefaultImageDescription() {
         case TF_FORCED_GAMMA22: return DEFAULT_GAMMA22_IMAGE_DESCRIPTION;
         case TF_DEFAULT:
         case TF_SRGB: return DEFAULT_SRGB_IMAGE_DESCRIPTION;
+        case TF_BT1886: return DEFAULT_BT1886_IMAGE_DESCRIPTION;
         default: UNREACHABLE();
     }
 }

--- a/src/helpers/cm/ColorManagement.hpp
+++ b/src/helpers/cm/ColorManagement.hpp
@@ -402,6 +402,14 @@ namespace NColorManagement {
         .luminances       = {.min = SDR_MIN_LUMINANCE, .max = 80, .reference = 80},
     });
 
+    inline const auto DEFAULT_BT1886_IMAGE_DESCRIPTION = CImageDescription::from(SImageDescription{
+        .transferFunction = NColorManagement::CM_TRANSFER_FUNCTION_BT1886,
+        .primariesNameSet = true,
+        .primariesNamed   = NColorManagement::CM_PRIMARIES_SRGB,
+        .primaries        = NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_SRGB),
+        .luminances       = {.min = SDR_MIN_LUMINANCE, .max = 80, .reference = 80},
+    });
+
     inline const auto DEFAULT_HDR_IMAGE_DESCRIPTION = CImageDescription::from(SImageDescription{
         .transferFunction = NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ,
         .primariesNameSet = true,

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -535,6 +535,7 @@ static NColorManagement::eTransferFunction chooseTF(NTransferFunction::eTF tf) {
         case NTransferFunction::TF_FORCED_GAMMA22: return NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22;
         case NTransferFunction::TF_DEFAULT:
         case NTransferFunction::TF_SRGB: return NColorManagement::CM_TRANSFER_FUNCTION_SRGB;
+        case NTransferFunction::TF_BT1886: return NColorManagement::CM_TRANSFER_FUNCTION_BT1886;
 
         case NTransferFunction::TF_AUTO: // use global setting
             switch (sdrEOTF) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1979,6 +1979,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
             srcTF = NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_SRGB;
         else if (sdrEOTF == NTransferFunction::TF_GAMMA22 || sdrEOTF == NTransferFunction::TF_FORCED_GAMMA22)
             srcTF = NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_GAMMA22;
+        else if (sdrEOTF == NTransferFunction::TF_BT1886)
+            srcTF = NColorManagement::eTransferFunction::CM_TRANSFER_FUNCTION_BT1886;
         else
             srcTF = imageDescription->value().transferFunction;
     } else

--- a/tests/helpers/TransferFunction.cpp
+++ b/tests/helpers/TransferFunction.cpp
@@ -10,6 +10,7 @@ TEST(Helpers, transferFunctionFromStringNamed) {
     EXPECT_EQ(fromString("srgb"), TF_SRGB);
     EXPECT_EQ(fromString("gamma22"), TF_GAMMA22);
     EXPECT_EQ(fromString("gamma22force"), TF_FORCED_GAMMA22);
+    EXPECT_EQ(fromString("bt1886"), TF_BT1886);
 }
 
 TEST(Helpers, transferFunctionFromStringNumeric) {
@@ -32,6 +33,7 @@ TEST(Helpers, transferFunctionToString) {
     EXPECT_FALSE(toString(TF_SRGB).empty());
     EXPECT_FALSE(toString(TF_GAMMA22).empty());
     EXPECT_FALSE(toString(TF_FORCED_GAMMA22).empty());
+    EXPECT_FALSE(toString(TF_BT1886).empty());
 }
 
 TEST(Helpers, transferFunctionRoundTrip) {
@@ -40,4 +42,5 @@ TEST(Helpers, transferFunctionRoundTrip) {
     EXPECT_EQ(fromString(toString(TF_SRGB)), TF_SRGB);
     EXPECT_EQ(fromString(toString(TF_GAMMA22)), TF_GAMMA22);
     EXPECT_EQ(fromString(toString(TF_FORCED_GAMMA22)), TF_FORCED_GAMMA22);
+    EXPECT_EQ(fromString(toString(TF_BT1886)), TF_BT1886);
 }


### PR DESCRIPTION
Adds `bt1886` to the values accepted by `sdr_eotf` / `render:cm_sdr_eotf`.

BT.1886 (≈gamma 2.4, defined against the display's actual black level) is the reference EOTF for video mastered for a dim viewing environment, which is what film and TV content expects. Today `sdr_eotf` offers only piecewise sRGB and gamma 2.2, so there is no way to ask for it.

Requested in #12933 (currently unanswered).

### Why this is small

`CM_TRANSFER_FUNCTION_BT1886` is already fully plumbed — both shader directions (`tfBT1886` / `tfInvBT1886`), a name in `tfToString()`, and min/max/reference luminances in `ColorManagement.hpp`. Only `NTransferFunction::eTF` did not expose it. This wires up existing transfer-function maths rather than adding any:

- `TF_BT1886` in the enum
- `{"bt1886", TF_BT1886}` in the `fromString` table
- one `case` in `chooseTF()`
- `DEFAULT_BT1886_IMAGE_DESCRIPTION`, mirroring the sRGB/gamma22 constants (same `SDR_MIN_LUMINANCE, 80, 80`, so the transfer function is the only difference)
- one `else if` in `getCMSettings()` for untagged SDR content
- three test cases

No numeric alias was added. The existing ones (`0`/`1`/`2`/`3`) look like legacy compatibility for the previously int-typed option, and a new value has no legacy to be compatible with — happy to add `4` if you'd prefer consistency.

### Testing

Built clean against `main` (zero compiler diagnostics) and all **398 gtests across 39 suites** pass.

Also validated on hardware, since unit tests only cover string→enum parsing: an 85" Sony HDR TV on an RTX 4090, `cm = "hdr"`, 4K120 10-bit, against a generated test pattern (21-step neutral grey wedge + near-black PLUGE strip at levels 0–24 + smooth ramp). Comparing `srgb` / `gamma22` / `bt1886`, the panel owner reported `bt1886` gave **the most gradation, the least crushed blacks, and the smoothest ramp** — the expected result for film-oriented content on a display in a dim room.

### Note for anyone testing this

`NTransferFunction::fromConfig()` caches the parsed enum in a function-local `static` refreshed only from a `config.reloaded` event, so changing `render:cm_sdr_eotf` at runtime updates the stored string (and `hyprctl getoption` reports the new value) without the renderer picking it up. Set it in the config and reload, or you will see no effect. That is pre-existing behavior and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxJCnu4paJffthUzEfFy3e