### PR TITLE
config: apply render:cm_sdr_eotf changes at runtime

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -657,7 +657,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
                 {.min = 0, .max = 2, .map = OptionMap{{"disable", 0}, {"hdr", 1}, {"hdredid", 2}}}),
         MS<Bool>("render:new_render_scheduling", "enable new render scheduling, which should improve FPS on underpowered devices.", false),
         MS<Int>("render:non_shader_cm", "Enable CM without shader.", 3, {.min = 0, .max = 3, .map = OptionMap{{"disable", 0}, {"always", 1}, {"ondemand", 2}, {"ignore", 3}}}),
-        MS<String>("render:cm_sdr_eotf", "Default transfer function for displaying SDR apps.", "default"),
+        MS<String>("render:cm_sdr_eotf", "Default transfer function for displaying SDR apps.", "default", {.refresh = Supplementary::REFRESH_MONITOR_STATES}),
         MS<Bool>("render:commit_timing_enabled", "Enable commit timing proto. Requires restart", true),
         MS<Bool>("render:icc_vcgt_enabled", "Enable sending VCGT ramps to KMS with ICC profiles", true),
         MS<Bool>("render:use_shader_blur_blend", "Use experimental blurred bg blending", false),

--- a/src/helpers/TransferFunction.cpp
+++ b/src/helpers/TransferFunction.cpp
@@ -33,6 +33,11 @@ eTF NTransferFunction::fromConfig(bool useICC) {
     static auto PSDREOTF = CConfigValue<Config::STRING>("render:cm_sdr_eotf");
     static auto sdrEOTF  = NTransferFunction::fromString(*PSDREOTF);
     static auto P        = Event::bus()->m_events.config.reloaded.listen([]() { sdrEOTF = NTransferFunction::fromString(*PSDREOTF); });
+    // Also refresh on a prop refresh, not just a full reload: a runtime config
+    // change (hyprctl / the Lua config API) does not emit config.reloaded, so
+    // without this the cached enum keeps its startup value while the stored
+    // string reports the new one.
+    static auto P2 = Event::bus()->m_events.config.props_refreshed.listen([](const bool) { sdrEOTF = NTransferFunction::fromString(*PSDREOTF); });
 
     return sdrEOTF;
 }


### PR DESCRIPTION
`render:cm_sdr_eotf` cannot be changed at runtime. Worse, it reports success: the stored string updates and `hyprctl getoption` returns the new value, while rendering keeps using whatever was parsed at startup. There is no warning and nothing in the log, so it presents as "this option does nothing".

### Cause

Two things have to line up, and neither does.

`fromConfig()` caches the parsed enum in a function-local `static`, refreshed only from `config.reloaded`:

```cpp
static auto sdrEOTF = NTransferFunction::fromString(*PSDREOTF);
static auto P       = Event::bus()->m_events.config.reloaded.listen([]() { sdrEOTF = ...; });
```

A runtime config change does not emit `config.reloaded` — that comes from the reload path in `config/lua/ConfigManager.cpp`. Runtime changes instead go through the prop refresher, which emits `config.props_refreshed`.

But the refresher only runs for values that declare refresh props, and `render:cm_sdr_eotf` declares none:

```cpp
MS<String>("render:cm_sdr_eotf", "Default transfer function for displaying SDR apps.", "default"),
```

So nothing trips the refresher, no event fires, and the cache is never invalidated.

### Fix

- Declare `REFRESH_MONITOR_STATES` on the value. That bucket calls `monitorRuleMgr()->scheduleReload()`, which re-runs `applyCMType()` to re-derive the monitor's image description — needed because `chooseTF()` feeds the output transfer function for the non-HDR CM types.
- Refresh the cached enum from `props_refreshed` as well as `config.reloaded`, matching the existing listeners in `Aurora.cpp`, `Water.cpp`, `Drops.cpp` and `HeatShimmer.cpp`.

The cache is kept deliberately. `fromConfig()` is called per-surface per-frame from `getCMSettings()`, so re-parsing the string on every call would put an `unordered_map` lookup in the render path; the bug is that the cache is never invalidated, not that it exists.

`REFRESH_MONITOR_STATES` is the part I'd most welcome a second opinion on — it also recalculates layouts and workspace placement, which is more than an EOTF change strictly needs. I picked it because a monitor's colour state is monitor state and it is the only bucket that re-applies monitor rules. Happy to narrow it, or to add a dedicated bit, if you'd prefer.

### Testing

Builds clean against `main` (zero compiler diagnostics); all 398 gtests across 39 suites pass.

Verified on hardware, before and after, on the same machine — an HDR TV at `cm = "hdr"`, 4K120 10-bit, running a local build of `main`:

```
hyprctl eval 'hl.config({ render = { cm_sdr_eotf = "srgb" } })'
```

- **Before:** no visible change for any value. Setting it from the config plus `hyprctl reload` did work, which is what isolated the caching to the runtime path.
- **After:** the same runtime command changes the rendering immediately, with no reload.

The root cause was also confirmed independently: `general:gaps_in`, which declares `REFRESH_LAYOUTS`, does take effect on a runtime `hl.config()` — window geometry moved and reverted — establishing that the refresher works and that the missing refresh declaration is what excluded this value from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxJCnu4paJffthUzEfFy3e