### PR TITLE
hyprpm: make hyprwayland-scanner runtime dep explicit

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -149,7 +149,9 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
     }
 
     if (!hasDeps()) {
-        std::println(stderr, "\n{}", failureString("Could not clone the plugin repository. Dependencies not satisfied. Hyprpm requires: cmake, cpio, hyprwayland-scanner, pkg-config, git, g++, gcc"));
+        std::println(
+            stderr, "\n{}",
+            failureString("Could not clone the plugin repository. Dependencies not satisfied. Hyprpm requires: cmake, cpio, hyprwayland-scanner, pkg-config, git, g++, gcc"));
         return false;
     }
 

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -149,7 +149,7 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
     }
 
     if (!hasDeps()) {
-        std::println(stderr, "\n{}", failureString("Could not clone the plugin repository. Dependencies not satisfied. Hyprpm requires: cmake, cpio, pkg-config, git, g++, gcc"));
+        std::println(stderr, "\n{}", failureString("Could not clone the plugin repository. Dependencies not satisfied. Hyprpm requires: cmake, cpio, hyprwayland-scanner, pkg-config, git, g++, gcc"));
         return false;
     }
 
@@ -493,7 +493,7 @@ bool CPluginManager::updateHeaders(bool force) {
     const auto HLVER = getHyprlandVersion(false);
 
     if (!hasDeps()) {
-        std::println("\n{}", failureString("Could not update. Dependencies not satisfied. Hyprpm requires: cmake, cpio, pkg-config, git, g++, gcc"));
+        std::println("\n{}", failureString("Could not update. Dependencies not satisfied. Hyprpm requires: cmake, cpio, hyprwayland-scanner, pkg-config, git, g++, gcc"));
         return false;
     }
 
@@ -1123,7 +1123,7 @@ bool CPluginManager::hasDeps() {
         return true; // dep check not needed if we are on nix
 
     bool                     hasAllDeps = true;
-    std::vector<std::string> deps       = {"cpio", "cmake", "pkg-config", "g++", "gcc", "git"};
+    std::vector<std::string> deps       = {"cmake", "cpio", "hyprwayland-scanner", "pkg-config", "g++", "gcc", "git"};
 
     for (auto const& d : deps) {
         if (!execAndGet(std::format("command -v {}", d)).contains("/")) {


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Currently, running `hyprpm update` without `hyprwayland-scanner` installed just confusingly fails:
```
! configuring Hyprland
✔ configured Hyprland
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╍━━━━━━━━━  4 / 5  Installing sourcesterminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot remove all: Permission denied [/run/user/1000/hyprpm/hyprland-alba4k] [/run/user/1000/hyprpm/hyprland-alba4k/build/CMakeFiles/Progress/count.txt]
fish: Job 1, 'hyprpm update --force' terminated by signal SIGABRT (Abort)
```
This PR adresses that by having it check if it exists (which is also done for cmake, cpio, pkg-config, git, g++, gcc)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

