### PR TITLE
allow for negative scale on scroll move gesture

### DIFF
--- a/hyprtester/src/tests/main/gestures.cpp
+++ b/hyprtester/src/tests/main/gestures.cpp
@@ -94,6 +94,27 @@ TEST_CASE(live_gesture_callbacks) {
     )"));
 
     OK(evalLua(R"(
+        __liveGesture.negative_scale_delta = nil
+
+        hl.gesture({
+            fingers = 9,
+            direction = 'left',
+            action = {
+                update = function(e)
+                    __liveGesture.negative_scale_delta = e.delta.x
+                end,
+            },
+            scale = -1,
+        })
+
+        hl.plugin.test.gesture('left', 9)
+
+        if __liveGesture.negative_scale_delta ~= 300 then
+            error('unexpected negatively scaled delta: ' .. tostring(__liveGesture.negative_scale_delta))
+        end
+    )"));
+
+    OK(evalLua(R"(
         __liveGesture.pinch = { start = 0, update = 0, finish = 0, last_scale = 0, last_rotation = 0 }
 
         local function expect_eq(actual, expected, name)
@@ -180,6 +201,7 @@ TEST_CASE(live_gesture_callbacks) {
 
     EXPECT_CONTAINS(evalLua("hl.gesture({ fingers = 8, direction = 'up', action = { start = 1 } })"), "action.start must be a function");
     EXPECT_CONTAINS(evalLua("hl.gesture({ fingers = 8, direction = 'up', action = {} })"), "must define at least one of start, update, end, or finish");
+    EXPECT_CONTAINS(evalLua("hl.gesture({ fingers = 8, direction = 'up', action = function() end, scale = 0 })"), "value must be between -10 and -0.1 or between 0.1 and 10");
 }
 
 // TODO: decompose this into multiple test cases

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -893,13 +893,17 @@ static int hlGesture(lua_State* L) {
     float deltaScale = 1.F;
     lua_getfield(L, 1, "scale");
     if (!lua_isnil(L, -1)) {
-        CLuaConfigFloat scaleParser(1.F, 0.1F, 10.F);
+        CLuaConfigFloat scaleParser(1.F, -10.F, 10.F);
         auto            scaleErr = scaleParser.parse(L);
         if (scaleErr.errorCode != PARSE_ERROR_OK) {
             lua_pop(L, 1);
             return Internal::configError(L, std::format("hl.gesture: field \"scale\": {}", scaleErr.message));
         }
         deltaScale = scaleParser.parsed();
+        if (deltaScale > -0.1F && deltaScale < 0.1F) {
+            lua_pop(L, 1);
+            return Internal::configError(L, "hl.gesture: field \"scale\": value must be between -10 and -0.1 or between 0.1 and 10");
+        }
     }
     lua_pop(L, 1);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Allows for a negative scale in the gesture scroll. this will allow to invert the scrolling by passing a negative scale which today is restricted to 0.1 to 10.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is a follow-up on the rejected https://github.com/hyprwm/Hyprland/pull/16027 which was a more complicated solution for something that we could already do with a negative scale.

This has been AI-assisted but I manually made changes I thought necessary and made sure the test added didn't break any existing test. It's a simple change anyway.

#### Is it ready for merging, or does it need work?

Ready for merging
