### PR TITLE
screenshare: render no_screen_share views as if they did not exist

### DIFF
--- a/src/desktop/state/Fadeout.cpp
+++ b/src/desktop/state/Fadeout.cpp
@@ -14,3 +14,7 @@ PHLWORKSPACEREF IFadeout::workspace() const {
 SFadeoutRenderEffects IFadeout::effects() const {
     return m_effects;
 }
+
+bool IFadeout::noScreenShare() const {
+    return m_noScreenShare;
+}

--- a/src/desktop/state/Fadeout.hpp
+++ b/src/desktop/state/Fadeout.hpp
@@ -58,6 +58,7 @@ namespace Desktop {
         virtual float                 alpha() const     = 0;
         virtual bool                  done() const      = 0;
         virtual SFadeoutRenderEffects effects() const;
+        bool                          noScreenShare() const;
 
       protected:
         IFadeout() = default;
@@ -65,5 +66,6 @@ namespace Desktop {
         SP<Render::IFramebuffer> m_framebuffer;
         PHLWORKSPACEREF          m_workspace;
         SFadeoutRenderEffects    m_effects;
+        bool                     m_noScreenShare = false; // source view had the no_screen_share rule
     };
 }

--- a/src/desktop/state/LayerFadeout.cpp
+++ b/src/desktop/state/LayerFadeout.cpp
@@ -55,6 +55,8 @@ SP<CLayerFadeout> CLayerFadeout::create(PHLLS layer, SP<Render::IFramebuffer> sn
     fadeout->m_geometry    = layer->m_geometry;
     fadeout->m_zIndex      = layerZIndex(layer);
 
+    fadeout->m_noScreenShare = layer->m_ruleApplicator->noScreenShare().valueOrDefault();
+
     static auto PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
     if (*PDIMAROUND && layer->m_ruleApplicator->dimAround().valueOrDefault())
         fadeout->m_effects.dimAroundAlpha = *PDIMAROUND;

--- a/src/desktop/state/PopupFadeout.cpp
+++ b/src/desktop/state/PopupFadeout.cpp
@@ -1,6 +1,7 @@
 #include "PopupFadeout.hpp"
 #include "../view/LayerSurface.hpp"
 #include "../view/Popup.hpp"
+#include "../view/window/Window.hpp"
 #include "../../config/ConfigValue.hpp"
 #include "../../config/shared/animation/AnimationTree.hpp"
 #include "../../animation/AnimationManager.hpp"
@@ -43,6 +44,11 @@ SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffe
     auto fadeout           = SP<CPopupFadeout>(new CPopupFadeout());
     fadeout->m_monitor     = MONITOR;
     fadeout->m_framebuffer = snapshot;
+
+    if (const auto WINDOW = popup->windowOwner(); WINDOW)
+        fadeout->m_noScreenShare = WINDOW->m_ruleApplicator->noScreenShare().valueOrDefault();
+    else if (const auto LAYER = popup->layerOwner(); LAYER)
+        fadeout->m_noScreenShare = LAYER->m_ruleApplicator->noScreenShare().valueOrDefault();
 
     static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
     if (shouldBlurPopup()) {

--- a/src/desktop/state/WindowFadeout.cpp
+++ b/src/desktop/state/WindowFadeout.cpp
@@ -71,6 +71,7 @@ SP<CWindowFadeout> CWindowFadeout::create(PHLWINDOW window, SP<Render::IFramebuf
     fadeout->m_roundingPower = window->presentation().roundingPower();
     fadeout->m_blur          = shouldBlurWindow(window);
     fadeout->m_blurXray      = window->m_ruleApplicator->xray().valueOr(false);
+    fadeout->m_noScreenShare = window->m_ruleApplicator->noScreenShare().valueOrDefault();
 
     static auto PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
     if (*PDIMAROUND && window->m_ruleApplicator->dimAround().valueOrDefault())

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -390,6 +390,10 @@ PHLLS CPopup::layerOwner() const {
     return m_layerOwner.lock();
 }
 
+PHLWINDOW CPopup::windowOwner() const {
+    return m_windowOwner.lock();
+}
+
 Vector2D CPopup::coordsRelativeToParent() const {
     Vector2D offset;
 

--- a/src/desktop/view/Popup.hpp
+++ b/src/desktop/view/Popup.hpp
@@ -51,6 +51,7 @@ namespace Desktop::View {
 
         SP<Desktop::View::CWLSurface>                             getT1Owner() const;
         PHLLS                                                     layerOwner() const;
+        PHLWINDOW                                                 windowOwner() const;
         Vector2D                                                  coordsRelativeToParent() const;
         Vector2D                                                  coordsGlobal() const;
         PHLMONITOR                                                getMonitor() const;

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -184,7 +184,50 @@ void CScreenshareFrame::renderMonitor() {
 
     const auto PMONITOR = m_session->monitor();
 
-    auto       TEXTURE = g_pHyprRenderer->m_renderData.pMonitor->resources()->getMirrorTexture();
+    g_pHyprRenderer->m_renderData.fbSize = m_bufferSize;
+    g_pHyprRenderer->setProjectionType(Render::RPT_EXPORT);
+    g_pHyprRenderer->m_renderData.transformDamage = false;
+    g_pHyprRenderer->m_renderData.noSimplify      = true;
+    g_pHyprRenderer->setViewport(0, 0, m_bufferSize.x, m_bufferSize.y);
+
+    // the mirror texture has views with the no_screen_share rule baked into it, so if any of them would be
+    // visible, re-render the whole scene instead, skipping them as if they didn't exist
+    const auto ANY_NO_SCREEN_SHARE_VIEWS = [&PMONITOR] {
+        for (auto const& l : Desktop::layerState()->layers()) {
+            if (l->m_monitor != PMONITOR || !l->m_ruleApplicator->noScreenShare().valueOrDefault())
+                continue;
+
+            if UNLIKELY (!l->mapped() || !l->acceptsInput() || !l->alphaNonZero())
+                continue;
+
+            return true;
+        }
+
+        for (auto const& w : Desktop::windowState()->windows()) {
+            if (!w->m_ruleApplicator->noScreenShare().valueOrDefault() || w->isHidden() || !g_pHyprRenderer->shouldRenderWindow(w, PMONITOR))
+                continue;
+
+            return true;
+        }
+
+        return false;
+    };
+
+    // mirrored monitors can't re-render their scene, they fall back to blanking no_screen_share views out
+    if (!PMONITOR->isMirror() && ANY_NO_SCREEN_SHARE_VIEWS())
+        renderMonitorScene(PMONITOR);
+    else
+        renderMonitorMirror(PMONITOR);
+
+    if (m_overlayCursor) {
+        CRegion  fakeDamage = {0, 0, m_bufferSize.x, m_bufferSize.y};
+        Vector2D cursorPos  = g_pInputManager->getMouseCoordsInternal() - PMONITOR->m_position - m_session->m_captureBox.pos() / PMONITOR->m_scale;
+        Pointer::mgr()->renderSoftwareCursorsFor(PMONITOR, Time::steadyNow(), fakeDamage, cursorPos, true);
+    }
+}
+
+void CScreenshareFrame::renderMonitorMirror(PHLMONITOR PMONITOR) {
+    auto TEXTURE = g_pHyprRenderer->m_renderData.pMonitor->resources()->getMirrorTexture();
     if (!TEXTURE) {
         LOGM(Log::ERR, "Invalid source texture");
         return;
@@ -200,12 +243,7 @@ void CScreenshareFrame::renderMonitor() {
         Log::logger->log(Log::TRACE, "CM: screenshot renderMonitor {} -> {}", TEXTURE->m_imageDescription->value(),
                          g_pHyprRenderer->m_renderData.currentFB->imageDescription()->value());
 
-    const bool IS_CM_AWARE               = PROTO::colorManagement && PROTO::colorManagement->isClientCMAware(m_session->m_client);
-    g_pHyprRenderer->m_renderData.fbSize = m_bufferSize;
-    g_pHyprRenderer->setProjectionType(Render::RPT_EXPORT);
-    g_pHyprRenderer->m_renderData.transformDamage = false;
-    g_pHyprRenderer->m_renderData.noSimplify      = true;
-    g_pHyprRenderer->setViewport(0, 0, m_bufferSize.x, m_bufferSize.y);
+    const bool IS_CM_AWARE = PROTO::colorManagement && PROTO::colorManagement->isClientCMAware(m_session->m_client);
 
     // render monitor texture
     CBox       monbox = CBox{{}, PMONITOR->m_transformedSize}.translate(-m_session->m_captureBox.pos());
@@ -222,7 +260,10 @@ void CScreenshareFrame::renderMonitor() {
         {0, 0, m_bufferSize.x, m_bufferSize.y});
     g_pHyprRenderer->m_renderData.renderModif.enabled = OLD;
 
-    // render black boxes for noscreenshare
+    // re-rendering the scene isn't possible for mirrored monitors, blank no_screen_share views out instead
+    if (!PMONITOR->isMirror())
+        return;
+
     auto hidePopups = [&](Vector2D popupBaseOffset) {
         return [&, popupBaseOffset](WP<Desktop::View::CPopup> popup, void*) {
             if (!popup->wlSurface() || !popup->wlSurface()->resource() || !popup->mapped() || !popup->acceptsInput() || !popup->alphaNonZero())
@@ -310,12 +351,34 @@ void CScreenshareFrame::renderMonitor() {
 
         w->popupHead()->breadthfirst(hidePopups(popupBaseOffset), nullptr);
     }
+}
 
-    if (m_overlayCursor) {
-        CRegion  fakeDamage = {0, 0, m_bufferSize.x, m_bufferSize.y};
-        Vector2D cursorPos  = g_pInputManager->getMouseCoordsInternal() - PMONITOR->m_position - m_session->m_captureBox.pos() / PMONITOR->m_scale;
-        Pointer::mgr()->renderSoftwareCursorsFor(PMONITOR, Time::steadyNow(), fakeDamage, cursorPos, true);
+void CScreenshareFrame::renderMonitorScene(PHLMONITOR PMONITOR) {
+    const auto NOW       = Time::steadyNow();
+    const CBox RENDERBOX = {{}, PMONITOR->m_transformedSize};
+
+    // for region captures, shift the scene so that the capture box starts at (0, 0)
+    const bool NEEDS_TRANSLATE = m_session->m_captureBox.pos() != Vector2D();
+    if (NEEDS_TRANSLATE) {
+        Render::SRenderModifData modifs;
+        modifs.modifs.emplace_back(Render::SRenderModifData::RMOD_TYPE_TRANSLATE, -m_session->m_captureBox.pos());
+        g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{modifs}));
     }
+
+    g_pHyprRenderer->startRenderPass();
+
+    g_pHyprRenderer->m_skipNoScreenShare     = true;
+    g_pHyprRenderer->m_bBlockSurfaceFeedback = true; // the monitor render already sends feedback, avoid spamming surfaces
+
+    g_pHyprRenderer->renderWorkspace(PMONITOR, PMONITOR->m_activeWorkspace, NOW, RENDERBOX);
+    g_pHyprRenderer->renderLockscreen(PMONITOR, NOW, RENDERBOX);
+    g_pHyprRenderer->renderIME(PMONITOR, NOW, RENDERBOX);
+
+    g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
+    g_pHyprRenderer->m_skipNoScreenShare     = false;
+
+    if (NEEDS_TRANSLATE)
+        g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{Render::SRenderModifData{}}));
 }
 
 void CScreenshareFrame::renderWindow() {

--- a/src/managers/screenshare/ScreenshareManager.hpp
+++ b/src/managers/screenshare/ScreenshareManager.hpp
@@ -185,7 +185,8 @@ namespace Screenshare {
 
         void render();
         void renderMonitor();
-        void renderMonitorRegion();
+        void renderMonitorMirror(PHLMONITOR monitor);
+        void renderMonitorScene(PHLMONITOR monitor);
         void renderWindow();
 
         void storeTempFB();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -559,6 +559,9 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     if (!pWindow->mapped())
         return;
 
+    if (m_skipNoScreenShare && pWindow->m_ruleApplicator->noScreenShare().valueOrDefault())
+        return;
+
     TRACY_GPU_ZONE("RenderWindow");
 
     const auto PWORKSPACE = pWindow->m_workspace;
@@ -937,6 +940,9 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
         return;
 
     if (!pLayer->mapped() || !pLayer->acceptsInput() || !pLayer->alphaNonZero())
+        return;
+
+    if (m_skipNoScreenShare && pLayer->m_ruleApplicator->noScreenShare().valueOrDefault())
         return;
 
     // skip rendering based on abovelock rule and make sure to not render abovelock layers twice
@@ -3298,6 +3304,9 @@ void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane pl
             continue;
 
         if (fadeout->workspace() && fadeout->workspace() != workspace)
+            continue;
+
+        if (m_skipNoScreenShare && fadeout->noScreenShare())
             continue;
 
         fadeouts.emplace_back(fadeout);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -112,6 +112,7 @@ namespace Render {
         NColorManagement::PImageDescription workBufferImageDescription();
         bool                                m_bBlockSurfaceFeedback = false;
         bool                                m_bRenderingSnapshot    = false;
+        bool                                m_skipNoScreenShare     = false; // skip views with the no_screen_share rule, as if they didn't exist
         PHLMONITORREF                       m_mostHzMonitor;
         bool                                m_directScanoutBlocked = false;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Changes the behavior of the `no_screen_share` window/layer rule during
screencopy. Previously, windows and layers matching the rule were blanked
out with solid black boxes drawn over the monitor mirror texture. This PR
instead re-renders the monitor scene into the screencopy buffer while
skipping those views entirely, so the content behind them is shown — as if
the view did not exist.

Because the mirror texture already has the hidden views baked into it, it
cannot be used when any `no_screen_share` view is visible. In that case the
scene is re-rendered (`renderWorkspace` + `renderLockscreen` + `renderIME`)
with a new `m_skipNoScreenShare` renderer flag that makes `renderWindow`,
`renderLayer` and `renderFadeouts` skip matching views.

Implementation details:
- The fast mirror-texture path is kept when no `no_screen_share` view is
  present, so there is no overhead in the common case.
- Region captures shift the re-rendered scene via a
  `CRendererHintsPassElement` translate modif so the capture box starts at
  (0, 0).
- Surface presentation feedback is blocked during the re-render to avoid
  double feedback (the real monitor render already sends it).
- Fadeout snapshots of `no_screen_share` views are skipped too, so closing
  such a window mid-share no longer leaks its content through the fade-out.
  The flag is recorded on the fadeout at creation (window/layer/popup).
- Adds a `CPopup::windowOwner()` accessor to resolve the owning window for
  popup fadeouts.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Mirrored monitors cannot re-render their own scene, so they keep the
  previous black-box fallback. No change in behavior there.

#### Is it ready for merging, or does it need work?

Ready for review. Builds cleanly and all existing unit tests pass.