### PR TITLE
core/fullscreen: add missing early return when compensating for incorrectly made isFullscreen() call

### DIFF
--- a/src/managers/fullscreen/FullscreenController.cpp
+++ b/src/managers/fullscreen/FullscreenController.cpp
@@ -34,7 +34,7 @@ bool CFullscreenController::isFullscreen(const PHLWINDOW window, const std::opti
 
     if (mode.value_or(FSMODE_FULLSCREEN) == FSMODE_NONE) {
         Log::logger->log(Log::ERR, "Passed mode = FSMODE_NONE into isFullscreen(). Negating the result instead");
-        !isFullscreen(window, std::nullopt, covering);
+        return !isFullscreen(window, std::nullopt, covering);
     }
 
     /* Error Correction - try once */


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fix oopsie (return after negating)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Sorry about that


#### Is it ready for merging, or does it need work?

Yes

