### PR TITLE
Core/Fullscreen: Improve `syncFullscreenTargets()`, account for an edge case, misc. improvements

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -30,6 +30,12 @@ CScrollingFullscreenHandler::CScrollingFullscreenHandler(Layout::Tiled::CScrolli
 
 CScrollingFullscreenHandler::~CScrollingFullscreenHandler() {
 
+
+    // sift through any expired entries in case the following loop fucks us - read CScrollingFullscreenHandler::removeFsTarget()
+    std::erase_if(m_fsTargets, [&](const auto& it){
+        return !it.first;
+    });
+
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
         const auto NEXT = std::next(it); // save next before removeFsTarget invalidates it
         removeFsTarget(it->first.lock());
@@ -368,8 +374,7 @@ void CScrollingFullscreenHandler::setNoMembersAboveFullscreen(const std::optiona
     const auto LAYOUT_TILED_COVERING_FS_WINDOW_TARGET = coveringFsTarget.value_or(getFullscreen(true));
     const auto LAYOUT_TILED_COVERING_FS_WINDOW        = LAYOUT_TILED_COVERING_FS_WINDOW_TARGET ? LAYOUT_TILED_COVERING_FS_WINDOW_TARGET->window() : nullptr;
 
-    const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW =
-        m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow ? m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock() : nullptr;
+    const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
     const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW_FS_MODE = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindowMode;
 
     if (!COVERING_FS_WINDOW && LAYOUT_TILED_COVERING_FS_WINDOW) {
@@ -446,35 +451,42 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
     if (m_syncingFullscreenTargets)
         return;
 
+
     m_syncingFullscreenTargets = true;
     Hyprutils::Utils::CScopeGuard guard([this] { m_syncingFullscreenTargets = false; });
 
-    // to prevent a rehash
-    std::vector<std::pair<WP<Layout::ITarget>, SFullscreenMode>> toInsert;
+
+
+    const auto removeTargetFromList = [&](auto& it){
+            const auto NEXT = std::next(it);
+            m_fsTargets.erase(it);
+            it = NEXT;
+    };
+
+    const auto removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {
+            const auto NEXT = std::next(it);
+            removeFsTarget(TARGET, true);
+            return NEXT;
+    };
+
+
+    decltype(m_fsTargets) keep = {};
+    keep.reserve(m_fsTargets.size());
 
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
 
-        // Somehow happens sometimes and causes WP<> to segfault
-        if (m_fsTargets.empty())
-            return;
-
-        // Rigorously check if WP<> is valid as WP<> randomly segfaults sometimes without this
-        const auto TARGET = !it->first.expired() && it->first.valid() && it->first ? it->first.lock() : nullptr;
-
+        const auto TARGET = it->first.lock();
+        
+        // expired/invalid entries. We need not perform any post-removal operations on these
         if (!TARGET || !TARGET->window() || TARGET->space() != getSpace() || !m_scrollingAlgorithm->dataFor(TARGET, true)) {
-            // simply erase from list. no need to re-set its prev col width as the TARGET is 'invalid'
-            const auto NEXT = std::next(it);
-            removeFsTarget(TARGET, true);
-            it = NEXT;
+            removeTargetFromList(it);
             continue;
         }
 
         const auto TARGET_FS_MODES = getFullscreenModes(TARGET);
 
         if (!isFullscreen(TARGET, std::nullopt, std::nullopt) && TARGET_FS_MODES.client == FSMODE_NONE) {
-            const auto NEXT = std::next(it);
-            removeFsTarget(TARGET, true);
-            it = NEXT;
+            it = removeFsTargetAndreturnNextIter(it, TARGET);
             continue;
         }
 
@@ -485,49 +497,62 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
                 const auto COL_DATA = m_scrollingAlgorithm->dataFor(TARGET, true)->column;
                 // use TARGET_FS_MODES.internal != FSMODE_NONE here because isFullscreen() would catch that target isn't alone in col and return false
                 if (COL_DATA && TARGET_FS_MODES.internal != FSMODE_NONE && COL_DATA->targetDatas.size() != 1) {
-                    // Empty the list now so the unFS operation has an updated tracked FS target list it can check
-                    for (const auto& e : toInsert) {
-                        m_fsTargets.emplace(e.first, e.second);
-                    }
-                    toInsert.clear();
 
                     controller()->setFullscreenMode(TARGET_WINDOW, FSMODE_NONE, std::nullopt, true);
                     if (getFullscreenModes(TARGET).internal != FSMODE_NONE)
                         removeFsTarget(TARGET, true);
+                    // we start from the beginning
                     it = m_fsTargets.begin();
+                    keep.clear();
                     continue;
                 }
             }
         }
 
         // If ITarget's underlying type is CWindowGroupTarget; only store the current window, NOT the whole group
-        if (TARGET->type() == Layout::TARGET_TYPE_GROUP || (TARGET->window()->grouping().group() && TARGET->window()->grouping().group()->current()->windowTarget() != TARGET)) {
+        if (TARGET->type() == Layout::TARGET_TYPE_GROUP) {
             LOG(Log::WARN, "Handler tracked a window group. This should have never happened. Recovering...");
-
+            const SFullscreenMode MODE = SFullscreenMode{.internal = it->second.mode.internal, .client = it->second.mode.client};
+            // gets the current window's target in the window group
             const auto WINDOWTARGET = TARGET->window()->windowTarget();
-            const auto NEXT         = std::next(it);
-            removeFsTarget(TARGET, true);
-            it = NEXT;
-            if (WINDOWTARGET)
-                toInsert.emplace_back(WINDOWTARGET, TARGET_FS_MODES);
+
+            if (!WINDOWTARGET) {
+                removeTargetFromList(it);
+                continue;
+            }
+            
+            if (!isFullscreen(WINDOWTARGET) && MODE.client == FSMODE_NONE) {
+                it = removeFsTargetAndreturnNextIter(it, TARGET);
+                continue;                
+            }
+            // do post-remove-ops on the window group target as that's what algorithms store as a target, then save only the current window of the group
+            it = removeFsTargetAndreturnNextIter(it, TARGET);
+            keep.emplace(WINDOWTARGET, MODE);
             continue;
         }
 
         if (isFullscreen(TARGET, std::nullopt, std::nullopt)) {
             m_scrollingAlgorithm->dataFor(TARGET, true)->column->setColumnWidth((TARGET_FS_MODES.internal == FSMODE_FULLSCREEN ? fullscreenColumnWidth() : 1.F));
+            keep.emplace(it->first, it->second);
             ++it;
             continue;
         }
-
+        keep.emplace(it->first, it->second);
         ++it;
     }
 
-    for (const auto& e : toInsert) {
-        m_fsTargets.emplace(e.first, e.second);
-    }
+    m_fsTargets.swap(keep);
+
 }
 
 void CScrollingFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, const bool recursionGuard) {
+
+    // This should not be done because if there are 2 expired elements in the list, this will remove one of them with little guarantee as to which and the caller is preumsably looking forward and getting the next
+    // iterator in the list; which would corrupt the map if that next iter is also nullptr. We let this go through on the offchance that there is Ǝ! expired entries or the erase hits the right expired target but it is
+    // non-deterministic
+    if (!target)
+        Log::logger->log(Log::CRIT, "IFullscreenHandler::removeFsTarget() called with target = nullptr. This is possibly non-deterministic and should NOT happen. This is a bug and should be reported!");
+
 
     const auto ITR = m_fsTargets.find(target);
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -470,8 +470,9 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
     };
 
 
-    decltype(m_fsTargets) keep = {};
-    keep.reserve(m_fsTargets.size());
+    // to prevent a rehash
+    std::vector<std::pair<WP<Layout::ITarget>, SFullscreenMode>> toInsert;
+
 
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
 
@@ -497,13 +498,15 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
                 const auto COL_DATA = m_scrollingAlgorithm->dataFor(TARGET, true)->column;
                 // use TARGET_FS_MODES.internal != FSMODE_NONE here because isFullscreen() would catch that target isn't alone in col and return false
                 if (COL_DATA && TARGET_FS_MODES.internal != FSMODE_NONE && COL_DATA->targetDatas.size() != 1) {
-
+                    // Empty the list now so the unFS operation has an updated tracked FS target list it can check
+                    for (const auto& e : toInsert) {
+                        m_fsTargets.emplace(e.first, e.second);
+                    }
+                    toInsert.clear();
                     controller()->setFullscreenMode(TARGET_WINDOW, FSMODE_NONE, std::nullopt, true);
                     if (getFullscreenModes(TARGET).internal != FSMODE_NONE)
                         removeFsTarget(TARGET, true);
-                    // we start from the beginning
                     it = m_fsTargets.begin();
-                    keep.clear();
                     continue;
                 }
             }
@@ -527,22 +530,21 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
             }
             // do post-remove-ops on the window group target as that's what algorithms store as a target, then save only the current window of the group
             it = removeFsTargetAndreturnNextIter(it, TARGET);
-            keep.emplace(WINDOWTARGET, MODE);
+            toInsert.emplace_back(WINDOWTARGET, MODE);
             continue;
         }
 
         if (isFullscreen(TARGET, std::nullopt, std::nullopt)) {
             m_scrollingAlgorithm->dataFor(TARGET, true)->column->setColumnWidth((TARGET_FS_MODES.internal == FSMODE_FULLSCREEN ? fullscreenColumnWidth() : 1.F));
-            keep.emplace(it->first, it->second);
             ++it;
             continue;
         }
-        keep.emplace(it->first, it->second);
         ++it;
     }
 
-    m_fsTargets.swap(keep);
-
+    for (const auto& e : toInsert) {
+        m_fsTargets.emplace(e.first, e.second);
+    }
 }
 
 void CScrollingFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, const bool recursionGuard) {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -30,11 +30,8 @@ CScrollingFullscreenHandler::CScrollingFullscreenHandler(Layout::Tiled::CScrolli
 
 CScrollingFullscreenHandler::~CScrollingFullscreenHandler() {
 
-
     // sift through any expired entries in case the following loop fucks us - read CScrollingFullscreenHandler::removeFsTarget()
-    std::erase_if(m_fsTargets, [&](const auto& it){
-        return !it.first;
-    });
+    std::erase_if(m_fsTargets, [&](const auto& it) { return !it.first; });
 
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
         const auto NEXT = std::next(it); // save next before removeFsTarget invalidates it
@@ -374,7 +371,7 @@ void CScrollingFullscreenHandler::setNoMembersAboveFullscreen(const std::optiona
     const auto LAYOUT_TILED_COVERING_FS_WINDOW_TARGET = coveringFsTarget.value_or(getFullscreen(true));
     const auto LAYOUT_TILED_COVERING_FS_WINDOW        = LAYOUT_TILED_COVERING_FS_WINDOW_TARGET ? LAYOUT_TILED_COVERING_FS_WINDOW_TARGET->window() : nullptr;
 
-    const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
+    const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW         = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
     const auto LAST_SCROLL_HANDLED_TILED_FS_WINDOW_FS_MODE = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindowMode;
 
     if (!COVERING_FS_WINDOW && LAYOUT_TILED_COVERING_FS_WINDOW) {
@@ -451,31 +448,24 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
     if (m_syncingFullscreenTargets)
         return;
 
-
     m_syncingFullscreenTargets = true;
     Hyprutils::Utils::CScopeGuard guard([this] { m_syncingFullscreenTargets = false; });
 
+    const auto                    removeTargetFromList = [&](auto& it) { it = m_fsTargets.erase(it); };
 
-
-    const auto removeTargetFromList = [&](auto& it){
-            it = m_fsTargets.erase(it);
+    const auto                    removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {
+        const auto NEXT = std::next(it);
+        removeFsTarget(TARGET, true);
+        return NEXT;
     };
-
-    const auto removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {
-            const auto NEXT = std::next(it);
-            removeFsTarget(TARGET, true);
-            return NEXT;
-    };
-
 
     // to prevent a rehash
     std::vector<std::pair<WP<Layout::ITarget>, SFullscreenMode>> toInsert;
 
-
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
 
         const auto TARGET = it->first.lock();
-        
+
         // expired/invalid entries. We need not perform any post-removal operations on these
         if (!TARGET || !TARGET->window() || TARGET->space() != getSpace() || !m_scrollingAlgorithm->dataFor(TARGET, true)) {
             removeTargetFromList(it);
@@ -521,10 +511,10 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
                 removeTargetFromList(it);
                 continue;
             }
-            
+
             if (!isFullscreen(WINDOWTARGET) && MODE.client == FSMODE_NONE) {
                 it = removeFsTargetAndreturnNextIter(it, TARGET);
-                continue;                
+                continue;
             }
             // do post-remove-ops on the window group target as that's what algorithms store as a target, then save only the current window of the group
             it = removeFsTargetAndreturnNextIter(it, TARGET);
@@ -551,8 +541,9 @@ void CScrollingFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, con
     // iterator in the list; which would corrupt the map if that next iter is also nullptr. We let this go through on the offchance that there is Ǝ! expired entries or the erase hits the right expired target but it is
     // non-deterministic
     if (!target)
-        Log::logger->log(Log::CRIT, "IFullscreenHandler::removeFsTarget() called with target = nullptr. This is possibly non-deterministic and should NOT happen. This is a bug and should be reported!");
-
+        Log::logger->log(
+            Log::CRIT,
+            "IFullscreenHandler::removeFsTarget() called with target = nullptr. This is possibly non-deterministic and should NOT happen. This is a bug and should be reported!");
 
     const auto ITR = m_fsTargets.find(target);
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -458,9 +458,7 @@ void CScrollingFullscreenHandler::syncFullscreenTargets() {
 
 
     const auto removeTargetFromList = [&](auto& it){
-            const auto NEXT = std::next(it);
-            m_fsTargets.erase(it);
-            it = NEXT;
+            it = m_fsTargets.erase(it);
     };
 
     const auto removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {

--- a/src/managers/fullscreen/FullscreenController.cpp
+++ b/src/managers/fullscreen/FullscreenController.cpp
@@ -42,10 +42,9 @@ bool CFullscreenController::isFullscreen(const PHLWINDOW window, const std::opti
         if (!FS_WINDOW || !FS_WINDOW->windowTarget())
             return false;
 
-        const auto FS_TARGET     = FS_HANDLER->getFullscreen(covering);
         const auto INTERNAL_MODE = FS_HANDLER->getFullscreenModes(window->windowTarget()).internal;
 
-        if (FS_TARGET && FS_WINDOW == FS_TARGET->window() && INTERNAL_MODE != FSMODE_NONE && (!mode.has_value() || INTERNAL_MODE == mode.value()))
+        if (INTERNAL_MODE != FSMODE_NONE && (!mode.has_value() || INTERNAL_MODE == mode.value()))
             return true;
         else {
             FS_HANDLER->syncFullscreenTargets();

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -300,22 +300,16 @@ void IFullscreenHandler::setNoMembersAboveFullscreen(const std::optional<SP<Layo
 void IFullscreenHandler::syncFullscreenTargets() {
     // Mode checking logic is the same as getFullscreenModes() - keep it in sync
 
-
-
-    const auto removeTargetFromList = [&](auto& it){
-            it = m_fsTargets.erase(it);
-    };
+    const auto removeTargetFromList = [&](auto& it) { it = m_fsTargets.erase(it); };
 
     const auto removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {
-            const auto NEXT = std::next(it);
-            removeFsTarget(TARGET, true);
-            return NEXT;
+        const auto NEXT = std::next(it);
+        removeFsTarget(TARGET, true);
+        return NEXT;
     };
-
 
     // to prevent a rehash
     std::vector<std::pair<WP<Layout::ITarget>, SFullscreenMode>> toInsert;
-
 
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
 
@@ -342,10 +336,10 @@ void IFullscreenHandler::syncFullscreenTargets() {
                 removeTargetFromList(it);
                 continue;
             }
-            
+
             if (!isFullscreen(WINDOWTARGET) && MODE.client == FSMODE_NONE) {
                 it = removeFsTargetAndreturnNextIter(it, TARGET);
-                continue;                
+                continue;
             }
             // do post-remove-ops on the window group target as that's what algorithms store as a target, then save only the current window of the group
             it = removeFsTargetAndreturnNextIter(it, TARGET);
@@ -358,7 +352,6 @@ void IFullscreenHandler::syncFullscreenTargets() {
     for (const auto& e : toInsert) {
         m_fsTargets.emplace(e.first, e.second);
     }
-
 }
 
 void IFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, const bool recursionGuard) {
@@ -367,7 +360,9 @@ void IFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, const bool r
     // iterator in the list; which would corrupt the map if that next iter is also nullptr. We let this go through on the offchance that there is Ǝ! expired entries or the erase hits the right expired target but it is
     // non-deterministic
     if (!target)
-        Log::logger->log(Log::CRIT, "IFullscreenHandler::removeFsTarget() called with target = nullptr. This is possibly non-deterministic and should NOT happen. This is a bug and should be reported!");
+        Log::logger->log(
+            Log::CRIT,
+            "IFullscreenHandler::removeFsTarget() called with target = nullptr. This is possibly non-deterministic and should NOT happen. This is a bug and should be reported!");
 
     m_fsTargets.erase(target);
 

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -303,9 +303,7 @@ void IFullscreenHandler::syncFullscreenTargets() {
 
 
     const auto removeTargetFromList = [&](auto& it){
-            const auto NEXT = std::next(it);
-            m_fsTargets.erase(it);
-            it = NEXT;
+            it = m_fsTargets.erase(it);
     };
 
     const auto removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -315,11 +315,8 @@ void IFullscreenHandler::syncFullscreenTargets() {
     };
 
 
-    
-    decltype(m_fsTargets) keep = {};
-    keep.reserve(m_fsTargets.size());
-
-
+    // to prevent a rehash
+    std::vector<std::pair<WP<Layout::ITarget>, SFullscreenMode>> toInsert;
 
 
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
@@ -354,14 +351,16 @@ void IFullscreenHandler::syncFullscreenTargets() {
             }
             // do post-remove-ops on the window group target as that's what algorithms store as a target, then save only the current window of the group
             it = removeFsTargetAndreturnNextIter(it, TARGET);
-            keep.emplace(WINDOWTARGET, MODE);
+            toInsert.emplace_back(WINDOWTARGET, MODE);
             continue;
         }
-        keep.emplace(it->first, it->second);
         ++it;
     }
 
-    m_fsTargets.swap(keep);
+    for (const auto& e : toInsert) {
+        m_fsTargets.emplace(e.first, e.second);
+    }
+
 }
 
 void IFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, const bool recursionGuard) {

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -300,22 +300,40 @@ void IFullscreenHandler::setNoMembersAboveFullscreen(const std::optional<SP<Layo
 void IFullscreenHandler::syncFullscreenTargets() {
     // Mode checking logic is the same as getFullscreenModes() - keep it in sync
 
-    // to prevent a rehash
-    std::vector<std::pair<WP<Layout::ITarget>, SFullscreenMode>> toInsert;
+
+
+    const auto removeTargetFromList = [&](auto& it){
+            const auto NEXT = std::next(it);
+            m_fsTargets.erase(it);
+            it = NEXT;
+    };
+
+    const auto removeFsTargetAndreturnNextIter = [&](auto& it, const auto& TARGET) {
+            const auto NEXT = std::next(it);
+            removeFsTarget(TARGET, true);
+            return NEXT;
+    };
+
+
+    
+    decltype(m_fsTargets) keep = {};
+    keep.reserve(m_fsTargets.size());
+
+
+
 
     for (auto it = m_fsTargets.begin(); it != m_fsTargets.end();) {
 
-        // Somehow happens sometimes and causes WP<> to segfault
-        if (m_fsTargets.empty())
-            return;
+        const auto TARGET = it->first.lock();
 
-        // Rigorously check if WP<> is valid as WP<> randomly segfaults sometimes without this
-        const auto TARGET = !it->first.expired() && it->first.valid() && it->first ? it->first.lock() : nullptr;
+        // expired/invalid entries. We need not perform any post-removal operations on these
+        if (!TARGET || !TARGET->window()) {
+            removeTargetFromList(it);
+            continue;
+        }
 
-        if (!TARGET || !TARGET->window() || (!isFullscreen(TARGET) && it->second.client == FSMODE_NONE)) {
-            const auto NEXT = std::next(it);
-            removeFsTarget(TARGET, true);
-            it = NEXT;
+        if (!isFullscreen(TARGET) && it->second.client == FSMODE_NONE) {
+            it = removeFsTargetAndreturnNextIter(it, TARGET);
             continue;
         }
 
@@ -324,25 +342,37 @@ void IFullscreenHandler::syncFullscreenTargets() {
             const SFullscreenMode MODE = SFullscreenMode{.internal = it->second.internal, .client = it->second.client};
             // gets the current window's target in the window group
             const auto WINDOWTARGET = TARGET->window()->windowTarget();
-            const auto NEXT         = std::next(it);
-            removeFsTarget(TARGET, true);
-            it = NEXT;
-            toInsert.emplace_back(WINDOWTARGET, MODE);
+
+            if (!WINDOWTARGET) {
+                removeTargetFromList(it);
+                continue;
+            }
+            
+            if (!isFullscreen(WINDOWTARGET) && MODE.client == FSMODE_NONE) {
+                it = removeFsTargetAndreturnNextIter(it, TARGET);
+                continue;                
+            }
+            // do post-remove-ops on the window group target as that's what algorithms store as a target, then save only the current window of the group
+            it = removeFsTargetAndreturnNextIter(it, TARGET);
+            keep.emplace(WINDOWTARGET, MODE);
             continue;
         }
-
+        keep.emplace(it->first, it->second);
         ++it;
     }
 
-    for (const auto& e : toInsert) {
-        m_fsTargets.emplace(e.first, e.second);
-    }
+    m_fsTargets.swap(keep);
 }
 
 void IFullscreenHandler::removeFsTarget(SP<Layout::ITarget> target, const bool recursionGuard) {
-    const auto ITER = m_fsTargets.find(target);
-    if (ITER != m_fsTargets.end())
-        m_fsTargets.erase(ITER);
+
+    // This should not be done because if there are 2 expired elements in the list, this will remove one of them with little guarantee as to which and the caller is preumsably looking forward and getting the next
+    // iterator in the list; which would corrupt the map if that next iter is also nullptr. We let this go through on the offchance that there is Ǝ! expired entries or the erase hits the right expired target but it is
+    // non-deterministic
+    if (!target)
+        Log::logger->log(Log::CRIT, "IFullscreenHandler::removeFsTarget() called with target = nullptr. This is possibly non-deterministic and should NOT happen. This is a bug and should be reported!");
+
+    m_fsTargets.erase(target);
 
     if (!recursionGuard)
         syncFullscreenTargets();

--- a/src/protocols/GammaControl.cpp
+++ b/src/protocols/GammaControl.cpp
@@ -160,7 +160,7 @@ void CGammaControl::applyToMonitor() {
 }
 
 PHLMONITOR CGammaControl::getMonitor() {
-    return m_monitor ? m_monitor.lock() : nullptr;
+    return m_monitor.lock();
 }
 
 void CGammaControl::onMonitorDestroy() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Title.

The edge case is the possible non-determinism if there is more than one invalid entry in the FS targets list. At best this corrects itself, at worst this corrupts the list.

Also fixes a bug where the self correction lambda of isFullscreen() keeps triggering when you have 2+ FS windows on a scrolling workspace cuz it didn't account for isFullscreen() getting one and getFullscreen() getting another. 

Realistically neither of these has been a problem in both testing and in prod. but it's best to fix nonetheless.


Thanks @gulafaran for the suggestion of swap. That's a rotate, indeed. I'll need to profile to see if it's a good use case here.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Bugfix, refinement. Nothing breaking.

#### Is it ready for merging, or does it need work?

Ready

~~Profile new vs old sync to see perf gap is measurable.~~
