### PR TITLE
allow for negative scale on scroll move gesture

### DIFF
--- a/hyprtester/src/tests/main/gestures.cpp
+++ b/hyprtester/src/tests/main/gestures.cpp
@@ -180,6 +180,8 @@ TEST_CASE(live_gesture_callbacks) {
 
     EXPECT_CONTAINS(evalLua("hl.gesture({ fingers = 8, direction = 'up', action = { start = 1 } })"), "action.start must be a function");
     EXPECT_CONTAINS(evalLua("hl.gesture({ fingers = 8, direction = 'up', action = {} })"), "must define at least one of start, update, end, or finish");
+    EXPECT_CONTAINS(evalLua("hl.gesture({ fingers = 8, direction = 'up', action = function() end, scale = 0 })"),
+                    "value must be between -10 and -0.1 or between 0.1 and 10 - It's currently: 0");
 }
 
 // TODO: decompose this into multiple test cases

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -2391,6 +2391,50 @@ TEST_CASE(scroll_DEFAULT_HANDLED_FullscreenNonInterference) {
 
 /* Scroll viewport tests */
 
+TEST_CASE(scrollNegativeScaleGesture) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
+    OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = false }, gestures = { scrolling = { move_snap_to_grid = false, move_snap_cursor = false } } })"));
+
+    // Move away from the tape boundary before testing the negative scale.
+    OK(getFromSocket("/eval hl.gesture({ fingers = 6, direction = 'left', action = 'scroll_move', scale = -2 })"));
+    OK(getFromSocket("/eval hl.gesture({ fingers = 7, direction = 'left', action = 'scroll_move', scale = 2 })"));
+    OK(getFromSocket("/eval hl.gesture({ fingers = 8, direction = 'left', action = 'scroll_move', scale = -1 })"));
+    OK(getFromSocket("/eval hl.gesture({ fingers = 9, direction = 'left', action = 'scroll_move', scale = 1 })"));
+
+    for (const auto& win : {"negative_scale_a", "negative_scale_b", "negative_scale_c", "negative_scale_d"})
+        SPAWN_KITTY(win);
+
+    const auto xCoordinate = [&](const std::string& window) {
+        const auto at = Tests::getAttribute(getClientBlock(getFromSocket("/clients"), window), "at");
+        return std::stoi(at.substr(0, at.find(',')));
+    };
+
+    const int pos = xCoordinate("negative_scale_a");
+
+    OK(getFromSocket("/eval hl.plugin.test.gesture('left', 7)"));
+    const int posPlus2 = xCoordinate("negative_scale_a");
+
+    // Test negative delta when moving the viewport in scrolling via a gesture.
+    OK(getFromSocket("/eval hl.plugin.test.gesture('left', 8)"));
+    const int posPlus1 = xCoordinate("negative_scale_a");
+
+    if (posPlus1 <= posPlus2)
+        FAIL_TEST("Expected a negative gesture scale to move the scrolling view right, from x={} to x={}", posPlus2, posPlus1);
+
+    // Return to the same tape position before comparing scale -2.
+    OK(getFromSocket("/eval hl.plugin.test.gesture('left', 9)"));
+    const int posPlus2Again = xCoordinate("negative_scale_a");
+
+    if (posPlus2Again != posPlus2)
+        FAIL_TEST("Expected scale 1 to reset the scrolling view from x={} to x={}, got x={}", posPlus1, posPlus2, posPlus2Again);
+
+    OK(getFromSocket("/eval hl.plugin.test.gesture('left', 6)"));
+    const int posAgain = xCoordinate("negative_scale_a");
+
+    if (posAgain != pos)
+        FAIL_TEST("Expected scale -2 to return the scrolling view from x={} to x={}, got x={}", posPlus2, pos, posAgain);
+}
+
 TEST_CASE(testScrollingViewBehaviourDispatchFocusWindowFollowFocusFalse) {
 
     /*

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -898,13 +898,19 @@ static int hlGesture(lua_State* L) {
     float deltaScale = 1.F;
     lua_getfield(L, 1, "scale");
     if (!lua_isnil(L, -1)) {
-        CLuaConfigFloat scaleParser(1.F, 0.1F, 10.F);
+        CLuaConfigFloat scaleParser(1.F, -10.F, 10.F);
         auto            scaleErr = scaleParser.parse(L);
         if (scaleErr.errorCode != PARSE_ERROR_OK) {
             lua_pop(L, 1);
             return Internal::configError(L, std::format("hl.gesture: field \"scale\": {}", scaleErr.message));
         }
         deltaScale = scaleParser.parsed();
+        // must be [-10.F, -0.1F] ∪ [0.1F, 10.F]
+        // < -10 and >10 checks are made above
+        if (deltaScale > -0.1F && deltaScale < 0.1F) {
+            lua_pop(L, 1);
+            return Internal::configError(L, "hl.gesture: field \"scale\": value must be between -10 and -0.1 or between 0.1 and 10 - It's currently: {}", deltaScale);
+        }
     }
     lua_pop(L, 1);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Allows for a negative scale in the gesture scroll. this will allow to invert the scrolling by passing a negative scale which today is restricted to 0.1 to 10. The new range will be from -10 to -0.1 and from 0.1 to 10.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is a follow-up for https://github.com/hyprwm/Hyprland/pull/16053 after vouch.

This has been AI-assisted but I manually made changes and applied follow-ups from the feedback from the other PR. I've also tested this manually on a nested hyprland calling `hl.plugin.test.gesture` with hyprctl with both a positive and a negative scale.

I'm still happy to take any further feedback if needed.

#### Is it ready for merging, or does it need work?

Ready for merging.
