### PR TITLE
desktop/view: let floating wayland windows resize themselves

### DIFF
--- a/src/desktop/view/window/WaylandBackend.cpp
+++ b/src/desktop/view/window/WaylandBackend.cpp
@@ -376,9 +376,24 @@ void CWaylandBackend::updateGeometry(bool emitEvent) {
     if (GEOMETRY.box == m_geometry.box && GEOMETRY.positionAuthoritative == m_geometry.positionAuthoritative)
         return;
 
+    const Vector2D OLD_SIZE = m_geometry.box.size();
+
     m_geometry = GEOMETRY;
     if (emitEvent)
         m_events.geometryChanged.emit(m_geometry.box);
+
+    if (!emitEvent || !m_mapped)
+        return;
+
+    // Everything we configure ourselves comes back with the size we asked for, so a geometry
+    // whose size differs from our last configure is the client asking for a size of its own.
+    if (!m_pendingReportedSize.has_value() || m_geometry.box.size() == *m_pendingReportedSize)
+        return;
+
+    if (m_geometry.box.size() == OLD_SIZE || m_geometry.box.size().x <= 1 || m_geometry.box.size().y <= 1)
+        return;
+
+    m_events.clientResizeRequest.emit(CBox{{}, m_geometry.box.size()});
 }
 
 void CWaylandBackend::updateGeometryHints() {

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -137,6 +137,8 @@ void CWindow::attachBackendListeners() {
     m_backendListeners.stateRequest      = m_backend->m_events.stateRequest.listen([this](const auto& request) { onUpdateState(request); });
     m_backendListeners.configureRequest  = m_backend->m_events.configureRequest.listen([this](const auto& box) { onConfigureRequest(box); });
     m_backendListeners.geometryChanged   = m_backend->m_events.geometryChanged.listen([this](const auto& box) { onGeometryChanged(box); });
+    m_backendListeners.clientResizeRequest =
+        m_backend->m_events.clientResizeRequest.listen([this](const auto& box) { onClientResizeRequest(box); });
     m_backendListeners.activationRequest = m_backend->m_events.activationRequest.listen([this] { onActivationRequest(); });
     m_backendListeners.moveRequest       = m_backend->m_events.moveRequest.listen([this] { onMoveRequest(); });
     m_backendListeners.resizeRequest     = m_backend->m_events.resizeRequest.listen([this](eBackendResizeEdge edge) { onResizeRequest(edge); });
@@ -1846,6 +1848,34 @@ void CWindow::onResizeRequest(eBackendResizeEdge edge) {
 void CWindow::onGeometryChanged(const CBox& box) {
     if (m_backend->isX11() && m_backend->traits().overrideRedirect)
         unmanagedSetGeometry(box);
+}
+
+// An xdg_shell client may resize itself by changing its window geometry, e.g. when a
+// collapsible panel is expanded or folded away. X11 clients have had this via
+// onConfigureRequest since forever; without this, a wayland client can only ever grow
+// itself (by raising its min size, which clampWindowSize enforces) and never shrink back.
+void CWindow::onClientResizeRequest(const CBox& clientBox) {
+    if (m_backend->isX11() || !m_isMapped || isHidden() || !m_backend->isMapped())
+        return;
+
+    // The compositor owns the size of everything that is not a plain floating window.
+    if (!m_target->floating() || Fullscreen::controller()->isFullscreen(m_self.lock()) || g_layoutManager->dragController()->target() == layoutTarget())
+        return;
+
+    const auto HINTS   = m_backend->geometryHints(eBackendState::BACKEND_STATE_CURRENT);
+    const auto REQUEST = m_backend->clientToLogical(clientBox, m_monitor.lock()).size();
+    const auto NEWSIZE = REQUEST.clamp(HINTS.minSize.value_or(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE}), HINTS.maxSize.value_or(Vector2D{INFINITY, INFINITY}));
+
+    if (NEWSIZE == m_realSize->goal() || NEWSIZE.x <= MIN_WINDOW_SIZE || NEWSIZE.y <= MIN_WINDOW_SIZE)
+        return;
+
+    Log::logger->log(Log::DEBUG, "Window '{}' ({:#x}) resized itself to {}", m_metadata->title(), (uintptr_t)this, NEWSIZE);
+
+    g_pHyprRenderer->damageWindow(m_self.lock());
+    // Anchored at the top left: the client grew or shrank its own content downwards/rightwards,
+    // so moving the window out from under the pointer would be surprising.
+    layoutTarget()->setPositionGlobal(CBox{m_realPosition->goal(), NEWSIZE});
+    g_pHyprRenderer->damageWindow(m_self.lock());
 }
 
 void CWindow::unmanagedSetGeometry(const CBox& box) {

--- a/src/desktop/view/window/Window.hpp
+++ b/src/desktop/view/window/Window.hpp
@@ -265,6 +265,7 @@ namespace Desktop::View {
         void         onSurfaceChanged(SP<CWLSurfaceResource> surface);
         void         onConfigureRequest(const CBox& box);
         void         onGeometryChanged(const CBox& box);
+        void         onClientResizeRequest(const CBox& clientBox);
         void         onActivationRequest();
         void         onMoveRequest();
         void         onResizeRequest(eBackendResizeEdge edge);
@@ -301,6 +302,7 @@ namespace Desktop::View {
             CHyprSignalListener stateRequest;
             CHyprSignalListener configureRequest;
             CHyprSignalListener geometryChanged;
+            CHyprSignalListener clientResizeRequest;
             CHyprSignalListener activationRequest;
             CHyprSignalListener moveRequest;
             CHyprSignalListener resizeRequest;

--- a/src/desktop/view/window/WindowBackend.hpp
+++ b/src/desktop/view/window/WindowBackend.hpp
@@ -144,6 +144,7 @@ namespace Desktop::View {
             CSignalT<SBackendStateRequest>   stateRequest;
             CSignalT<CBox>                   configureRequest;
             CSignalT<CBox>                   geometryChanged;
+            CSignalT<CBox>                   clientResizeRequest;
             CSignalT<>                       activationRequest;
             CSignalT<>                       moveRequest;
             CSignalT<eBackendResizeEdge>     resizeRequest;


### PR DESCRIPTION
### Describe your PR, what does it fix/add?

An xdg_shell client cannot shrink itself. If a floating wayland window changes its
window geometry to something smaller than its current size, the change is dropped and
Hyprland re-configures the window back to the size it already had.

Clients that grow *do* work, but only by accident: they raise their min size, and
`clampWindowSize()` enforces the minimum on the next commit. Lowering the min size again
does nothing, because a minimum is a floor and never pulls a window back down. So a
window with a collapsible panel expands correctly the first time and is then stuck at its
expanded size forever.

`onGeometryChanged()` only ever did anything for X11 override-redirect surfaces, so
nothing consumed a wayland client's own geometry change. X11 windows have had this path
since forever via `onConfigureRequest()`, which resizes floating windows to whatever the
client asks for; this brings xdg_shell to parity.

The fix adds a `clientResizeRequest` backend signal, emitted from
`CWaylandBackend::updateGeometry()` when the committed geometry size differs from the
size we last configured (anything we drive ourselves comes back with the size we asked
for, so a mismatch is the client asking for something of its own). `CWindow` applies it
to plain floating windows only, clamped to the client's own min/max hints, and anchored
at the top left rather than re-centering — the client grew or shrank its content
downwards, so recentering would slide the window out from under the pointer.

Tiled, fullscreen and interactively-dragged windows are untouched, and so is X11.

### Reproduction

Any app that resizes itself around a collapsible panel. Windscribe's VPN client is a
clean case — its window is 350x271 with the Locations drawer closed and 350x600 with it
open:

```
 -> xdg_surface#142.set_window_geometry(0, 0, 350, 290)   # drawer opening, 15 steps
 -> xdg_surface#142.set_window_geometry(0, 0, 350, 600)
 -> xdg_toplevel#143.set_min_size(350, 600)
    xdg_toplevel#143.configure(350, 600, array[24])       # honoured (min size floor)

 -> xdg_toplevel#143.set_min_size(350, 271)               # drawer closing
 -> xdg_surface#142.set_window_geometry(0, 0, 350, 271)   # client asks to shrink
    xdg_toplevel#143.configure(350, 600, array[20])       # ignored, 600 re-asserted
 -> xdg_surface#142.set_window_geometry(0, 0, 350, 600)   # client gives in
```

With the patch the last three lines become a `configure(350, 271)` and the window
returns to its compact size.

### Testing

Built clean on `main` (4a4a527), no new warnings. Verified with a minimal xdg_shell
client that declares `min_size`/`window_geometry` of 350x271, grows to 600 at t=2s and
asks to shrink back at t=5s, floated in both compositors:

| phase | stock 0.56.2 | patched |
| --- | --- | --- |
| mapped | 350x271 | 350x271 |
| after grow | 350x600 | 350x600 |
| after shrink | **350x600** | **350x271** |

On stock the client receives no configure at all in response to its shrink; with the
patch it gets `configure(350, 271)`. Mapping and growth are byte-identical between the
two, and tiled windows are unaffected (the same app tiled maps at the layout size on
both).

One deliberate behaviour change worth calling out: a floating client that attaches a
buffer *before* declaring any window geometry now gets sized to its buffer bounds, since
that is what its geometry resolves to. Toolkits that declare geometry up front (the
normal case, and what the table above exercises) see no difference.

### Is it ready for merging, or does it need work?

Ready.
