### PR TITLE
core/compositor: don't kill clients whose dmabuf the renderer can't import (CPU-copy fallback)

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -621,12 +621,14 @@ void CWLSurfaceResource::scheduleState(WP<SSurfaceState> state) {
             if (!waiter)
                 whenReadable(state);
         }
+    } else if (state->buffer && !state->buffer->m_syncFds.empty()) {
+        // dmabuf with implicit fences: wait for them asynchronously. This must come before the
+        // isSynchronous() check: a CPU-fallback dmabuf is synchronous (read at commit) but still
+        // GPU-written, and reading it before its fences signal would block in the sync ioctl.
+        drainSyncFds(state, LOCK_REASON_FENCE);
     } else if (state->buffer && state->buffer->isSynchronous()) {
         // synchronous (shm) buffers can be read immediately
         m_stateQueue.unlockFence(state);
-    } else if (state->buffer && !state->buffer->m_syncFds.empty()) {
-        // async buffer and is dmabuf, then we can wait on implicit fences
-        drainSyncFds(state, LOCK_REASON_FENCE);
     } else {
         // state commit without a buffer.
         m_stateQueue.tryProcess();

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -5,6 +5,47 @@
 #include "../../helpers/Format.hpp"
 #include "helpers/Drm.hpp"
 #include <hyprgraphics/egl/Egl.hpp>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <linux/dma-buf.h>
+#include <cstring>
+#include <cstdlib>
+#if defined(__x86_64__) || defined(__i386__)
+#include <immintrin.h>
+
+// reading a write-combined dmabuf mapping with normal loads is uncached and extremely slow
+// (~0.4 GB/s); MOVNTDQA streaming loads are the intended way to read WC memory.
+__attribute__((target("sse4.1"))) static void streamLoadCopySSE41(uint8_t* dst, const uint8_t* src, size_t len) {
+    size_t i = 0;
+    if (const size_t HEAD = (16 - ((uintptr_t)src & 15)) & 15; HEAD) {
+        const size_t N = HEAD < len ? HEAD : len;
+        memcpy(dst, src, N);
+        i = N;
+    }
+    for (; i + 64 <= len; i += 64) {
+        __m128i a = _mm_stream_load_si128((__m128i*)(src + i));
+        __m128i b = _mm_stream_load_si128((__m128i*)(src + i + 16));
+        __m128i c = _mm_stream_load_si128((__m128i*)(src + i + 32));
+        __m128i d = _mm_stream_load_si128((__m128i*)(src + i + 48));
+        _mm_storeu_si128((__m128i*)(dst + i), a);
+        _mm_storeu_si128((__m128i*)(dst + i + 16), b);
+        _mm_storeu_si128((__m128i*)(dst + i + 32), c);
+        _mm_storeu_si128((__m128i*)(dst + i + 48), d);
+    }
+    if (i < len)
+        memcpy(dst + i, src + i, len - i);
+}
+#endif
+
+static void wcReadCopy(uint8_t* dst, const uint8_t* src, size_t len) {
+#if defined(__x86_64__) || defined(__i386__)
+    if (__builtin_cpu_supports("sse4.1")) {
+        streamLoadCopySSE41(dst, src, len);
+        return;
+    }
+#endif
+    memcpy(dst, src, len);
+}
 
 using namespace Hyprutils::OS;
 using namespace Hyprgraphics::Egl;
@@ -21,11 +62,22 @@ CDMABuffer::CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs 
     m_texture  = g_pHyprRenderer->createTexture(m_attrs, m_opaque); // texture takes ownership of the eglImage
 
     if UNLIKELY (!m_texture) {
+        const auto EXPLICITMODIFIER = m_attrs.modifier;
         Log::logger->log(Log::ERR, "CDMABuffer: failed to import EGLImage, retrying as implicit");
         m_attrs.modifier = DRM_FORMAT_MOD_INVALID;
         m_texture        = g_pHyprRenderer->createTexture(m_attrs, m_opaque);
 
         if UNLIKELY (!m_texture) {
+            // a single-plane explicitly-linear buffer the GPU refuses to sample (e.g. a
+            // cross-device buffer with a stride the render GPU can't import) can still be
+            // read by the CPU: treat it like an shm buffer and upload the pixels each commit.
+            if (m_attrs.planes == 1 && EXPLICITMODIFIER == DRM_FORMAT_MOD_LINEAR) {
+                Log::logger->log(Log::WARN, "CDMABuffer: EGL import failed, using CPU-copy fallback for linear buffer");
+                m_attrs.modifier = EXPLICITMODIFIER;
+                m_cpuFallback    = true;
+                m_success        = true;
+                return;
+            }
             Log::logger->log(Log::ERR, "CDMABuffer: failed to import EGLImage");
             return;
         }
@@ -57,7 +109,7 @@ void CDMABuffer::update(const CRegion& damage) {
 }
 
 bool CDMABuffer::isSynchronous() {
-    return false;
+    return m_cpuFallback; // the CPU-copy fallback reads the buffer at commit, like shm
 }
 
 Aquamarine::SDMABUFAttrs CDMABuffer::dmabuf() {
@@ -65,12 +117,48 @@ Aquamarine::SDMABUFAttrs CDMABuffer::dmabuf() {
 }
 
 std::tuple<uint8_t*, uint32_t, size_t> CDMABuffer::beginDataPtr(uint32_t flags) {
-    // FIXME:
-    return {nullptr, 0, 0};
+    if (!m_cpuFallback || m_attrs.planes != 1 || m_attrs.fds[0] < 0)
+        return {nullptr, 0, 0};
+
+    const size_t LEN = (size_t)m_attrs.strides[0] * m_attrs.size.y;
+
+    if (!m_map) {
+        m_mapSize = m_attrs.offsets[0] + LEN;
+        void* map = mmap(nullptr, m_mapSize, PROT_READ, MAP_SHARED, m_attrs.fds[0], 0);
+        if (map == MAP_FAILED) {
+            Log::logger->log(Log::ERR, "CDMABuffer: CPU fallback mmap failed");
+            m_mapSize = 0;
+            return {nullptr, 0, 0};
+        }
+        m_map = map;
+    }
+
+    if (!m_staging) {
+        m_staging = aligned_alloc(64, (LEN + 63) & ~(size_t)63);
+        if (!m_staging) {
+            Log::logger->log(Log::ERR, "CDMABuffer: CPU fallback staging alloc failed");
+            return {nullptr, 0, 0};
+        }
+    }
+
+    // the mapping is typically write-combined: bracket a streaming-load copy into cached
+    // staging memory with the sync ioctls, and let GL read the fast staging copy instead.
+    dma_buf_sync sync = {.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ};
+    ioctl(m_attrs.fds[0], DMA_BUF_IOCTL_SYNC, &sync);
+
+    wcReadCopy((uint8_t*)m_staging, (uint8_t*)m_map + m_attrs.offsets[0], LEN);
+
+    sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+    ioctl(m_attrs.fds[0], DMA_BUF_IOCTL_SYNC, &sync);
+
+    // returned length must be exactly stride * height: SSurfaceState::updateSynchronousTexture
+    // derives the stride from it as len / bufferSize.y
+    return {(uint8_t*)m_staging, m_attrs.format, LEN};
 }
 
 void CDMABuffer::endDataPtr() {
-    // FIXME:
+    // nothing to do: the dmabuf sync bracket is fully handled inside beginDataPtr,
+    // the caller only ever sees the staging copy
 }
 
 bool CDMABuffer::good() {
@@ -78,6 +166,15 @@ bool CDMABuffer::good() {
 }
 
 void CDMABuffer::closeFDs() {
+    if (m_map) {
+        munmap(m_map, m_mapSize);
+        m_map     = nullptr;
+        m_mapSize = 0;
+    }
+    if (m_staging) {
+        free(m_staging);
+        m_staging = nullptr;
+    }
     for (int i = 0; i < m_attrs.planes; ++i) {
         if (m_attrs.fds[i] == -1)
             continue;

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -22,6 +22,10 @@ class CDMABuffer : public IHLBuffer {
 
   private:
     Aquamarine::SDMABUFAttrs m_attrs;
+    bool                     m_cpuFallback = false;
+    void*                    m_map         = nullptr;
+    size_t                   m_mapSize     = 0;
+    void*                    m_staging     = nullptr;
 
     struct {
         CHyprSignalListener resourceDestroy;


### PR DESCRIPTION
## AI Disclosure

  Yes, I use AI both for investigation and for coding. Also it polishes my English. The lengthy message beneath was written by me as a draft and then enriched with facts by Claude. Most importantly, I run this patch locally, I made sure it performs (it took me a few iterations) and it fixes the annoying bug I have been experiencing for quite some time already!

## Describe your PR, what does it fix/add?

On a multi-GPU setup (AMD primary/renderer, Intel iGPU secondary), any Wayland client rendering on the secondary GPU via `DRI_PRIME=1` is killed with a fatal core-protocol error as soon as it attaches a linear dmabuf whose stride the primary GPU cannot import:

```
wl_display#1: error 1: invalid arguments for wl_surface#N.attach
```

Minimal repro (any client works; Firefox with `MOZ_ENABLE_WAYLAND=1 DRI_PRIME=1` dies ~0.7 s after launch because its startup dummy EGL surface is 2×2):

```
DRI_PRIME=1 mpv --vo=gpu --gpu-context=wayland --geometry=2x2 --no-border --autofit-larger=2x2 av://lavfi:testsrc
```

Server side the import failure shows as `eglCreateImageKHR ... EGL_BAD_ALLOC: createImageFromDmaBufs failed` (radeonsi wants pitch alignment mesa on the Intel side doesn't produce; buffer widths divisible by 32 px import fine, everything else dies). Same signature as discussion #15325.

Root cause: on import failure `CLinuxDMABUFParamsResource::create()` sends `failed` and destroys the `wl_buffer` — but mesa's EGL platform uses `create_immed` and never listens for `failed`, and the destroyed id lives in the *client's* id space, so the client's next `wl_surface.attach` no longer demarshals and libwayland kills the client. The EGL failure is just the trigger; destroying a client-allocated resource without a protocol-visible reason is the bug (wlroots survives the same situation because import there is lazy and non-fatal).

**Fix:** when both explicit and implicit EGL imports of a single-plane explicitly-LINEAR buffer fail, keep the buffer alive and read it on the CPU through the existing synchronous (shm) texture path — implementing the `beginDataPtr`/`endDataPtr` `// FIXME:` stubs via `mmap` + `DMA_BUF_IOCTL_SYNC`. Aligned buffers keep the zero-copy EGL path. Two measured perf details:

- the mapping is write-combined (~0.4 GB/s with normal loads: a 6.5 MB frame cost 15 ms `memcpy` + 41 ms `glTexSubImage2D` reading the map directly, stalling the event loop ~57 ms/commit), so the copy goes through a cached staging buffer using MOVNTDQA streaming loads (runtime SSE4.1 check, plain memcpy fallback): 0.8 ms copy + 0.3 ms upload for the same frame;
- `DMA_BUF_SYNC_START` blocks on the client GPU's implicit fences (measured 7–14 ms/commit under a real Firefox/WebRender load), so `scheduleState` now checks `m_syncFds` before `isSynchronous()` and drains them asynchronously first. `m_syncFds` is only ever populated for dmabuf-type buffers, so shm/single-pixel behavior is unchanged; non-fallback dmabufs already took that branch. After both: 0.00 ms fence wait on the loop, ≤3.5 ms per full-window commit, no event-loop stalls >5 ms.

## Is it ready for merging, or does it need work?

Ready. Tested as a backport on 0.56.2 as the daily driver of the affected machine (AMD gfx1201 primary via `AQ_DRM_DEVICES`, Intel ARL/xe secondary, 4K@180): mpv repro passes at every size, Firefox pure-Wayland-on-iGPU runs without lag or protocol errors; this branch builds against current main (aquamarine 0.15). I don't have a second multi-GPU combo to test the reverse direction.
