### PR TITLE
Core/Guidelines: add CLAUDE.md as a symlink to AGENTS.md, Add warning line in Issue auto-close message about AI use in discussions

### DIFF
--- a/.github/vouch_issue_message.md
+++ b/.github/vouch_issue_message.md
@@ -2,7 +2,7 @@ Users are no longer allowed to open issues themselves, please open a discussion 
 
 Please see the [wiki](https://wiki.hyprland.org/Contributing-and-Debugging/Issue-Guidelines/) on why this is the case.
 
-ATTENTION: If you are opening this issue with AI, please read the [AI Policy](https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md) and ask your AI to read AGENTS.md before opening a discussion. Failiure to obey the clauses outlined in either of these documents may result in severe repercussions.
+ATTENTION: If you are opening this issue with AI, please read the [AI Policy](https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md) and ask your AI to read AGENTS.md before opening a discussion. Failure to obey the clauses outlined in either of these documents may result in severe repercussions.
 
 We are volunteers, and we need your cooperation to make the best software we can. Thank you for understanding! ❤️
 

--- a/.github/vouch_issue_message.md
+++ b/.github/vouch_issue_message.md
@@ -1,5 +1,9 @@
 Users are no longer allowed to open issues themselves, please open a discussion instead.
 
-Please see the [wiki](https://wiki.hyprland.org/Contributing-and-Debugging/Issue-Guidelines/) on why this is the case.\n\nWe are volunteers, and we need your cooperation to make the best software we can. Thank you for understanding! ❤️
+Please see the [wiki](https://wiki.hyprland.org/Contributing-and-Debugging/Issue-Guidelines/) on why this is the case.
+
+ATTENTION: If you are opening this issue with AI, please read the [AI Policy](https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md) and ask your AI to read AGENTS.md before opening a discussion. Failiure to obey the clauses outlined in either of these documents may result in severe repercussions.
+
+We are volunteers, and we need your cooperation to make the best software we can. Thank you for understanding! ❤️
 
 [Open a discussion here](https://github.com/hyprwm/Hyprland/discussions)

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I hear that claude ignores agents.md in favour of claude.md.

Also most AI reach for issues first, unsurprisingly. Add a line there to warn about AI opened discussions to hopefully convince ppl to read the AI policy docs

`No Silica Animus shall escape the wrath of the Omnissiah`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Sanctified and Ready
