### PR TITLE
scrolling: honor the silent flag in moveTargetTo (focus-free direction moves)

### DIFF
--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -536,7 +536,9 @@ static int dsp_pseudoWindow(lua_State* L) {
 }
 
 static int dsp_moveInDirection(lua_State* L) {
-    return Internal::checkResult(L, CA::moveInDirection(sc<Math::eDirection>((int)lua_tonumber(L, lua_upvalueindex(1))), Internal::windowFromUpval(L, 2)));
+    return Internal::checkResult(L,
+                                 CA::moveInDirection(sc<Math::eDirection>((int)lua_tonumber(L, lua_upvalueindex(1))), Internal::windowFromUpval(L, 2),
+                                                     lua_toboolean(L, lua_upvalueindex(3))));
 }
 
 static int dsp_swapInDirection(lua_State* L) {
@@ -784,9 +786,11 @@ static int hlWindowMove(lua_State* L) {
             return 1;
         }
 
+        const bool silent = Internal::tableOptBool(L, 1, "silent").value_or(false);
         lua_pushnumber(L, (int)dir);
         Internal::pushWindowUpval(L, 1);
-        lua_pushcclosure(L, dsp_moveInDirection, 2);
+        lua_pushboolean(L, silent);
+        lua_pushcclosure(L, dsp_moveInDirection, 3);
         return 1;
     }
 

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -485,7 +485,7 @@ ActionResult Actions::focus(PHLWINDOW window) {
     return {};
 }
 
-ActionResult Actions::moveInDirection(Math::eDirection dir, std::optional<PHLWINDOW> w) {
+ActionResult Actions::moveInDirection(Math::eDirection dir, std::optional<PHLWINDOW> w, bool silent) {
     auto window = xtract(w);
     if (!window)
         return {};
@@ -495,8 +495,10 @@ ActionResult Actions::moveInDirection(Math::eDirection dir, std::optional<PHLWIN
 
     updateRelativeCursorCoords();
 
-    g_layoutManager->moveInDirection(window->layoutTarget(), dirToString(dir));
-    window->warpCursor();
+    g_layoutManager->moveInDirection(window->layoutTarget(), dirToString(dir), silent);
+
+    if (!silent)
+        window->warpCursor();
 
     return {};
 }

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -48,7 +48,7 @@ namespace Config::Actions {
     ActionResult moveToWorkspace(PHLWORKSPACE ws, bool silent, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult moveFocus(Math::eDirection dir);
     ActionResult focus(PHLWINDOW window);
-    ActionResult moveInDirection(Math::eDirection dir, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
+    ActionResult moveInDirection(Math::eDirection dir, std::optional<PHLWINDOW> window = std::nullopt /* Active */, bool silent = false);
     ActionResult swapInDirection(Math::eDirection dir, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult swapWith(PHLWINDOW other, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult focusCurrentOrLast();

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1137,7 +1137,8 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
     }
 
     m_scrollingData->recalculate();
-    focusTargetUpdate(t);
+    if (!silent)
+        focusTargetUpdate(t);
 }
 
 WP<Fullscreen::IFullscreenHandler> CScrollingAlgorithm::getFSHandler() {


### PR DESCRIPTION
### Summary

`CScrollingAlgorithm::moveTargetTo(t, dir, silent)` accepts a `silent` flag that is threaded all the way down from the lua dispatchers but is currently **dead code** — `focusTargetUpdate(t)` is called unconditionally at the end of the direction-move path. This wires it up: a silent direction move now relocates the window without changing focus (and without warping the cursor, matching the existing `moveToWorkspace`/`follow=false` silent semantics).

### Motivation

Automated or scripted window management — tiling helpers, workflow automation, background placement of windows — needs to rearrange windows **without disturbing the user's focus**. Today the scrolling layout offers no focus-free way to move a specific window into another column: `hl.window.move({ direction })` always moves focus to the moved window, and the layout messages (`consume`/`consume_or_expel`) only act on the focused window, forcing a focus detour and restore.

With this patch, moving a window is focus-free in a single dispatch:

```lua
hl.window.move({ direction = "left", window = "class:example-app", silent = true })
```

`silent` defaults to `false`, so every existing keybind, gesture, and config keeps its current behavior.

### Changes

| File | Change |
| --- | --- |
| `src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp` | `moveTargetTo` tail: `if (!silent) focusTargetUpdate(t);` — the one-line behavioral fix |
| `src/config/lua/bindings/LuaBindingsDispatchers.cpp` | `hl.window.move` direction branch accepts `silent` (tableOptBool), threads it into `dsp_moveInDirection` as a new upvalue |
| `src/config/shared/actions/ConfigActions.{hpp,cpp}` | `Actions::moveInDirection(dir, window, silent = false)` passes the flag through to `CLayoutManager::moveInDirection` (which already forwards it) and skips `warpCursor()` when silent |

The plumbing between the lua layer and the algorithm already existed (`Actions::moveInDirection` → `CLayoutManager::moveInDirection(target, dirStr, silent)` → `CSpace::moveTargetInDirection` → algorithm); only the scrolling algorithm dropped the flag. `dwindle`, `master`, and `monocle` already honor `silent` at the algorithm level, so the dispatcher change is layout-agnostic.

Note: `focusTargetUpdate` also writes `lastFocusedTarget` on the destination column; skipping it fully preserves focus state, so a subsequent normal move/consume has no stale-focus surprises.

### Semantics of `silent = true`

- No focus change (`fullWindowFocus` is not called).
- No cursor warp (mirrors the `moveToWorkspace(ws, silent = !follow)` precedent, which only warps in the non-silent branch).
- Viewport still follows the moved column (`centerOrFitCol`) as it does today — this patch is strictly about focus/cursor side-effects, not viewport behavior. Happy to gate viewport movement behind the same flag if the maintainers prefer.

### Out of scope (in this PR)

- The `group_aware` branch of `hl.window.move` still moves groups with focus (unchanged).
- Layout messages (`consume`, `consume_or_expel`, …) are already focus-free but remain active-window-only. A selector-based single-dispatch join (`layoutmsg "insert <selector>"`) is a candidate follow-up PR.

### Testing

No in-tree unit tests cover the layout algorithms (the `tests/` tree covers state queries, render passes, keybinds resolver). The `silent` branch was **verified live** on a locally built patched master (2026-09-01): `hl.window.move({direction, window, silent = true})` relocated the window with focus and cursor untouched, and cross-workspace placement works. Upstream manual verification:

1. Scrolling layout, two windows in separate columns, focus on the left window.
2. `hyprctl dispatch hl.window.move({direction="right", window=<right win>, silent=true})` → the right window moves to the left column; focus stays on the left window; cursor does not jump.
3. Same dispatch without `silent` → unchanged legacy behavior (focus + warp as before).
4. Regression sweep: `movewindow` keybind, trackpad move gesture, `movewindoworgroup`, workspace/monitor `follow=false` moves — all unaffected (flag defaults to `false`).

Adjacent context: #15979 (closed *not_planned*) asks about the separate `workspace … silent` windowrule meaning under Lua; unrelated to this patch, listed for completeness.
