### PR TITLE
Add `reload_config()` dispatcher

### DIFF
--- a/hyprtester/src/tests/main/lua_config.cpp
+++ b/hyprtester/src/tests/main/lua_config.cpp
@@ -52,3 +52,11 @@ TEST_CASE(luaEventConfigUnload) {
     EXPECT(Hyprutils::File::readFileAsString("/tmp/hyprtester-luaEventConfigUnload.txt").value_or("error"), "luaEventConfigUnload");
     std::filesystem::remove("/tmp/hyprtester-luaEventConfigUnload.txt", ec);
 }
+
+TEST_CASE(luaReloadConfig) {
+    constexpr auto VAR = "normally_nonexistent_variable";
+
+    OK(getFromSocket(std::format("/eval {} = true", VAR)));
+    OK(getFromSocket("/dispatch hl.dsp.reload_config()"));
+    EXPECT(getFromSocket(std::format("/repl return {}", VAR)), "nil");
+}

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -57,6 +57,7 @@ namespace Config {
         virtual std::string                      getConfigString()   = 0;
         virtual const std::vector<std::string>&  getConfigPaths()    = 0;
 
+        virtual bool                             configLoaded()      = 0;
         virtual bool                             configVerifPassed() = 0;
 
         virtual std::string                      getErrors() = 0;

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -1140,6 +1140,10 @@ void CConfigManager::handlePluginLoads() {
     }
 }
 
+bool CConfigManager::configLoaded() {
+    return !(m_isFirstLaunch || m_isParsingConfig);
+}
+
 bool CConfigManager::configVerifPassed() {
     return m_lastConfigVerificationWasSuccessful;
 }

--- a/src/config/lua/ConfigManager.hpp
+++ b/src/config/lua/ConfigManager.hpp
@@ -83,6 +83,7 @@ namespace Config::Lua {
         virtual std::expected<void, std::string> generateDefaultConfig(const std::filesystem::path&, bool safeMode) override;
 
         virtual void                             handlePluginLoads() override;
+        virtual bool                             configLoaded() override;
         virtual bool                             configVerifPassed() override;
 
         virtual std::expected<void, std::string> registerPluginValue(void* handle, SP<Config::Values::IValue> value) override;

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -184,6 +184,10 @@ static int dsp_exit(lua_State* L) {
     return Internal::checkResult(L, CA::exit());
 }
 
+static int dsp_reload_config(lua_State* L) {
+    return Internal::checkResult(L, CA::reloadConfig());
+}
+
 static int dsp_submap(lua_State* L) {
     return Internal::checkResult(L, CA::setSubmap(lua_tostring(L, lua_upvalueindex(1))));
 }
@@ -264,6 +268,11 @@ static int hlExecRaw(lua_State* L) {
 
 static int hlExit(lua_State* L) {
     lua_pushcclosure(L, dsp_exit, 0);
+    return 1;
+}
+
+static int hlReloadConfig(lua_State* L) {
+    lua_pushcclosure(L, dsp_reload_config, 0);
     return 1;
 }
 
@@ -1344,6 +1353,7 @@ void Internal::registerDispatcherBindings(lua_State* L) {
         Internal::setFn(L, "exec_cmd", hlExecCmd);
         Internal::setFn(L, "exec_raw", hlExecRaw);
         Internal::setFn(L, "exit", hlExit);
+        Internal::setFn(L, "reload_config", hlReloadConfig);
         Internal::setFn(L, "submap", hlSubmap);
         Internal::setFn(L, "pass", hlPass);
         Internal::setFn(L, "send_shortcut", hlSendShortcut);

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1221,6 +1221,8 @@ ActionResult Actions::exit() {
 }
 
 ActionResult Actions::reloadConfig() {
+    if (!Config::mgr()->configLoaded())
+        return std::unexpected(std::string("Cannot trigger a reload while the config is already loading!"));
     // probably don't tear down state while stuff is actively running
     g_pEventLoopManager->doLater([] { Config::mgr()->reload(); });
     return {};

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1,5 +1,6 @@
 #include "ConfigActions.hpp"
 #include "../parserUtils/ParserUtils.hpp"
+#include "../../ConfigManager.hpp"
 #include "../../../desktop/state/FocusState.hpp"
 #include "../../../desktop/state/GlobalWindowController.hpp"
 #include "../../../desktop/state/WindowState.hpp"
@@ -18,6 +19,7 @@
 #include "../../../keybinds/Manager.hpp"
 #include "../../../managers/input/InputManager.hpp"
 #include "../../../managers/fullscreen/FullscreenController.hpp"
+#include "../../../managers/eventLoop/EventLoopManager.hpp"
 #include "../../../layout/LayoutManager.hpp"
 #include "../../../layout/space/Space.hpp"
 #include "../../../layout/target/Target.hpp"
@@ -1215,6 +1217,12 @@ ActionResult Actions::exit() {
         return {};
 
     g_pCompositor->stopCompositor();
+    return {};
+}
+
+ActionResult Actions::reloadConfig() {
+    // probably don't tear down state while stuff is actively running
+    g_pEventLoopManager->doLater([] { Config::mgr()->reload(); });
     return {};
 }
 

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -86,6 +86,7 @@ namespace Config::Actions {
 
     ActionResult moveCursor(const Vector2D& pos);
     ActionResult exit();
+    ActionResult reloadConfig();
     ActionResult forceRendererReload();
     ActionResult toggleSwallow();
     ActionResult setSubmap(const std::string& submap);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
An `hl.dsp.reload_config()` dispatcher, because shelling out to `hyprctl reload` only to then do IPC back to Hyprland feels awkward.

Wiki PR: hyprwm/hyprland-wiki#1646

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing super complicated here. The only thing is, we use `doLater` to not tear down config state while it's in active use, but that's pretty routine.

#### Is it ready for merging, or does it need work?
Tested locally, and it reloads properly (wiping out extra Lua variables, for example) without crashing or anything.