### PR TITLE
input: release keys on keyboard leave, keep seat pressed-key set accurate under IME grabs

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1741,6 +1741,15 @@ void CInputManager::onKeyboardKey(const IKeyboard::SKeyEvent& event, SP<IKeyboar
         }
 
         if (USEIME) {
+            // keep the seat's pressed-key set accurate even while the IME has the
+            // grab: m_pressed is what wl_keyboard.enter carries on focus changes,
+            // and a stale entry re-arms stuck keys in stateful clients like XWayland.
+            const bool CONTAINS = std::ranges::contains(m_pressed, event.keycode);
+            if (pressed && !CONTAINS)
+                m_pressed.emplace_back(event.keycode);
+            else if (!pressed && CONTAINS)
+                std::erase(m_pressed, event.keycode);
+
             IME->setKeyboard(pKeyboard);
             IME->sendKey(event.timeMs, event.keycode, state);
         } else {

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -406,6 +406,14 @@ void CWLKeyboardResource::sendEnter(SP<CWLSurfaceResource> surface, wl_array* ke
     m_listeners.destroySurface = surface->m_events.destroy.listen([this] { sendLeave(); });
 
     m_resource->sendEnter(g_pSeatManager->nextSerial(m_owner.lock()), surface->getResource().get(), keys);
+    // track the keys this client saw pressed, so they can be released on
+    // leave and stateful clients (e.g. XWayland) don't get stuck keys.
+    m_pressedKeys.clear();
+    for (size_t i = 0; i < keys->size / sizeof(uint32_t); ++i) {
+        const auto KEY = sc<const uint32_t*>(keys->data)[i];
+        if (std::ranges::find(m_pressedKeys, KEY) == m_pressedKeys.end())
+            m_pressedKeys.emplace_back(KEY);
+    }
 }
 
 void CWLKeyboardResource::sendLeave() {
@@ -414,6 +422,15 @@ void CWLKeyboardResource::sendLeave() {
 
     if (!(PROTO::seat->m_currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD))
         return;
+    // bring the client's keyboard state back to neutral before leaving:
+    // release every key this client saw pressed. Stateful clients like
+    // XWayland don't reset key state on leave, and a stuck key re-arms
+    // the client-side auto-repeat once it's focused again.
+    const auto KEYS = m_pressedKeys;
+    m_pressedKeys.clear();
+    for (auto const& k : KEYS) {
+        sendKey(Time::millis(Time::steadyNow()), k, WL_KEYBOARD_KEY_STATE_RELEASED);
+    }
 
     m_resource->sendLeave(g_pSeatManager->nextSerial(m_owner.lock()), m_currentSurface->getResource().get());
     m_currentSurface.reset();
@@ -428,6 +445,12 @@ void CWLKeyboardResource::sendKey(uint32_t timeMs, uint32_t key, wl_keyboard_key
         return;
 
     m_resource->sendKey(g_pSeatManager->nextSerial(m_owner.lock()), timeMs, key, state);
+
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+        if (std::ranges::find(m_pressedKeys, key) == m_pressedKeys.end())
+            m_pressedKeys.emplace_back(key);
+    } else
+        std::erase(m_pressedKeys, key);
 }
 
 void CWLKeyboardResource::sendMods(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) {

--- a/src/protocols/core/Seat.hpp
+++ b/src/protocols/core/Seat.hpp
@@ -129,6 +129,7 @@ class CWLKeyboardResource {
   private:
     SP<CWlKeyboard>        m_resource;
     WP<CWLSurfaceResource> m_currentSurface;
+    std::vector<uint32_t>  m_pressedKeys;
 
     struct {
         CHyprSignalListener destroySurface;


### PR DESCRIPTION
# input: release keys on keyboard leave, keep seat pressed-key set accurate under IME grabs

Fixes runaway key-repeat bursts ("stuck keys") in XWayland applications — WeChat, Spotify, Chromium/Electron apps — after a focus switch while an fcitx5 (or any `zwp_input_method_v2`) grab is active, and after any key release that is delivered to a different client than the one that received the press.

## The bug

XWayland is a stateful `wl_keyboard` client: it does **not** reset its XKB key state from the `wl_keyboard.enter` payload, nor on `leave`. If a key press reaches XWayland but the matching release is delivered elsewhere, XWayland's XKB keeps the key down. When an X client regains focus, the stuck key re-arms XWayland's auto-repeat and the client is flooded with the same character at the compositor's repeat rate until another key is pressed.

Two code paths produce the missing release:

1. **Release delivered to the newly-focused client.** Press `/` in an XWayland app, switch focus to a native Wayland surface before releasing: the release is forwarded to the new focus, XWayland never sees it.
2. **`m_pressed` goes stale while an IME grab is active.** `onKeyboardKey` only maintains `m_pressed` in the no-grab branch. With an active `zwp_input_method_v2` grab (fcitx5 with an active input method — the default state for CJK users), a key pressed outside the grab and released inside it (or vice versa) leaves `m_pressed` stale. `CSeatManager::setKeyboardFocus` then sends the stale key in every `wl_keyboard.enter` payload, re-arming the stuck key in XWayland on *every* focus change.

Reproducer (no IME needed, Hyprland 0.56.2):

1. Open any X11 window (e.g. `xev`) and focus it.
2. Press a key and hold it (e.g. via `wtype -P slash`), switch focus to a native Wayland window, then release the key there.
3. Refocus the X11 window: it receives an endless burst of press/release pairs at `input:repeat_rate` until any other key is pressed. `XQueryKeymap` shows the stuck keycode.

Recorded occurrence (WeChat composer flooded with `/`): the user switches from a terminal back to WeChat and the input box fills with the last-typed character.

## The fix

Mirrors what `CWLPointerResource` already does for pressed buttons, applied to keys:

- `CWLKeyboardResource` tracks the keys a client has seen pressed (seeded from the `enter` payload, updated on every forwarded key) and releases them right before the leave event, bringing the leaving client's keyboard state back to neutral. This is the same "emulate release to reach neutral state" pattern wlroots uses for virtual keyboards on destroy (swaywm/wlroots@ad386c6).
- `CInputManager::onKeyboardKey` updates `m_pressed` in the IME-grab path too, so `wl_keyboard.enter` payloads stay accurate.

The synthetic releases are sent *before* `leave`, while the surface is still focused, so the event order stays protocol-clean; compliant clients see a release for every key they were told was pressed, and XWayland's repeat timer is disarmed before it can flood.

## Behavior notes

- Compliant clients reset keyboard state on `leave` and ignore keys afterwards; the extra releases are semantically accurate ("these keys are no longer pressed for you").
- The IME path itself is unaffected: forwarding to the IME, key forwarding via the virtual keyboard, and `m_pressed` consumers (only the `enter` payload) behave as before — the payload just stops being stale.

## Testing

- Built and verified against 0.56.2 with fcitx5-rime active (WeChat 4.1 under XWayland): the deterministic wtype focus-switch reproducer floods an unpatched compositor and produces zero stuck keys with the patch.
