### PR TITLE
protocols: clear data control selections

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -644,8 +644,11 @@ void CSeatManager::setCurrentSelection(SP<IDataSource> source) {
     if (m_selection.currentSelection)
         m_selection.currentSelection->cancelled();
 
-    if (!source)
+    if (!source) {
         PROTO::data->setSelection(nullptr);
+        PROTO::dataWlr->setSelection(nullptr, false);
+        PROTO::extDataDevice->setSelection(nullptr, false);
+    }
 
     m_selection.currentSelection = source;
 
@@ -670,8 +673,11 @@ void CSeatManager::setCurrentPrimarySelection(SP<IDataSource> source) {
     if (m_selection.currentPrimarySelection)
         m_selection.currentPrimarySelection->cancelled();
 
-    if (!source)
+    if (!source) {
         PROTO::primarySelection->setSelection(nullptr);
+        PROTO::dataWlr->setSelection(nullptr, true);
+        PROTO::extDataDevice->setSelection(nullptr, true);
+    }
 
     m_selection.currentPrimarySelection = source;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Clear the selection for `ext-data-control` and `wlr-data-control` when source is null.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Unless there is something I don't understand, we shouldn't let the data control objects keep a reference to an effectively stale selection. This prevents clients from knowing when the selection is cleared.

#### Is it ready for merging, or does it need work?

yes

