### PR TITLE
input/scroll: set scroll_factor from 2.00 --> 100.00

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -375,7 +375,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Int>("input:scroll_button", "Sets the scroll button. 0 means default.", 0, {.min = 0, .max = 300, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Bool>("input:scroll_button_lock", "If the scroll button lock is enabled, the button does not need to be held down.", false,
                  {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
-        MS<Float>("input:scroll_factor", "Multiplier added to scroll movement for external mice.", 1, {.min = 0, .max = 2, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
+        MS<Float>("input:scroll_factor", "Multiplier added to scroll movement for external mice.", 1, {.min = 0, .max = 100, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Bool>("input:natural_scroll", "Inverts scrolling direction.", false, {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Int>("input:follow_mouse", "Specify if and how cursor movement should affect window focus.", 1,
                 {.min = 0, .max = 3, .map = OptionMap{{"disabled", 0}, {"follow", 1}, {"detached", 2}, {"separate", 3}}, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
@@ -403,7 +403,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
 
         MS<Bool>("input:touchpad:disable_while_typing", "Disable the touchpad while typing.", true, {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Bool>("input:touchpad:natural_scroll", "Inverts scrolling direction.", false, {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
-        MS<Float>("input:touchpad:scroll_factor", "Multiplier applied to the amount of scroll movement.", 1, {.min = 0, .max = 2, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
+        MS<Float>("input:touchpad:scroll_factor", "Multiplier applied to the amount of scroll movement.", 1, {.min = 0, .max = 100, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Bool>("input:touchpad:middle_button_emulation", "Sending LMB and RMB simultaneously will be interpreted as a middle click.", false,
                  {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<String>("input:touchpad:tap_button_map", "Sets the tap button mapping for touchpad button emulation. [lrm/lmr]", STRVAL_EMPTY,

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -403,7 +403,8 @@ std::vector<SP<IValue>> Values::getConfigValues() {
 
         MS<Bool>("input:touchpad:disable_while_typing", "Disable the touchpad while typing.", true, {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Bool>("input:touchpad:natural_scroll", "Inverts scrolling direction.", false, {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
-        MS<Float>("input:touchpad:scroll_factor", "Multiplier applied to the amount of scroll movement.", 1, {.min = 0, .max = 100, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
+        MS<Float>("input:touchpad:scroll_factor", "Multiplier applied to the amount of scroll movement.", 1,
+                  {.min = 0, .max = 100, .refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<Bool>("input:touchpad:middle_button_emulation", "Sending LMB and RMB simultaneously will be interpreted as a middle click.", false,
                  {.refresh = Supplementary::REFRESH_INPUT_DEVICES}),
         MS<String>("input:touchpad:tap_button_map", "Sets the tap button mapping for touchpad button emulation. [lrm/lmr]", STRVAL_EMPTY,


### PR DESCRIPTION
#### Describe your PR: what does it fix/add?
Uncaps scroll_factor max; I found [2](https://github.com/hyprwm/Hyprland/commit/5ba33f846129f3e6c0505b19f94634b24505e828) to a rather minuscule maximum. I typically set it to at least 9, sometimes more (if I'm feeling *fucking* **CRAZY**). I feel like I can't be the only one who found this feature very helpful (especially on Wayland) and sees no risk in increasing the cap (or just not even having a limit, though maybe infinite scroll factor would heap overflow? lol).

#### Is there anything you want to mention? (unchecked code, potential bugs, found problems, breaking compatibility, etc.)
I have been using my compositor for the last month (finally switched from hyprlang2lua), compiling Hyprland myself to apply my patch; it has worked with 0 issues. I'm confident it was never capped with hyprlang, or at least if it was, the max was much higher than 2 (i'll check sometime when i'm less tired). I've procrastinated on this PR as I don't want to perturb anyone, but the more I think about it, the less sense the change makes to me.

#### Is it ready for merging, or does it need work?
Ready 2 Go!

