### PR TITLE
window: better evaluate when to block `Solitary`

### DIFF
--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1105,6 +1105,61 @@ SP<CWLSurfaceResource> CWindow::getSolitaryResource() const {
     return nullptr;
 }
 
+SP<CWLSurfaceResource> CWindow::getDirectScanoutResource() const {
+    if (auto sol = getSolitaryResource())
+        return sol;
+
+    if (m_wlSurface) {
+        auto res = m_wlSurface->resource();
+        if (!res || res->m_current.buffer)
+            return nullptr;
+
+        SP<CWLSurfaceResource> targetSubsurface = nullptr;
+
+        // inspect root window subsurfaces
+        for (auto& sub : res->m_subsurfaces) {
+            if (sub.expired())
+                continue;
+            auto subsurf = sub.lock();
+            if (!subsurf || subsurf->m_surface.expired())
+                continue;
+
+            auto surf = subsurf->m_surface.lock();
+            if (!surf)
+                continue;
+
+            if (subsurf->m_zIndex < 0) {
+                if (surf->m_current.buffer) {
+                    if (targetSubsurface)
+                        return nullptr; // multiple rendering subsurfaces active
+                    targetSubsurface = surf;
+                }
+            } else if (surf->m_current.buffer || surf->m_mapped) {
+                return nullptr;
+            }
+        }
+
+        // inspect nested subsurfaces attached directly to the surface
+        if (targetSubsurface) {
+            for (auto& sub : targetSubsurface->m_subsurfaces) {
+                if (sub.expired())
+                    continue;
+                auto subsurf = sub.lock();
+                if (!subsurf || subsurf->m_surface.expired())
+                    continue;
+
+                auto surf = subsurf->m_surface.lock();
+                if (surf && (surf->m_current.buffer || surf->m_mapped))
+                    return nullptr; // Steam Overlay or Wayland cursor subsurface active
+            }
+        }
+
+        return targetSubsurface;
+    }
+
+    return nullptr;
+}
+
 std::optional<Vector2D> CWindow::calculateExpression(const Math::SExpressionVec2& expr) {
     return m_target->calculateExpression(expr);
 }

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1078,46 +1078,48 @@ SP<CWLSurfaceResource> CWindow::getSolitaryResource() const {
     if (res->m_subsurfaces.size() == 0)
         return res;
 
-    if (res->m_subsurfaces.size() >= 1) {
-        if (!res->hasVisibleSubsurface())
-            return res;
-
+    if (res->hasVisibleSubsurface()) {
         if (res->m_subsurfaces.size() == 1) {
-            if (res->m_subsurfaces[0].expired() || res->m_subsurfaces[0]->m_surface.expired())
-                return nullptr;
+            auto subsurf = res->m_subsurfaces[0].lock();
+            if (subsurf && !subsurf->m_surface.expired() && subsurf->m_zIndex >= 0) {
+                auto surf = subsurf->m_surface.lock();
+                if (surf && surf->m_subsurfaces.empty() && surf->extends() == res->extends() && surf->m_current.texture && surf->m_current.texture->m_opaque)
+                    return surf;
+            }
+        }
+    } else {
+        return res;
+    }
 
-            auto subsurf = res->m_subsurfaces[0];
+    if (res->m_current.buffer)
+        return nullptr;
 
-            // A subsurface under the main surface cannot result in a solitary resource
-            if (subsurf->m_zIndex < 0)
-                return nullptr;
+    SP<CWLSurfaceResource> targetSubsurface = nullptr;
 
-            auto surf = subsurf->m_surface.lock();
+    for (auto& sub : res->m_subsurfaces) {
+        if (sub.expired())
+            continue;
+        auto subsurf = sub.lock();
+        if (!subsurf || subsurf->m_surface.expired())
+            continue;
 
-            // check if the subsurface covers the main surface
-            if (!surf || surf->m_subsurfaces.size() != 0 || surf->extends() != res->extends() || !surf->m_current.texture || !surf->m_current.texture->m_opaque)
-                return nullptr;
+        auto surf = subsurf->m_surface.lock();
+        if (!surf)
+            continue;
 
-            return surf;
+        if (subsurf->m_zIndex < 0) {
+            if (surf->m_current.buffer) {
+                if (targetSubsurface)
+                    return nullptr;
+                targetSubsurface = surf;
+            }
+        } else if (surf->m_current.buffer || surf->m_mapped) {
+            return nullptr; // overlay blocks solitary
         }
     }
 
-    return nullptr;
-}
-
-SP<CWLSurfaceResource> CWindow::getDirectScanoutResource() const {
-    if (auto sol = getSolitaryResource())
-        return sol;
-
-    if (m_wlSurface) {
-        auto res = m_wlSurface->resource();
-        if (!res || res->m_current.buffer)
-            return nullptr;
-
-        SP<CWLSurfaceResource> targetSubsurface = nullptr;
-
-        // inspect root window subsurfaces
-        for (auto& sub : res->m_subsurfaces) {
+    if (targetSubsurface) {
+        for (auto& sub : targetSubsurface->m_subsurfaces) {
             if (sub.expired())
                 continue;
             auto subsurf = sub.lock();
@@ -1125,39 +1127,22 @@ SP<CWLSurfaceResource> CWindow::getDirectScanoutResource() const {
                 continue;
 
             auto surf = subsurf->m_surface.lock();
-            if (!surf)
-                continue;
-
-            if (subsurf->m_zIndex < 0) {
-                if (surf->m_current.buffer) {
-                    if (targetSubsurface)
-                        return nullptr; // multiple rendering subsurfaces active
-                    targetSubsurface = surf;
-                }
-            } else if (surf->m_current.buffer || surf->m_mapped) {
-                return nullptr;
-            }
-        }
-
-        // inspect nested subsurfaces attached directly to the surface
-        if (targetSubsurface) {
-            for (auto& sub : targetSubsurface->m_subsurfaces) {
-                if (sub.expired())
-                    continue;
-                auto subsurf = sub.lock();
-                if (!subsurf || subsurf->m_surface.expired())
-                    continue;
-
-                auto surf = subsurf->m_surface.lock();
-                if (surf && (surf->m_current.buffer || surf->m_mapped))
-                    return nullptr; // Steam Overlay or Wayland cursor subsurface active
-            }
+            if (surf && (surf->m_current.buffer || surf->m_mapped))
+                return nullptr; // Nested overlay active
         }
 
         return targetSubsurface;
     }
 
     return nullptr;
+}
+
+bool CWindow::isSolitaryRoot() const {
+    if (!m_wlSurface)
+        return false;
+
+    auto res = m_wlSurface->resource();
+    return res && getSolitaryResource() == res;
 }
 
 std::optional<Vector2D> CWindow::calculateExpression(const Math::SExpressionVec2& expr) {

--- a/src/desktop/view/window/Window.hpp
+++ b/src/desktop/view/window/Window.hpp
@@ -231,6 +231,7 @@ namespace Desktop::View {
         bool                       isNotResponding();
         bool                       priorityFocus();
         SP<CWLSurfaceResource>     getSolitaryResource() const;
+        SP<CWLSurfaceResource>     getDirectScanoutResource() const;
         std::optional<Vector2D>    calculateExpression(const Math::SExpressionVec2& expr);
         std::optional<Vector2D>    minSize();
         std::optional<Vector2D>    maxSize();

--- a/src/desktop/view/window/Window.hpp
+++ b/src/desktop/view/window/Window.hpp
@@ -231,7 +231,7 @@ namespace Desktop::View {
         bool                       isNotResponding();
         bool                       priorityFocus();
         SP<CWLSurfaceResource>     getSolitaryResource() const;
-        SP<CWLSurfaceResource>     getDirectScanoutResource() const;
+        bool                       isSolitaryRoot() const;
         std::optional<Vector2D>    calculateExpression(const Math::SExpressionVec2& expr);
         std::optional<Vector2D>    minSize();
         std::optional<Vector2D>    maxSize();

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1900,7 +1900,9 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
         return reasons;
     }
 
-    if (!PCANDIDATE->presentation().opaque()) {
+    const auto DSRESOURCE = PCANDIDATE->getDirectScanoutResource();
+
+    if (!PCANDIDATE->presentation().opaque() && !DSRESOURCE) {
         reasons |= SC_OPAQUE;
         if (!full)
             return reasons;
@@ -1957,7 +1959,7 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
     }
 
     // check if it did not open any subsurfaces or shit
-    if (!PCANDIDATE->getSolitaryResource())
+    if (!PCANDIDATE->getDirectScanoutResource())
         reasons |= SC_SURFACES;
 
     return reasons;
@@ -2109,7 +2111,7 @@ uint16_t CMonitor::isDSBlocked(bool full) {
             return reasons;
     }
 
-    const auto PSURFACE = PCANDIDATE->getSolitaryResource();
+    const auto PSURFACE = PCANDIDATE->getDirectScanoutResource();
     if (!PSURFACE || !PSURFACE->m_current.texture || !PSURFACE->m_current.buffer) {
         reasons |= DS_BLOCK_SURFACE;
         return reasons;
@@ -2153,7 +2155,7 @@ bool CMonitor::attemptDirectScanout() {
         return false;
 
     const auto PCANDIDATE = m_solitaryClient.lock();
-    const auto PSURFACE   = PCANDIDATE->getSolitaryResource();
+    const auto PSURFACE   = PCANDIDATE->getDirectScanoutResource();
     auto       PBUFFER    = PSURFACE->m_current.buffer.m_buffer;
 
     // #TODO this entire bit needs figuring out, vrr goes down the drain without it

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1900,9 +1900,9 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
         return reasons;
     }
 
-    const auto DSRESOURCE = PCANDIDATE->getDirectScanoutResource();
+    const auto SOLRESOURCE = PCANDIDATE->getSolitaryResource();
 
-    if (!PCANDIDATE->presentation().opaque() && !DSRESOURCE) {
+    if (!PCANDIDATE->presentation().opaque() && PCANDIDATE->isSolitaryRoot()) {
         reasons |= SC_OPAQUE;
         if (!full)
             return reasons;
@@ -1959,7 +1959,7 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
     }
 
     // check if it did not open any subsurfaces or shit
-    if (!PCANDIDATE->getDirectScanoutResource())
+    if (!SOLRESOURCE)
         reasons |= SC_SURFACES;
 
     return reasons;
@@ -2111,7 +2111,7 @@ uint16_t CMonitor::isDSBlocked(bool full) {
             return reasons;
     }
 
-    const auto PSURFACE = PCANDIDATE->getDirectScanoutResource();
+    const auto PSURFACE = PCANDIDATE->getSolitaryResource();
     if (!PSURFACE || !PSURFACE->m_current.texture || !PSURFACE->m_current.buffer) {
         reasons |= DS_BLOCK_SURFACE;
         return reasons;
@@ -2155,7 +2155,7 @@ bool CMonitor::attemptDirectScanout() {
         return false;
 
     const auto PCANDIDATE = m_solitaryClient.lock();
-    const auto PSURFACE   = PCANDIDATE->getDirectScanoutResource();
+    const auto PSURFACE   = PCANDIDATE->getSolitaryResource();
     auto       PBUFFER    = PSURFACE->m_current.buffer.m_buffer;
 
     // #TODO this entire bit needs figuring out, vrr goes down the drain without it

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2228,7 +2228,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     bool renderCursor = true;
 
-    if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
+    if (pMonitor->m_solitaryClient && pMonitor->m_solitaryClient->getSolitaryResource() && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
         if (pMonitor->isMirror()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Another attempt at #16131 
After https://github.com/hyprwm/Hyprland/pull/15958 and the release of GE-Proton 11-6 which fixes Steam overlay in wine-wayland, Solitary is denied for Proton because of an empty surface that is created.

This PR adds a helper function for the subsurface buffer being empty before denying Solitary and allows Direct Scanout to engage. When the, now working, Steam Overlay is brought up, Hyprland correctly blocks Solitary and Direct Scanout until the Overlay is closed.

Tested with the following:
`direct_scanout = 1`
 - Plezy, when fullscreened, is granted Solitary and Direct Scanout until a video starts playing. When the latter happens, solitary is blocked with "not opaque, subsurfaces" as intended. That means the mpv overlay is rendered and the video is not just a black frame.
  - Proton-GE 11-6 games get granted Solitary now (previously blocked by "not opaque, subsurfaces" AT ALL TIMES), until you invoke the Steam overlay. At that moment, the helper function returns `nullptr` for because `if (surf && (surf->m_current.buffer || surf->m_mapped))`, blocking Solitary correctly, and rendering the overlay and the mouse while everything can be interacted with properly.
  - Games running directly on wine show no change with this PR vs. without. Solitary and DS both engage and work fine.
  -  Every other app when fullscreened, if no overlays or anything is involved, have Direct Scanout engaged properly (i.e. Chromium/Kitty/etc.
  
`direct_scanout = 0`
This is where my previous attempt fell short. On this PR, with the changes to `Renderer.cpp` we fall back to the correct subsurface to render instead of the empty dummy one.
Everything else already worked as expected anyway.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Again, needs testing in case I missed something obvious or there is an edge case I haven't thought of.

#### Is it ready for merging, or does it need work?
Possibly ready. Maybe the code can be trimmed down a bit. I'll take a look at it again hopefully in a couple of days when I'm going to be back from a trip.

