### PR TITLE
Lua: expose monitor mode, other hardware details

### DIFF
--- a/src/config/lua/objects/LuaMonitor.cpp
+++ b/src/config/lua/objects/LuaMonitor.cpp
@@ -203,6 +203,18 @@ static int monitorIndex(lua_State* L) {
         lua_setfield(L, -2, "bottom");
         lua_pushnumber(L, mon->m_reservedArea.left());
         lua_setfield(L, -2, "left");
+    } else if (key == "hardware_details") {
+        lua_newtable(L);
+        lua_pushstring(L, "FIXME!!!");
+        lua_setfield(L, -2, "backend");
+        lua_pushboolean(L, mon->m_output->parsedEDID.hdrMetadata.has_value());
+        lua_setfield(L, -2, "hdr");
+        lua_pushboolean(L, mon->m_output->parsedEDID.chromaticityCoords.has_value());
+        lua_setfield(L, -2, "chroma");
+        lua_pushboolean(L, mon->m_output->parsedEDID.supportsBT2020);
+        lua_setfield(L, -2, "bt2020");
+        lua_pushboolean(L, mon->m_output->vrrCapable);
+        lua_setfield(L, -2, "vrr_capable");
     }
 
     // Fns

--- a/src/config/lua/objects/LuaMonitor.cpp
+++ b/src/config/lua/objects/LuaMonitor.cpp
@@ -138,6 +138,14 @@ static int monitorIndex(lua_State* L) {
         lua_setfield(L, -2, "width");
         lua_pushinteger(L, sc<int>(mon->m_pixelSize.y));
         lua_setfield(L, -2, "height");
+    } else if (key == "mode") {
+        lua_newtable(L);
+        lua_pushinteger(L, sc<int>(mon->m_size.x));
+        lua_setfield(L, -2, "width");
+        lua_pushinteger(L, sc<int>(mon->m_size.y));
+        lua_setfield(L, -2, "height");
+        lua_pushnumber(L, sc<float>(mon->m_refreshRate));
+        lua_setfield(L, -2, "refresh_rate");
     } else if (key == "scale")
         lua_pushnumber(L, mon->m_scale);
     else if (key == "transform")

--- a/src/config/lua/objects/LuaMonitor.cpp
+++ b/src/config/lua/objects/LuaMonitor.cpp
@@ -1,5 +1,6 @@
 #include "LuaMonitor.hpp"
 #include "LuaWorkspace.hpp"
+#include "../../../helpers/string/StringUtils.hpp"
 #include "../../../state/WorkspaceState.hpp"
 #include "LuaObjectHelpers.hpp"
 
@@ -205,7 +206,7 @@ static int monitorIndex(lua_State* L) {
         lua_setfield(L, -2, "left");
     } else if (key == "hardware_details") {
         lua_newtable(L);
-        lua_pushstring(L, "FIXME!!!");
+        lua_pushstring(L, StringUtils::backendStr(mon->m_output->getBackend()->type()).c_str());
         lua_setfield(L, -2, "backend");
         lua_pushboolean(L, mon->m_output->parsedEDID.hdrMetadata.has_value());
         lua_setfield(L, -2, "hdr");

--- a/src/helpers/string/StringUtils.hpp
+++ b/src/helpers/string/StringUtils.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <aquamarine/backend/Backend.hpp>
+
+namespace StringUtils {
+    inline std::string backendStr(Aquamarine::eBackendType t) {
+        switch (t) {
+            case Aquamarine::AQ_BACKEND_DRM: return "drm";
+            case Aquamarine::AQ_BACKEND_HEADLESS: return "headless";
+            case Aquamarine::AQ_BACKEND_WAYLAND: return "wayland";
+            default: break;
+        }
+        return "?";
+    }
+}

--- a/src/ipc/s1/Commands.cpp
+++ b/src/ipc/s1/Commands.cpp
@@ -300,7 +300,7 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
             "{:x}\n\tdirectScanoutBlockedBy: {}\n\tdisabled: "
             "{}\n\tcurrentFormat: {}\n\tmirrorOf: "
             "{}\n\tavailableModes: {}\n\tcolorManagementPreset: {}\n\tsdrBrightness: {}\n\tsdrSaturation: {}\n\tsdrMinLuminance: {}\n\tsdrMaxLuminance: "
-            "{}\n\thardwareCursorsInUse: {}\n\thardwareDetails:\n\t  backend: {}\n\t  hdr: {}\n\t  chroma: {}\n\t  bt2020: {}\n\t  vrrCapable: {}\n\n",
+            "{}\n\thardwareCursorsInUse: {}\n\thardwareDetails:\n\t\tbackend: {}\n\t\thdr: {}\n\t\tchroma: {}\n\t\tbt2020: {}\n\t\tvrrCapable: {}\n\n",
             m->m_name, m->m_id, sc<int>(m->m_pixelSize.x), sc<int>(m->m_pixelSize.y), m->m_refreshRate, sc<int>(m->m_position.x), sc<int>(m->m_position.y), m->m_shortDescription,
             m->m_output->make, m->m_output->model, sc<int>(m->m_output->physicalSize.x), sc<int>(m->m_output->physicalSize.y), m->m_output->serial, m->activeWorkspaceID(),
             (!m->m_activeWorkspace ? "" : m->m_activeWorkspace->m_name), m->activeSpecialWorkspaceID(), (m->m_activeSpecialWorkspace ? m->m_activeSpecialWorkspace->m_name : ""),

--- a/src/ipc/s1/Commands.cpp
+++ b/src/ipc/s1/Commands.cpp
@@ -50,6 +50,7 @@ using namespace Hyprutils::String;
 #include "../../helpers/MiscFunctions.hpp"
 #include "../../keybinds/Manager.hpp"
 #include "../../helpers/SystemInfo.hpp"
+#include "../../helpers/string/StringUtils.hpp"
 #include "../../desktop/view/LayerSurface.hpp"
 #include "../../desktop/view/Group.hpp"
 #include "../../desktop/rule/Engine.hpp"
@@ -210,16 +211,6 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
     if (!m->m_output || m->m_id == -1)
         return "";
 
-    static auto backendStr = [](Aquamarine::eBackendType t) -> std::string {
-        switch (t) {
-            case Aquamarine::AQ_BACKEND_DRM: return "drm";
-            case Aquamarine::AQ_BACKEND_HEADLESS: return "headless";
-            case Aquamarine::AQ_BACKEND_WAYLAND: return "wayland";
-            default: break;
-        }
-        return "?";
-    };
-
     static auto tf = [](bool t) -> const char* { return t ? "true" : "false"; };
     static auto yn = [](bool t) -> const char* { return t ? "yes" : "no"; };
 
@@ -289,8 +280,8 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
             tf(m->m_tearingState.activelyTearing), getTearingBlockedReason(m, format), rc<uint64_t>(m->m_lastScanout.get()), getDSBlockedReason(m, format), tf(m->m_enabled),
             formatToString(m->m_output->state->state().drmFormat), m->m_mirrorOf ? std::format("{}", m->m_mirrorOf->m_id) : "none", availableModesForOutput(m, format),
             (NCMType::toString(m->m_cmType)), (m->m_sdrBrightness), (m->m_sdrSaturation), (m->m_sdrMinLuminance), (m->m_sdrMaxLuminance), tf(!m->shouldUseSoftwareCursors()),
-            backendStr(m->m_output->getBackend()->type()), tf(m->m_output->parsedEDID.hdrMetadata.has_value()), tf(m->m_output->parsedEDID.chromaticityCoords.has_value()),
-            tf(m->m_output->parsedEDID.supportsBT2020), tf(m->m_output->vrrCapable));
+            StringUtils::backendStr(m->m_output->getBackend()->type()), tf(m->m_output->parsedEDID.hdrMetadata.has_value()),
+            tf(m->m_output->parsedEDID.chromaticityCoords.has_value()), tf(m->m_output->parsedEDID.supportsBT2020), tf(m->m_output->vrrCapable));
 
     } else {
         result += std::format(
@@ -309,7 +300,7 @@ std::string CCommandFormatter::getMonitorData(PHLMONITOR m, eHyprCtlOutputFormat
             rc<uint64_t>(m->m_solitaryClient.get()), getSolitaryBlockedReason(m, format), m->m_tearingState.activelyTearing, getTearingBlockedReason(m, format),
             rc<uint64_t>(m->m_lastScanout.get()), getDSBlockedReason(m, format), !m->m_enabled, formatToString(m->m_output->state->state().drmFormat),
             m->m_mirrorOf ? std::format("{}", m->m_mirrorOf->m_id) : "none", availableModesForOutput(m, format), (NCMType::toString(m->m_cmType)), (m->m_sdrBrightness),
-            (m->m_sdrSaturation), (m->m_sdrMinLuminance), (m->m_sdrMaxLuminance), (!m->shouldUseSoftwareCursors()), backendStr(m->m_output->getBackend()->type()),
+            (m->m_sdrSaturation), (m->m_sdrMinLuminance), (m->m_sdrMaxLuminance), (!m->shouldUseSoftwareCursors()), StringUtils::backendStr(m->m_output->getBackend()->type()),
             yn(m->m_output->parsedEDID.hdrMetadata.has_value()), yn(m->m_output->parsedEDID.chromaticityCoords.has_value()), yn(m->m_output->parsedEDID.supportsBT2020),
             yn(m->m_output->vrrCapable));
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

A `.mode` field for monitor objects, which is a table of the form `{ width = int, height = int, refresh_rate = float }`.

Currently, all we expose are `.width`/`.height`, which are in physical pixels. The mode's width and height are in logical pixels, which makes them easier to use with `.x`/`.y`, without having to do the scaling math yourself in Lua.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not really, this is a pretty trivial addition

#### Is it ready for merging, or does it need work?

Good to go. No tests currently, because we don't test any of the other monitor fields
