### PR TITLE
layout/floating: fix "move" rule not using the size provided by the "size" rule

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -2182,3 +2182,26 @@ TEST_CASE(windowRuleBorderColorsFocus) {
 
     Tests::killAllWindows();
 }
+
+TEST_CASE(floatingMoveExpression) {
+    OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_floatingmove' }, "
+                     "float = true, size = { 800, 600 }, "
+                     "move = { '(monitor_w-window_w-10)', '(monitor_h-window_h-10)' } })"));
+
+    SPAWN_KITTY("kitty_floatingmove");
+
+    Tests::waitUntilWindowsN(1);
+
+    const auto EXPECTED_AT = getFromSocket("/repl local m = hl.get_active_monitor();"
+                                           "return (m.x + m.width - 800 - 10) .. ',' "
+                                           ".. (m.y + m.height - 600 - 10)");
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "floating: 1");
+        EXPECT_CONTAINS(str, std::format("size: {},{}", 800, 600));
+        EXPECT_CONTAINS(str, std::format("at: {}", EXPECTED_AT));
+    }
+
+    Tests::killAllWindows();
+}

--- a/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
+++ b/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
@@ -61,8 +61,8 @@ void CDefaultFloatingAlgorithm::newTarget(SP<ITarget> target) {
                 windowGeometry.w = COMPUTED->x;
                 windowGeometry.h = COMPUTED->y;
 
-                // update for pos to work with size.
-                WINDOW->positionAnimation()->setValueAndWarp(*COMPUTED);
+                // update the size for position expressions to use.
+                WINDOW->sizeAnimation()->setValueAndWarp(*COMPUTED);
             }
         }
 


### PR DESCRIPTION


<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Discussed in #13409

fixed a regression introduced by 723870337f299d4c80aa0048144f3a1ca1c885bd where the computed size was used to update realPosition

```cpp
// before src/desktop/view/Window.cpp
const auto COMPUTED = calculateExpression(m_ruleApplicator->static_.size);
// ...
*m_realSize = *COMPUTED;

// regression src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
const auto COMPUTED = WINDOW->calculateExpression(*WINDOW->m_ruleApplicator->static_.size);
// ...
WINDOW->m_realPosition->setValueAndWarp(*COMPUTED);
```

e7996dc9 renames `m_realPosition/m_realSize` to `positionAnimation()/sizeAnimation()` with no functional change
