### PR TITLE
docs: update links to wiki of Hyprland manpages

### DIFF
--- a/docs/Hyprland.1
+++ b/docs/Hyprland.1
@@ -38,7 +38,7 @@ Although Hyprland is pretty stable, it may have some bugs.
 .SH CONFIGURATION
 .PP
 For configuration information please see
-<\f[I]https://github.com/hyprwm/Hyprland/wiki\f[R]>.
+<\f[I]https://wiki.hypr.land\f[R]>.
 .SH OPTIONS
 .TP
 \f[B]-h\f[R], \f[B]--help\f[R]

--- a/docs/Hyprland.1.rst
+++ b/docs/Hyprland.1.rst
@@ -30,7 +30,7 @@ Although Hyprland is pretty stable, it may have some bugs.
 CONFIGURATION
 =============
 
-For configuration information please see <*https://github.com/hyprwm/Hyprland/wiki*>.
+For configuration information please see <*https://wiki.hypr.land*>.
 
 OPTIONS
 =======


### PR DESCRIPTION
point to external, up-to-date wiki instead of github's one
