### PR TITLE
xwayland: handle _NET_WM_STATE_DEMANDS_ATTENTION

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -457,6 +457,8 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
                     XSURF->m_state.requestsMinimize = updateState(action, XSURF->m_minimized);
                 if (prop == HYPRATOMS["_NET_WM_STATE_MAXIMIZED_VERT"] || prop == HYPRATOMS["_NET_WM_STATE_MAXIMIZED_HORZ"])
                     XSURF->m_state.requestsMaximize = updateState(action, XSURF->m_maximized);
+                if (prop == HYPRATOMS["_NET_WM_STATE_DEMANDS_ATTENTION"] && updateState(action, false))
+                    XSURF->m_events.activate.emit();
             }
 
             XSURF->m_events.stateChanged.emit();


### PR DESCRIPTION
<!--
WARNING: PRs from unvouched users (new contributors) will be automatically closed.
You MUST be vouched to be able to open PRs. Check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Handle `_NET_WM_STATE_DEMANDS_ATTENTION` from X11 clients (e.g. Wine's FlashWindowEx).
Window becomes urgent.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing.

#### Is it ready for merging, or does it need work?
Ready.

