### PR TITLE
 input-capture: implement the session destroy request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,6 +505,7 @@ function(protocolnew protoPath protoName external)
            ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp
     COMMAND hyprwayland-scanner ${path}/${protoName}.xml
             ${CMAKE_SOURCE_DIR}/protocols/
+    DEPENDS ${path}/${protoName}.xml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(hyprland_lib PRIVATE protocols/${protoName}.cpp
                                   protocols/${protoName}.hpp)
@@ -523,6 +524,7 @@ function(protocolWayland)
     COMMAND
       hyprwayland-scanner --wayland-enums
       ${WAYLAND_SCANNER_PKGDATA_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
+    DEPENDS ${WAYLAND_SCANNER_PKGDATA_DIR}/wayland.xml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(hyprland_lib PRIVATE protocols/wayland.cpp protocols/wayland.hpp)
   target_sources(generate-protocol-headers
@@ -540,7 +542,7 @@ else()
   target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GLES3 glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV Threads::Threads)
 endif()
 
-pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.7.0)
+pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.8.0)
 if(hyprland_protocols_dep_FOUND)
   pkg_get_variable(HYPRLAND_PROTOCOLS hyprland-protocols pkgdatadir)
   message(STATUS "hyprland-protocols dependency set to ${HYPRLAND_PROTOCOLS}")

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -208,7 +208,7 @@ CProtocolManager::CProtocolManager() {
     PROTO::singlePixel         = makeUnique<CSinglePixelProtocol>(&wp_single_pixel_buffer_manager_v1_interface, 1, "SinglePixel");
     PROTO::securityContext     = makeUnique<CSecurityContextProtocol>(&wp_security_context_manager_v1_interface, 1, "SecurityContext");
     PROTO::ctm                 = makeUnique<CHyprlandCTMControlProtocol>(&hyprland_ctm_control_manager_v1_interface, 2, "CTMControl");
-    PROTO::inputCapture        = makeUnique<CInputCaptureProtocol>(&hyprland_input_capture_manager_v1_interface, 1, "InputCapture");
+    PROTO::inputCapture        = makeUnique<CInputCaptureProtocol>(&hyprland_input_capture_manager_v1_interface, 2, "InputCapture");
     PROTO::hyprlandSurface     = makeUnique<CHyprlandSurfaceProtocol>(&hyprland_surface_manager_v1_interface, 2, "HyprlandSurface");
     PROTO::contentType         = makeUnique<CContentTypeProtocol>(&wp_content_type_manager_v1_interface, 1, "ContentType");
     PROTO::xdgTag              = makeUnique<CXDGToplevelTagProtocol>(&xdg_toplevel_tag_manager_v1_interface, 1, "XDGTag");

--- a/src/protocols/InputCapture.cpp
+++ b/src/protocols/InputCapture.cpp
@@ -33,6 +33,7 @@ CInputCaptureResource::CInputCaptureResource(SP<CHyprlandInputCaptureV1> resourc
     LOG(Log::INFO, "[input-capture]({}) new session", m_sessionId.c_str());
 
     m_resource->setOnDestroy([this](CHyprlandInputCaptureV1* r) { PROTO::inputCapture->destroyResource(this); }); //Remove & free this session
+    m_resource->setDestroy([this](CHyprlandInputCaptureV1* r) { PROTO::inputCapture->destroyResource(this); });
 
     m_resource->setEnable([this](CHyprlandInputCaptureV1* r) { onEnable(); });
     m_resource->setAddBarrier(
@@ -80,9 +81,6 @@ CInputCaptureResource::~CInputCaptureResource() {
         g_pEventLoopManager->removeTimer(m_keyRepeatTimer);
         m_keyRepeatTimer.reset();
     }
-
-    if (m_status == CLIENT_STATUS_ACTIVATED)
-        PROTO::inputCapture->forceRelease();
 
     LOG(Log::INFO, "[input-capture]({}) session destroyed", m_sessionId.c_str());
     PROTO::inputCapture->clearBarriers(m_sessionId);
@@ -358,7 +356,11 @@ void CInputCaptureProtocol::onCreateSession(CHyprlandInputCaptureManagerV1* pMgr
 }
 
 void CInputCaptureProtocol::destroyResource(CInputCaptureResource* resource) {
-    std::erase_if(m_Sessions, [resource](const auto& other) { return other->m_sessionId == resource->m_sessionId; });
+    //`active` holds a strong ref, so the erase alone would not destroy the session
+    if (active && active.get() == resource)
+        forceRelease();
+
+    std::erase_if(m_Sessions, [resource](const auto& other) { return other.get() == resource; });
 }
 
 bool CInputCaptureProtocol::isCaptured() {
@@ -417,6 +419,7 @@ void CInputCaptureProtocol::forceRelease() {
         auto cpy = active; //Because deactivate will put active to nullptr
         cpy->deactivate();
         cpy->disable();
+        g_pHyprRenderer->ensureCursorRenderingMode();
     }
     release();
 }


### PR DESCRIPTION
Compositor half of the fix for hyprwm/xdg-desktop-portal-hyprland#419: implements the session destroy request added in hyprwm/hyprland-protocols#22 so closed InputCapture sessions are actually freed instead of leaking their EIS fds. 

Depends on hyprwm/hyprland-protocols#22 landing first and pairs with hyprwm/xdg-desktop-portal-hyprland#421; replaces #15665.

Agent implemented/verified as part of the multi set of changes for this one.