### PR TITLE
Workspace events: `created` to `created_early`, new `created` after setup is done

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,6 +33,7 @@ FixNamespaceComments: false
 IncludeBlocks: Preserve
 IndentCaseLabels: true
 IndentWidth: 4
+OneLineFormatOffRegex: //<?[ \t]*clang-format[ \t]+off-one-line$
 PointerAlignment: Left
 ReflowComments: false
 SortIncludes: false

--- a/hyprtester/src/tests/main/workspaces.cpp
+++ b/hyprtester/src/tests/main/workspaces.cpp
@@ -1277,3 +1277,101 @@ TEST_CASE(workspaceSwitchUnfocusesWindowFromOldWorkspace) {
     // TODO: also test when workspaces 1 and 2 are on different workspaces.
     //       At the time of writing, it is broken (i.e., the test would fail).
 }
+
+SUBTEST(workspaceCreateEventFocus) {
+    // switch to a new workspace
+    NLog::log("{}Focusing a new workspace", Colors::YELLOW);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 2 })"));
+
+    // should have a kitty window appear on it
+    {
+        Tests::waitUntilWindowsN(1);
+        auto str = getFromSocket("/activeworkspace");
+        ASSERT_CONTAINS(str, "workspace 2 (2) on monitor HEADLESS-2:");
+        ASSERT_CONTAINS(str, "windows: 1");
+    }
+
+    // clean up
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 1 })"));
+    Tests::waitUntilWindowsN(1);
+    Tests::killAllWindows();
+}
+
+SUBTEST(workspaceCreateEventSilent) {
+    // spawn window to a new workspace, without focusing
+    NLog::log("{}Spawning window on a new workspace", Colors::YELLOW);
+    OK(getFromSocket("/dispatch hl.dsp.exec_cmd('kitty', { workspace = '2 silent' })"));
+
+    // should have a kitty window appear on it, and another on the current workspace from the event handler
+    {
+        Tests::waitUntilWindowsN(2);
+        auto str = getFromSocket("/workspaces");
+        ASSERT_CONTAINS(str, "workspace 2 (2) on monitor HEADLESS-2:");
+        ASSERT(Tests::countOccurrences(str, "windows: 1"), 2);
+    }
+
+    // clean up
+    Tests::killAllWindows();
+}
+
+SUBTEST(workspaceCreateEventSpecial) {
+    // create a special workspace
+    NLog::log("{}Focusing a special workspace", Colors::YELLOW);
+    OK(getFromSocket("/dispatch hl.dsp.workspace.toggle_special()"));
+
+    // should have a kitty window appear on it
+    {
+        Tests::waitUntilWindowsN(1);
+        int counter = 0;
+        while (getFromSocket("/repl hl.get_active_special_workspace().windows") != "1") {
+            counter++;
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            if (counter > 50) {
+                std::println("{}Timed out waiting for windows", Colors::RED);
+                MARK_TEST_FAILED_SILENT();
+                return;
+            }
+        }
+        LOG_OK("Got a window on special workspace{}", "");
+        ASSERT(getFromSocket("/repl hl.get_active_special_workspace().name"), "special:special");
+        ASSERT(getFromSocket("/repl hl.get_active_special_workspace().monitor.name"), "HEADLESS-2");
+    }
+
+    // clean up
+    OK(getFromSocket("/dispatch hl.dsp.workspace.toggle_special()"));
+    Tests::killAllWindows();
+}
+
+SUBTEST(workspaceCreateEventNewMonitor) {
+    static constexpr const char* SECOND_MONITOR = "HEADLESS-3";
+
+    // add a new monitor
+    NLog::log("{}Adding a new monitor", Colors::YELLOW);
+    OK(getFromSocket(std::format("/output create headless {}", SECOND_MONITOR)));
+
+    // should have a kitty window appear on it
+    {
+        Tests::waitUntilWindowsN(1);
+        auto str = getFromSocket("/workspaces");
+        ASSERT_CONTAINS(str, std::format("workspace 2 (2) on monitor {}:", SECOND_MONITOR));
+        ASSERT_CONTAINS(str, "windows: 1");
+    }
+
+    // clean up
+    Tests::killAllWindows();
+    OK(getFromSocket(std::format("/output remove {}", SECOND_MONITOR)));
+    ASSERT(waitForMonitorListed(SECOND_MONITOR, false), true);
+
+    // make sure removing the monitor didn't spawn a workspace and trigger the event
+    ASSERT(Tests::windowCount(), 0);
+}
+
+TEST_CASE(workspaceCreateEvents) {
+    // event handler to put a kitty instance on new workspaces
+    OK(getFromSocket("/eval hl.on('workspace.created', function(ws) hl.exec_cmd('kitty') end)"));
+
+    CALL_SUBTEST(workspaceCreateEventFocus);
+    CALL_SUBTEST(workspaceCreateEventSilent);
+    CALL_SUBTEST(workspaceCreateEventSpecial);
+    CALL_SUBTEST(workspaceCreateEventNewMonitor);
+}

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -138,11 +138,17 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             CLuaMonitor::push(L, mon);
         });
     }));
-    m_listeners.push_back(bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF wsRef) {
+    m_listeners.push_back(bus()->m_events.workspace.createdLate.listen([this](PHLWORKSPACEREF wsRef) {
         const auto ws = wsRef.lock();
         if (!ws)
             return;
         dispatch("workspace.created", 1, [&](lua_State* L) { CLuaWorkspace::push(L, ws); });
+    }));
+    m_listeners.push_back(bus()->m_events.workspace.createdEarly.listen([this](PHLWORKSPACEREF wsRef) {
+        const auto ws = wsRef.lock();
+        if (!ws)
+            return;
+        dispatch("workspace.created_early", 1, [&](lua_State* L) { CLuaWorkspace::push(L, ws); });
     }));
     m_listeners.push_back(bus()->m_events.workspace.removed.listen([this](PHLWORKSPACEREF wsRef) {
         if (!wsRef)
@@ -301,6 +307,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "workspace.active",
         "workspace.special_active",
         "workspace.created",
+        "workspace.created_early",
         "workspace.removed",
         "workspace.move_to_monitor",
         "config.reloaded",

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -217,8 +217,6 @@ namespace {
          [](ILuaConfigValue* v, Config::CWorkspaceRule& r) { r.m_decorate = *sc<const Config::BOOL*>(v->data()); }},
         {"no_shadow", []() -> ILuaConfigValue* { return new CLuaConfigBool(false); },
          [](ILuaConfigValue* v, Config::CWorkspaceRule& r) { r.m_noShadow = *sc<const Config::BOOL*>(v->data()); }},
-        {"on_created_empty", []() -> ILuaConfigValue* { return new CLuaConfigString(STRVAL_EMPTY); },
-         [](ILuaConfigValue* v, Config::CWorkspaceRule& r) { r.m_onCreatedEmptyRunCmd = *sc<const Config::STRING*>(v->data()); }},
         {"default_name", []() -> ILuaConfigValue* { return new CLuaConfigString(STRVAL_EMPTY); },
          [](ILuaConfigValue* v, Config::CWorkspaceRule& r) { r.m_defaultName = *sc<const Config::STRING*>(v->data()); }},
         {"layout", []() -> ILuaConfigValue* { return new CLuaConfigString(STRVAL_EMPTY); },

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1,6 +1,7 @@
 #include "LuaBindingsInternal.hpp"
 
 #include <lua.h>
+#include <hyprutils/utils/ScopeGuard.hpp>
 
 #include "Check.hpp"
 
@@ -443,7 +444,9 @@ static int dsp_moveToWorkspace(lua_State* L) {
     auto ws = Internal::resolveWorkspaceStr(lua_tostring(L, lua_upvalueindex(1)));
     if (!ws)
         return Internal::dispatcherError(L, "Invalid workspace", ERR, C_INVARG);
+    Hyprutils::Utils::CScopeGuard x([&]() { ws->ready(); });
 
+    //
     bool silent = lua_toboolean(L, lua_upvalueindex(2));
     return Internal::checkResult(L, CA::moveToWorkspace(ws, silent, Internal::windowFromUpval(L, 3)));
 }
@@ -1091,6 +1094,7 @@ static int dsp_focusWorkspaceOnCurrentMonitor(lua_State* L) {
     auto ws = Internal::resolveWorkspaceStr(lua_tostring(L, lua_upvalueindex(1)));
     if (!ws)
         return Internal::dispatcherError(L, "Invalid workspace", ERR, C_INVARG);
+    Hyprutils::Utils::CScopeGuard x([&]() { ws->ready(); });
     return Internal::checkResult(L, CA::changeWorkspaceOnCurrentMonitor(ws));
 }
 
@@ -1175,6 +1179,7 @@ static int dsp_toggleSpecial(lua_State* L) {
     if (!ws)
         return Internal::dispatcherError(L, "Could not resolve special workspace", ERR, C_UNAVAIL);
 
+    Hyprutils::Utils::CScopeGuard x([&]() { ws->ready(); });
     return Internal::checkResult(L, CA::toggleSpecial(ws));
 }
 

--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -406,7 +406,7 @@ PHLWORKSPACE Internal::resolveWorkspaceStr(const std::string& args) {
     if (!ws) {
         const auto PMONITOR = Desktop::focusState()->monitor();
         if (PMONITOR)
-            ws = State::Workspace::state()->create(TARGET, PMONITOR, false);
+            ws = State::Workspace::state()->create(TARGET, PMONITOR);
     }
 
     return ws;

--- a/src/config/lua/objects/LuaMonitor.cpp
+++ b/src/config/lua/objects/LuaMonitor.cpp
@@ -56,6 +56,7 @@ static int monitorSetWorkspace(lua_State* L) {
 
     State::Workspace::placementController()->moveWorkspaceToMonitor(ws, ref->lock(), true, false);
     (*ref)->changeWorkspace(ws, false, true, Desktop::focusState()->monitor() != *ref);
+    ws->ready();
 
     return 0;
 }
@@ -82,6 +83,7 @@ static int monitorSetSpecialWorkspace(lua_State* L) {
         ws = State::Workspace::state()->create(TARGET, ref->lock());
 
     (*ref)->setSpecialWorkspace(ws, true);
+    ws->ready();
 
     return 0;
 }

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1076,6 +1076,7 @@ ActionResult Actions::changeWorkspace(const std::string& ws) {
     auto p = resolveWorkspaceForChange(ws);
     if (!p)
         return actionError("Bad workspace", eActionErrorLevel::WARNING, eActionErrorCode::NO_TARGET);
+    Hyprutils::Utils::CScopeGuard x([&]() { p->ready(); });
     return Actions::changeWorkspace(p);
 }
 

--- a/src/config/shared/workspace/WorkspaceRule.cpp
+++ b/src/config/shared/workspace/WorkspaceRule.cpp
@@ -27,8 +27,6 @@ void CWorkspaceRule::mergeLeft(const CWorkspaceRule& other) {
         m_decorate = other.m_decorate;
     if (other.m_noShadow.has_value())
         m_noShadow = other.m_noShadow;
-    if (other.m_onCreatedEmptyRunCmd.has_value())
-        m_onCreatedEmptyRunCmd = other.m_onCreatedEmptyRunCmd;
     if (other.m_defaultName.has_value())
         m_defaultName = other.m_defaultName;
     if (other.m_layout.has_value())

--- a/src/config/shared/workspace/WorkspaceRule.hpp
+++ b/src/config/shared/workspace/WorkspaceRule.hpp
@@ -36,7 +36,6 @@ namespace Config {
         std::optional<bool>                m_noRounding;
         std::optional<bool>                m_noBorder;
         std::optional<bool>                m_noShadow;
-        std::optional<std::string>         m_onCreatedEmptyRunCmd;
         std::optional<std::string>         m_defaultName;
         std::optional<std::string>         m_layout;
         std::map<std::string, std::string> m_layoutopts;

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1370,7 +1370,7 @@ void CWindow::mapWindow() {
             auto pWorkspace = State::Workspace::state()->find(target);
 
             if (!pWorkspace)
-                pWorkspace = State::Workspace::state()->create(target, m_monitor.lock(), false);
+                pWorkspace = State::Workspace::state()->create(target, m_monitor.lock());
 
             if (!pWorkspace) {
                 LOG(Log::ERR, "Failed to create requested workspace {}", joined);

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1588,6 +1588,7 @@ void CWindow::mapWindow() {
         m_workspace->updateWindows();
 
     Event::bus()->m_events.window.openLate.emit(m_self.lock());
+    PWORKSPACE->ready();
 }
 
 void CWindow::unmapWindow() {

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -175,7 +175,8 @@ namespace Event {
                 Event<PHLWORKSPACE, PHLMONITOR> moveToMonitor;
                 Event<PHLWORKSPACE>             active;
                 Event<PHLWORKSPACE, PHLMONITOR> specialActive;
-                Event<PHLWORKSPACEREF>          created;
+                Event<PHLWORKSPACEREF>          createdEarly;
+                Event<PHLWORKSPACEREF>          createdLate;
                 Event<PHLWORKSPACEREF>          removed;
                 Event<PHLWORKSPACEREF>          renamed;
             } workspace;

--- a/src/ipc/s1/Commands.cpp
+++ b/src/ipc/s1/Commands.cpp
@@ -557,39 +557,36 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
         const std::string decorate    = sc<bool>(r.m_decorate) ? std::format(",\n    \"decorate\": {}", boolToString(r.m_decorate.value())) : "";
         const std::string shadow      = sc<bool>(r.m_noShadow) ? std::format(",\n    \"shadow\": {}", boolToString(!r.m_noShadow.value())) : "";
         const std::string defaultName = r.m_defaultName.has_value() ? std::format(",\n    \"defaultName\": \"{}\"", escapeJSONStrings(r.m_defaultName.value())) : "";
-        const std::string onCreatedEmpty =
-            r.m_onCreatedEmptyRunCmd.has_value() ? std::format(",\n    \"onCreatedEmpty\": \"{}\"", escapeJSONStrings(r.m_onCreatedEmptyRunCmd.value())) : "";
 
         std::string result = std::format(R"#({{
-    "workspaceString": "{}"{}{}{}{}{}{}{}{}{}{}{}{}{}
+    "workspaceString": "{}"{}{}{}{}{}{}{}{}{}{}{}{}
 }})#",
                                          escapeJSONStrings(r.m_workspaceString), enabled, monitor, default_, persistent, gapsIn, gapsOut, borderSize, border, rounding, decorate,
-                                         shadow, defaultName, onCreatedEmpty);
+                                         shadow, defaultName);
 
         return result;
     } else {
-        const std::string monitor        = std::format("\tmonitor: {}\n", r.m_monitor.empty() ? "<unset>" : escapeJSONStrings(r.m_monitor));
-        const std::string enabled        = std::format("\tenabled: {}\n", boolToString(r.isEnabled()));
-        const std::string default_       = std::format("\tdefault: {}\n", sc<bool>(r.m_isDefault) ? boolToString(r.m_isDefault.value()) : "<unset>");
-        const std::string persistent     = std::format("\tpersistent: {}\n", sc<bool>(r.m_isPersistent) ? boolToString(r.m_isPersistent.value()) : "<unset>");
-        const std::string gapsIn         = sc<bool>(r.m_gapsIn) ?
+        const std::string monitor     = std::format("\tmonitor: {}\n", r.m_monitor.empty() ? "<unset>" : escapeJSONStrings(r.m_monitor));
+        const std::string enabled     = std::format("\tenabled: {}\n", boolToString(r.isEnabled()));
+        const std::string default_    = std::format("\tdefault: {}\n", sc<bool>(r.m_isDefault) ? boolToString(r.m_isDefault.value()) : "<unset>");
+        const std::string persistent  = std::format("\tpersistent: {}\n", sc<bool>(r.m_isPersistent) ? boolToString(r.m_isPersistent.value()) : "<unset>");
+        const std::string gapsIn      = sc<bool>(r.m_gapsIn) ?
             std::format("\tgapsIn: {} {} {} {}\n", std::to_string(r.m_gapsIn.value().m_top), std::to_string(r.m_gapsIn.value().m_right),
                         std::to_string(r.m_gapsIn.value().m_bottom), std::to_string(r.m_gapsIn.value().m_left)) :
             std::format("\tgapsIn: <unset>\n");
-        const std::string gapsOut        = sc<bool>(r.m_gapsOut) ?
+        const std::string gapsOut     = sc<bool>(r.m_gapsOut) ?
             std::format("\tgapsOut: {} {} {} {}\n", std::to_string(r.m_gapsOut.value().m_top), std::to_string(r.m_gapsOut.value().m_right),
                         std::to_string(r.m_gapsOut.value().m_bottom), std::to_string(r.m_gapsOut.value().m_left)) :
             std::format("\tgapsOut: <unset>\n");
-        const std::string borderSize     = std::format("\tborderSize: {}\n", sc<bool>(r.m_borderSize) ? std::to_string(r.m_borderSize.value()) : "<unset>");
-        const std::string border         = std::format("\tborder: {}\n", sc<bool>(r.m_noBorder) ? boolToString(!r.m_noBorder.value()) : "<unset>");
-        const std::string rounding       = std::format("\trounding: {}\n", sc<bool>(r.m_noRounding) ? boolToString(!r.m_noRounding.value()) : "<unset>");
-        const std::string decorate       = std::format("\tdecorate: {}\n", sc<bool>(r.m_decorate) ? boolToString(r.m_decorate.value()) : "<unset>");
-        const std::string shadow         = std::format("\tshadow: {}\n", sc<bool>(r.m_noShadow) ? boolToString(!r.m_noShadow.value()) : "<unset>");
-        const std::string defaultName    = std::format("\tdefaultName: {}\n", r.m_defaultName.value_or("<unset>"));
-        const std::string onCreatedEmpty = std::format("\tonCreatedEmpty: {}\n", r.m_onCreatedEmptyRunCmd.value_or("<unset>"));
+        const std::string borderSize  = std::format("\tborderSize: {}\n", sc<bool>(r.m_borderSize) ? std::to_string(r.m_borderSize.value()) : "<unset>");
+        const std::string border      = std::format("\tborder: {}\n", sc<bool>(r.m_noBorder) ? boolToString(!r.m_noBorder.value()) : "<unset>");
+        const std::string rounding    = std::format("\trounding: {}\n", sc<bool>(r.m_noRounding) ? boolToString(!r.m_noRounding.value()) : "<unset>");
+        const std::string decorate    = std::format("\tdecorate: {}\n", sc<bool>(r.m_decorate) ? boolToString(r.m_decorate.value()) : "<unset>");
+        const std::string shadow      = std::format("\tshadow: {}\n", sc<bool>(r.m_noShadow) ? boolToString(!r.m_noShadow.value()) : "<unset>");
+        const std::string defaultName = std::format("\tdefaultName: {}\n", r.m_defaultName.value_or("<unset>"));
 
-        std::string result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.m_workspaceString), enabled, monitor, default_, persistent, gapsIn,
-                                         gapsOut, borderSize, border, rounding, decorate, shadow, defaultName, onCreatedEmpty);
+        std::string result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.m_workspaceString), enabled, monitor, default_, persistent, gapsIn,
+                                         gapsOut, borderSize, border, rounding, decorate, shadow, defaultName);
 
         return result;
     }

--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
@@ -344,8 +344,10 @@ void CUnifiedWorkspaceSwipeGesture::end() {
 
     g_pInputManager->refocus();
 
-    // apply alpha
     if (pSwitchedTo) {
+        pSwitchedTo->ready();
+
+        // apply alpha
         const auto  FSWINDOW         = Fullscreen::controller()->getFullscreenWindow(pSwitchedTo);
         const auto  FS_MODE_INTERNAL = FSWINDOW ? Fullscreen::controller()->getFullscreenModes(FSWINDOW).internal : Fullscreen::FSMODE_NONE;
         const auto& SPACE            = pSwitchedTo->space();

--- a/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.cpp
+++ b/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.cpp
@@ -58,6 +58,7 @@ void CSpecialWorkspaceGesture::begin(const ITrackpadGesture::STrackpadGestureBeg
         if (!WS)
             return;
         m_monitor->setSpecialWorkspace(WS);
+        WS->ready();
         m_specialWorkspace = WS;
     }
 

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -374,6 +374,8 @@ void CMonitor::onConnect(bool noRule) {
     IPC::Socket2::sock()->postEvent({"monitoradded", m_name});
     IPC::Socket2::sock()->postEvent({"monitoraddedv2", std::format("{},{},{}", m_id, m_name, m_shortDescription)});
     Event::bus()->m_events.monitor.added.emit(m_self.lock());
+
+    m_activeWorkspace->ready();
 }
 
 void CMonitor::onDisconnect(bool destroy) {

--- a/src/protocols/ExtWorkspace.cpp
+++ b/src/protocols/ExtWorkspace.cpp
@@ -360,7 +360,7 @@ void CExtWorkspaceManagerResource::onWorkspaceCreated(const PHLWORKSPACE& worksp
 }
 
 CExtWorkspaceProtocol::CExtWorkspaceProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
-    static auto P1 = Event::bus()->m_events.workspace.created.listen([this](PHLWORKSPACEREF workspace) {
+    static auto P1 = Event::bus()->m_events.workspace.createdEarly.listen([this](PHLWORKSPACEREF workspace) {
         for (auto const& m : m_managers) {
             m->onWorkspaceCreated(workspace.lock());
         }

--- a/src/state/workspace/LifecyclePolicy.cpp
+++ b/src/state/workspace/LifecyclePolicy.cpp
@@ -115,7 +115,7 @@ void CMonitorLifecyclePolicy::monitorDisconnected(const SMonitorSnapshot& monito
             m_returnMonitors.emplace_back(workspace.identity, monitor.address);
 
         if (BACKUP != MONITORS.end())
-            context.moveWorkspace(workspace.identity, BACKUP->address);
+            context.moveWorkspace(workspace.identity, BACKUP->address, false);
     }
 }
 

--- a/src/state/workspace/LifecyclePolicy.hpp
+++ b/src/state/workspace/LifecyclePolicy.hpp
@@ -39,13 +39,13 @@ namespace State::Workspace {
         virtual ~IPolicyContext() = default;
 
         // Mutation callbacks are synchronous: later snapshot reads must observe their effects.
-        virtual std::vector<SMonitorSnapshot>           monitors() const                                                                       = 0;
-        virtual std::vector<SWorkspaceSnapshot>         workspaces() const                                                                     = 0;
-        virtual std::optional<SWorkspaceIdentity>       configuredDefaultWorkspace(std::string_view monitorAddress) const                      = 0;
-        virtual std::vector<SDefaultWorkspaceCandidate> defaultWorkspaceCandidates(std::string_view monitorAddress) const                      = 0;
-        virtual void                                    createWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress)   = 0;
-        virtual void                                    moveWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress)     = 0;
-        virtual void                                    activateWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress) = 0;
+        virtual std::vector<SMonitorSnapshot>           monitors() const                                                                                        = 0;
+        virtual std::vector<SWorkspaceSnapshot>         workspaces() const                                                                                      = 0;
+        virtual std::optional<SWorkspaceIdentity>       configuredDefaultWorkspace(std::string_view monitorAddress) const                                       = 0;
+        virtual std::vector<SDefaultWorkspaceCandidate> defaultWorkspaceCandidates(std::string_view monitorAddress) const                                       = 0;
+        virtual void                                    createWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress)                    = 0;
+        virtual void                                    moveWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress, bool replace = true) = 0;
+        virtual void                                    activateWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress)                  = 0;
     };
 
     class CMonitorLifecyclePolicy {

--- a/src/state/workspace/LifecyclePolicyAdapter.cpp
+++ b/src/state/workspace/LifecyclePolicyAdapter.cpp
@@ -140,9 +140,9 @@ class CHyprlandPolicyContext final : public IPolicyContext {
         finishLifecycleTransition(m_createdWorkspace);
     }
 
-    void moveWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress) override {
+    void moveWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress, bool replace) override {
         const auto WORKSPACE = findWorkspace(identity);
-        placementController()->moveWorkspaceToMonitor(WORKSPACE, findMonitor(monitorAddress), true, false);
+        placementController()->moveWorkspaceToMonitor(WORKSPACE, findMonitor(monitorAddress), true, false, replace);
         finishLifecycleTransition(WORKSPACE);
     }
 

--- a/src/state/workspace/PlacementController.cpp
+++ b/src/state/workspace/PlacementController.cpp
@@ -52,9 +52,8 @@ void CPlacementController::ensurePersistentWorkspacesPresent(const std::vector<S
         const auto&  rule = *rulePtr;
 
         PHLWORKSPACE PWORKSPACE = nullptr;
-        // clang-format off
+        // clang-format off-one-line
         Hyprutils::Utils::CScopeGuard x([&]() { if (PWORKSPACE) PWORKSPACE->ready(); });
-        // clang-format on
         if (pWorkspace) {
             if (pWorkspace->matchesStaticSelector(rule.m_workspaceString))
                 PWORKSPACE = pWorkspace;
@@ -265,9 +264,8 @@ void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMO
 
     // fix old mon
     PHLWORKSPACE nextWorkspaceOnMonitor;
-    // clang-format off
+    // clang-format off-one-line
     Hyprutils::Utils::CScopeGuard x([&]() { if (nextWorkspaceOnMonitor) nextWorkspaceOnMonitor->ready(); });
-    // clang-format on
     if (replace) {
         if (!SWITCHINGISACTIVE)
             nextWorkspaceOnMonitor = pWorkspace;

--- a/src/state/workspace/PlacementController.cpp
+++ b/src/state/workspace/PlacementController.cpp
@@ -52,6 +52,9 @@ void CPlacementController::ensurePersistentWorkspacesPresent(const std::vector<S
         const auto&  rule = *rulePtr;
 
         PHLWORKSPACE PWORKSPACE = nullptr;
+        // clang-format off
+        Hyprutils::Utils::CScopeGuard x([&]() { if (PWORKSPACE) PWORKSPACE->ready(); });
+        // clang-format on
         if (pWorkspace) {
             if (pWorkspace->matchesStaticSelector(rule.m_workspaceString))
                 PWORKSPACE = pWorkspace;
@@ -262,6 +265,9 @@ void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMO
 
     // fix old mon
     PHLWORKSPACE nextWorkspaceOnMonitor;
+    // clang-format off
+    Hyprutils::Utils::CScopeGuard x([&]() { if (nextWorkspaceOnMonitor) nextWorkspaceOnMonitor->ready(); });
+    // clang-format on
     if (!SWITCHINGISACTIVE)
         nextWorkspaceOnMonitor = pWorkspace;
     else {

--- a/src/state/workspace/PlacementController.cpp
+++ b/src/state/workspace/PlacementController.cpp
@@ -243,7 +243,7 @@ void CPlacementController::swapActiveWorkspaces(PHLMONITOR pMonitorA, PHLMONITOR
     Event::bus()->m_events.workspace.moveToMonitor.emit(PWORKSPACEB, pMonitorA);
 }
 
-void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMonitor, bool noWarpCursor, bool carryFocus) const {
+void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMonitor, bool noWarpCursor, bool carryFocus, bool replace) const {
     static auto PHIDESPECIALONWORKSPACECHANGE = CConfigValue<Config::INTEGER>("binds:hide_special_on_workspace_change");
 
     if (!pWorkspace || !pMonitor)
@@ -268,37 +268,39 @@ void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMO
     // clang-format off
     Hyprutils::Utils::CScopeGuard x([&]() { if (nextWorkspaceOnMonitor) nextWorkspaceOnMonitor->ready(); });
     // clang-format on
-    if (!SWITCHINGISACTIVE)
-        nextWorkspaceOnMonitor = pWorkspace;
-    else {
-        PHLWORKSPACE newWorkspace; // for holding a ref to the new workspace that might be created
+    if (replace) {
+        if (!SWITCHINGISACTIVE)
+            nextWorkspaceOnMonitor = pWorkspace;
+        else {
+            PHLWORKSPACE newWorkspace; // for holding a ref to the new workspace that might be created
 
-        for (auto const& w : state()->workspaces()) {
-            if (w->m_monitor == POLDMON && w.lock() != pWorkspace && w->type() != ::Workspace::eWorkspaceType::SPECIAL) {
-                nextWorkspaceOnMonitor = w.lock();
-                break;
+            for (auto const& w : state()->workspaces()) {
+                if (w->m_monitor == POLDMON && w.lock() != pWorkspace && w->type() != ::Workspace::eWorkspaceType::SPECIAL) {
+                    nextWorkspaceOnMonitor = w.lock();
+                    break;
+                }
             }
-        }
 
-        if (!nextWorkspaceOnMonitor) {
-            ::Workspace::WorkspaceIDContainer nextWorkspaceOnMonitorID = 1;
+            if (!nextWorkspaceOnMonitor) {
+                ::Workspace::WorkspaceIDContainer nextWorkspaceOnMonitorID = 1;
 
-            while (state()->query().numbered(::Workspace::SWorkspaceNumberedID{nextWorkspaceOnMonitorID}).run() || [&]() -> bool {
-                const auto B = Config::workspaceRuleMgr()->getBoundMonitorForWS(std::to_string(nextWorkspaceOnMonitorID));
-                return B && B != POLDMON;
-            }())
-                nextWorkspaceOnMonitorID++;
+                while (state()->query().numbered(::Workspace::SWorkspaceNumberedID{nextWorkspaceOnMonitorID}).run() || [&]() -> bool {
+                    const auto B = Config::workspaceRuleMgr()->getBoundMonitorForWS(std::to_string(nextWorkspaceOnMonitorID));
+                    return B && B != POLDMON;
+                }())
+                    nextWorkspaceOnMonitorID++;
 
-            LOG(Log::DEBUG, "moveWorkspaceToMonitor: Plugging gap with new {}", nextWorkspaceOnMonitorID);
+                LOG(Log::DEBUG, "moveWorkspaceToMonitor: Plugging gap with new {}", nextWorkspaceOnMonitorID);
 
+                if (POLDMON)
+                    newWorkspace = state()->createNumbered(::Workspace::SWorkspaceNumberedID{nextWorkspaceOnMonitorID}, POLDMON);
+                nextWorkspaceOnMonitor = newWorkspace;
+            }
+
+            LOG(Log::DEBUG, "moveWorkspaceToMonitor: Plugging gap with existing {}", nextWorkspaceOnMonitor ? nextWorkspaceOnMonitor->addressableName() : "none");
             if (POLDMON)
-                newWorkspace = state()->createNumbered(::Workspace::SWorkspaceNumberedID{nextWorkspaceOnMonitorID}, POLDMON);
-            nextWorkspaceOnMonitor = newWorkspace;
+                POLDMON->changeWorkspace(nextWorkspaceOnMonitor, false, true, carryFocus || POLDMON != Desktop::focusState()->monitor());
         }
-
-        LOG(Log::DEBUG, "moveWorkspaceToMonitor: Plugging gap with existing {}", nextWorkspaceOnMonitor ? nextWorkspaceOnMonitor->addressableName() : "none");
-        if (POLDMON)
-            POLDMON->changeWorkspace(nextWorkspaceOnMonitor, false, true, carryFocus || POLDMON != Desktop::focusState()->monitor());
     }
 
     // move the workspace
@@ -308,7 +310,7 @@ void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMO
 
     for (auto const& w : Desktop::windowState()->windows()) {
         if (w->m_workspace == pWorkspace) {
-            if (w->m_state & Desktop::View::WINDOW_STATE_PINNED) {
+            if (nextWorkspaceOnMonitor && (w->m_state & Desktop::View::WINDOW_STATE_PINNED)) {
                 w->m_workspace = nextWorkspaceOnMonitor;
                 continue;
             }

--- a/src/state/workspace/PlacementController.cpp
+++ b/src/state/workspace/PlacementController.cpp
@@ -77,7 +77,7 @@ void CPlacementController::ensurePersistentWorkspacesPresent(const std::vector<S
                 PMONITOR = Desktop::focusState()->monitor();
 
             if (!PWORKSPACE)
-                PWORKSPACE = State::Workspace::state()->create(TARGET, PMONITOR, false);
+                PWORKSPACE = State::Workspace::state()->create(TARGET, PMONITOR);
         }
 
         const auto REGULAR = dynamicPointerCast<::Workspace::CRegularWorkspace>(PWORKSPACE);

--- a/src/state/workspace/PlacementController.hpp
+++ b/src/state/workspace/PlacementController.hpp
@@ -16,7 +16,7 @@ namespace State::Workspace {
         void ensurePersistentWorkspacesPresent(PHLWORKSPACE pWorkspace, const FMoveWorkspace& moveWorkspace) const;
         void ensurePersistentWorkspacesPresent(const std::vector<SP<Config::CWorkspaceRule>>& rules, PHLWORKSPACE pWorkspace, const FMoveWorkspace& moveWorkspace) const;
         void ensureWorkspacesOnAssignedMonitors(const FMoveWorkspace& moveWorkspace) const;
-        void moveWorkspaceToMonitor(PHLWORKSPACE, PHLMONITOR, bool noWarpCursor = false, bool carryFocus = true) const;
+        void moveWorkspaceToMonitor(PHLWORKSPACE, PHLMONITOR, bool noWarpCursor = false, bool carryFocus = true, bool replace = true) const;
         void swapActiveWorkspaces(PHLMONITOR, PHLMONITOR) const;
     };
 

--- a/src/state/workspace/State.cpp
+++ b/src/state/workspace/State.cpp
@@ -81,18 +81,18 @@ PHLWORKSPACE CState::find(const STarget& target) const {
     return query().identity(*target.id, target.address, target.type).run();
 }
 
-PHLWORKSPACE CState::create(const STarget& target, PHLMONITOR monitor, bool isEmpty) {
+PHLWORKSPACE CState::create(const STarget& target, PHLMONITOR monitor) {
     if (!target.valid() || !monitor)
         return nullptr;
 
     if (const auto NUMBERED = std::get_if<::Workspace::SWorkspaceNumberedID>(&*target.id); NUMBERED)
-        return createNumbered(*NUMBERED, std::move(monitor), target.displayName, isEmpty);
+        return createNumbered(*NUMBERED, std::move(monitor), target.displayName);
     if (target.type == ::Workspace::eWorkspaceType::SPECIAL)
-        return createSpecial(target.address, std::move(monitor), isEmpty);
-    return createNamed(target.address, std::move(monitor), target.displayName, isEmpty);
+        return createSpecial(target.address, std::move(monitor));
+    return createNamed(target.address, std::move(monitor), target.displayName);
 }
 
-PHLWORKSPACE CState::createNumbered(::Workspace::SWorkspaceNumberedID id, PHLMONITOR monitor, std::string displayName, bool isEmpty) {
+PHLWORKSPACE CState::createNumbered(::Workspace::SWorkspaceNumberedID id, PHLMONITOR monitor, std::string displayName) {
     const auto ADDRESS = std::to_string(id.value);
     if (query().numbered(id).run()) {
         LOG(Log::ERR, "Refusing duplicate numbered workspace {}", id.value);
@@ -105,7 +105,7 @@ PHLWORKSPACE CState::createNumbered(::Workspace::SWorkspaceNumberedID id, PHLMON
         return nullptr;
     }
 
-    auto workspace = ::Workspace::CRegularWorkspace::create(id, std::move(monitor), std::move(displayName), isEmpty);
+    auto workspace = ::Workspace::CRegularWorkspace::create(id, std::move(monitor), std::move(displayName));
     if (!workspace)
         return nullptr;
 
@@ -115,7 +115,7 @@ PHLWORKSPACE CState::createNumbered(::Workspace::SWorkspaceNumberedID id, PHLMON
     return workspace;
 }
 
-PHLWORKSPACE CState::createNamed(std::string address, PHLMONITOR monitor, std::string displayName, bool isEmpty) {
+PHLWORKSPACE CState::createNamed(std::string address, PHLMONITOR monitor, std::string displayName) {
     if (query().identity(::Workspace::SWorkspaceSpecialID{}, address, ::Workspace::eWorkspaceType::NORMAL).run()) {
         LOG(Log::ERR, "Refusing duplicate named workspace {}", address);
         return nullptr;
@@ -127,7 +127,7 @@ PHLWORKSPACE CState::createNamed(std::string address, PHLMONITOR monitor, std::s
         return nullptr;
     }
 
-    auto workspace = ::Workspace::CRegularWorkspace::createNamed(std::move(monitor), std::move(address), std::move(displayName), isEmpty);
+    auto workspace = ::Workspace::CRegularWorkspace::createNamed(std::move(monitor), std::move(address), std::move(displayName));
     if (!workspace)
         return nullptr;
 
@@ -137,7 +137,7 @@ PHLWORKSPACE CState::createNamed(std::string address, PHLMONITOR monitor, std::s
     return workspace;
 }
 
-PHLWORKSPACE CState::createSpecial(std::string address, PHLMONITOR monitor, bool isEmpty) {
+PHLWORKSPACE CState::createSpecial(std::string address, PHLMONITOR monitor) {
     if (address == "special")
         address = "special:special";
     else if (!address.starts_with("special:"))
@@ -150,7 +150,7 @@ PHLWORKSPACE CState::createSpecial(std::string address, PHLMONITOR monitor, bool
     if (!monitor)
         return nullptr;
 
-    auto workspace = ::Workspace::CSpecialWorkspace::create(std::move(monitor), std::move(address), isEmpty);
+    auto workspace = ::Workspace::CSpecialWorkspace::create(std::move(monitor), std::move(address));
     if (!workspace)
         return nullptr;
 

--- a/src/state/workspace/State.hpp
+++ b/src/state/workspace/State.hpp
@@ -22,10 +22,10 @@ namespace State::Workspace {
         void                       clear();
 
         PHLWORKSPACE               find(const STarget& target) const;
-        [[nodiscard]] PHLWORKSPACE create(const STarget& target, PHLMONITOR monitor, bool isEmpty = true);
-        [[nodiscard]] PHLWORKSPACE createNumbered(::Workspace::SWorkspaceNumberedID id, PHLMONITOR monitor, std::string displayName = {}, bool isEmpty = true);
-        [[nodiscard]] PHLWORKSPACE createNamed(std::string address, PHLMONITOR monitor, std::string displayName = {}, bool isEmpty = true);
-        [[nodiscard]] PHLWORKSPACE createSpecial(std::string address, PHLMONITOR monitor, bool isEmpty = true);
+        [[nodiscard]] PHLWORKSPACE create(const STarget& target, PHLMONITOR monitor);
+        [[nodiscard]] PHLWORKSPACE createNumbered(::Workspace::SWorkspaceNumberedID id, PHLMONITOR monitor, std::string displayName = {});
+        [[nodiscard]] PHLWORKSPACE createNamed(std::string address, PHLMONITOR monitor, std::string displayName = {});
+        [[nodiscard]] PHLWORKSPACE createSpecial(std::string address, PHLMONITOR monitor);
 
       private:
         std::vector<PHLWORKSPACEREF> m_workspaces;

--- a/src/workspace/HLWorkspace.cpp
+++ b/src/workspace/HLWorkspace.cpp
@@ -101,6 +101,14 @@ void Workspace::CHLWorkspace::applyTypeSpecificRules(const Config::CWorkspaceRul
     ;
 }
 
+void Workspace::CHLWorkspace::ready() {
+    if (!m_ready) {
+        m_ready = true;
+        LOG(Log::DEBUG, "Workspace {} ready", m_name);
+        Event::bus()->m_events.workspace.createdLate.emit(m_self);
+    }
+}
+
 Workspace::CHLWorkspace::~CHLWorkspace() {
     LOG(Log::DEBUG, "Destroying workspace {}", addressableName());
 

--- a/src/workspace/HLWorkspace.cpp
+++ b/src/workspace/HLWorkspace.cpp
@@ -32,8 +32,8 @@
 using namespace Hyprutils::String;
 using namespace Desktop::View;
 
-Workspace::CHLWorkspace::CHLWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string addressableName, eWorkspaceType type, bool isEmpty) :
-    Workspace::IAbstractWorkspace(type), m_monitor(monitor), m_wasCreatedEmpty(isEmpty), m_focusTracker(this), m_name(std::move(displayName)), m_id(std::move(id)),
+Workspace::CHLWorkspace::CHLWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string addressableName, eWorkspaceType type) :
+    Workspace::IAbstractWorkspace(type), m_monitor(monitor), m_focusTracker(this), m_name(std::move(displayName)), m_id(std::move(id)),
     m_addressableName(std::move(addressableName)) {
     ;
 }
@@ -90,10 +90,6 @@ void Workspace::CHLWorkspace::init(PHLWORKSPACE self) {
     m_space->setAlgorithmProvider(Layout::Supplementary::algoMatcher()->createAlgorithmForWorkspace(m_self.lock()));
 
     applyTypeSpecificRules(RULEFORTHIS);
-
-    if (self->m_wasCreatedEmpty)
-        if (auto cmd = RULEFORTHIS.m_onCreatedEmptyRunCmd)
-            Config::Supplementary::executor()->spawnWithRules(*cmd, self);
 
     IPC::Socket2::sock()->postEvent({.event = "createworkspace", .data = m_name});
     IPC::Socket2::sock()->postEvent({.event = "createworkspacev2", .data = std::format("{},{}", Workspace::selector(*this), displayName())});

--- a/src/workspace/HLWorkspace.cpp
+++ b/src/workspace/HLWorkspace.cpp
@@ -91,9 +91,10 @@ void Workspace::CHLWorkspace::init(PHLWORKSPACE self) {
 
     applyTypeSpecificRules(RULEFORTHIS);
 
+    LOG(Log::DEBUG, "Creating workspace {}", addressableName());
     IPC::Socket2::sock()->postEvent({.event = "createworkspace", .data = m_name});
     IPC::Socket2::sock()->postEvent({.event = "createworkspacev2", .data = std::format("{},{}", Workspace::selector(*this), displayName())});
-    Event::bus()->m_events.workspace.created.emit(self);
+    Event::bus()->m_events.workspace.createdEarly.emit(self);
 }
 
 void Workspace::CHLWorkspace::applyTypeSpecificRules(const Config::CWorkspaceRule&) {

--- a/src/workspace/HLWorkspace.hpp
+++ b/src/workspace/HLWorkspace.hpp
@@ -70,7 +70,7 @@ namespace Workspace {
         } m_events;
 
       protected:
-        CHLWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string addressableName, eWorkspaceType type, bool isEmpty = true);
+        CHLWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string addressableName, eWorkspaceType type);
 
         void         init(PHLWORKSPACE self);
         virtual void applyTypeSpecificRules(const Config::CWorkspaceRule&);

--- a/src/workspace/HLWorkspace.hpp
+++ b/src/workspace/HLWorkspace.hpp
@@ -43,23 +43,27 @@ namespace Workspace {
 
         bool                                m_wasCreatedEmpty = true;
 
-        MONITORID                           monitorID() const;
-        PHLWINDOW                           getLastFocusedWindow() const;
-        void                                rememberFocusedWindow(PHLWINDOW window);
-        PHLWINDOW                           getFocusCandidate() const;
-        bool                                matchesStaticSelector(const std::string& selector) const;
-        void                                updateWindowDecos();
-        void                                updateWindowData();
-        int                                 getWindowCount(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {}) const;
-        int                                 getGroups(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {}) const;
-        bool                                hasUrgentWindow() const;
-        PHLWINDOW                           getFirstWindow() const;
-        PHLWINDOW                           getTopLeftWindow() const;
-        bool                                isVisibleNotCovered() const;
-        void                                rename(const std::string& name = "");
-        void                                changeID(SWorkspaceNumberedID id);
-        void                                forceReportSizesToWindows();
-        void                                updateWindows();
+        // Fire events and such, after a new workspace has been fully set up.
+        // Safe to call multiple times if unsure.
+        void      ready();
+
+        MONITORID monitorID() const;
+        PHLWINDOW getLastFocusedWindow() const;
+        void      rememberFocusedWindow(PHLWINDOW window);
+        PHLWINDOW getFocusCandidate() const;
+        bool      matchesStaticSelector(const std::string& selector) const;
+        void      updateWindowDecos();
+        void      updateWindowData();
+        int       getWindowCount(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {}) const;
+        int       getGroups(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {}) const;
+        bool      hasUrgentWindow() const;
+        PHLWINDOW getFirstWindow() const;
+        PHLWINDOW getTopLeftWindow() const;
+        bool      isVisibleNotCovered() const;
+        void      rename(const std::string& name = "");
+        void      changeID(SWorkspaceNumberedID id);
+        void      forceReportSizesToWindows();
+        void      updateWindows();
 
         struct {
             CSignalT<> destroy;
@@ -72,6 +76,11 @@ namespace Workspace {
       protected:
         CHLWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string addressableName, eWorkspaceType type);
 
+        // NOTE: For newly created workspaces, you must call their ready()
+        // method once they've been set up! For example, if you're going to
+        // move or focus the workspace, do that *beforehand*, so when event
+        // callbacks run they can see the fully set-up workspace. You may want
+        // to automate this with a CScopeGuard.
         void         init(PHLWORKSPACE self);
         virtual void applyTypeSpecificRules(const Config::CWorkspaceRule&);
 
@@ -81,6 +90,7 @@ namespace Workspace {
         std::string                  m_name       = "";
         bool                         m_visible    = false;
         bool                         m_wasRenamed = false;
+        bool                         m_ready      = false;
         WorkspaceID                  m_id;
         std::string                  m_addressableName;
     };

--- a/src/workspace/RegularWorkspace.cpp
+++ b/src/workspace/RegularWorkspace.cpp
@@ -4,31 +4,31 @@
 
 using namespace Workspace;
 
-CRegularWorkspace::CRegularWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string address, bool isEmpty) :
-    CHLWorkspace(std::move(id), std::move(monitor), std::move(displayName), std::move(address), eWorkspaceType::NORMAL, isEmpty) {
+CRegularWorkspace::CRegularWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string address) :
+    CHLWorkspace(std::move(id), std::move(monitor), std::move(displayName), std::move(address), eWorkspaceType::NORMAL) {
     ;
 }
 
-PHLWORKSPACE CRegularWorkspace::create(SWorkspaceNumberedID id, PHLMONITOR monitor, std::string name, bool isEmpty) {
+PHLWORKSPACE CRegularWorkspace::create(SWorkspaceNumberedID id, PHLMONITOR monitor, std::string name) {
     if (id.value == 0)
         return nullptr;
 
     if (name.empty())
         name = std::to_string(id.value);
 
-    auto workspace = makeShared<CRegularWorkspace>(id, std::move(monitor), std::move(name), std::to_string(id.value), isEmpty);
+    auto workspace = makeShared<CRegularWorkspace>(id, std::move(monitor), std::move(name), std::to_string(id.value));
     workspace->init(workspace);
     return workspace;
 }
 
-PHLWORKSPACE CRegularWorkspace::createNamed(PHLMONITOR monitor, std::string address, std::string displayName, bool isEmpty) {
+PHLWORKSPACE CRegularWorkspace::createNamed(PHLMONITOR monitor, std::string address, std::string displayName) {
     if (address.empty())
         return nullptr;
 
     if (displayName.empty())
         displayName = address;
 
-    auto workspace = makeShared<CRegularWorkspace>(SWorkspaceSpecialID{}, std::move(monitor), std::move(displayName), std::move(address), isEmpty);
+    auto workspace = makeShared<CRegularWorkspace>(SWorkspaceSpecialID{}, std::move(monitor), std::move(displayName), std::move(address));
     workspace->init(workspace);
     return workspace;
 }

--- a/src/workspace/RegularWorkspace.hpp
+++ b/src/workspace/RegularWorkspace.hpp
@@ -6,14 +6,14 @@
 namespace Workspace {
     class CRegularWorkspace : public CHLWorkspace {
       public:
-        static PHLWORKSPACE create(SWorkspaceNumberedID id, PHLMONITOR monitor, std::string name, bool isEmpty = true);
-        static PHLWORKSPACE createNamed(PHLMONITOR monitor, std::string address, std::string displayName = {}, bool isEmpty = true);
+        static PHLWORKSPACE create(SWorkspaceNumberedID id, PHLMONITOR monitor, std::string name);
+        static PHLWORKSPACE createNamed(PHLMONITOR monitor, std::string address, std::string displayName = {});
         ~CRegularWorkspace() override = default;
 
         void setPersistent(bool persistent);
         bool isPersistent() const;
 
-        CRegularWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string address, bool isEmpty);
+        CRegularWorkspace(WorkspaceID id, PHLMONITOR monitor, std::string displayName, std::string address);
 
       protected:
         void applyTypeSpecificRules(const Config::CWorkspaceRule& rule) override;

--- a/src/workspace/SpecialWorkspace.cpp
+++ b/src/workspace/SpecialWorkspace.cpp
@@ -2,12 +2,11 @@
 
 using namespace Workspace;
 
-CSpecialWorkspace::CSpecialWorkspace(PHLMONITOR monitor, std::string address, bool isEmpty) :
-    CHLWorkspace(SWorkspaceSpecialID{}, std::move(monitor), address, address, eWorkspaceType::SPECIAL, isEmpty) {
+CSpecialWorkspace::CSpecialWorkspace(PHLMONITOR monitor, std::string address) : CHLWorkspace(SWorkspaceSpecialID{}, std::move(monitor), address, address, eWorkspaceType::SPECIAL) {
     ;
 }
 
-PHLWORKSPACE CSpecialWorkspace::create(PHLMONITOR monitor, std::string address, bool isEmpty) {
+PHLWORKSPACE CSpecialWorkspace::create(PHLMONITOR monitor, std::string address) {
     if (address == "special")
         address = "special:special";
     else if (!address.starts_with("special:"))
@@ -16,7 +15,7 @@ PHLWORKSPACE CSpecialWorkspace::create(PHLMONITOR monitor, std::string address, 
     if (address.size() == 8)
         return nullptr;
 
-    auto workspace = makeShared<CSpecialWorkspace>(std::move(monitor), std::move(address), isEmpty);
+    auto workspace = makeShared<CSpecialWorkspace>(std::move(monitor), std::move(address));
     workspace->init(workspace);
     return workspace;
 }

--- a/src/workspace/SpecialWorkspace.hpp
+++ b/src/workspace/SpecialWorkspace.hpp
@@ -6,9 +6,9 @@
 namespace Workspace {
     class CSpecialWorkspace : public CHLWorkspace {
       public:
-        static PHLWORKSPACE create(PHLMONITOR monitor, std::string address, bool isEmpty = true);
+        static PHLWORKSPACE create(PHLMONITOR monitor, std::string address);
         ~CSpecialWorkspace() override = default;
 
-        CSpecialWorkspace(PHLMONITOR monitor, std::string address, bool isEmpty);
+        CSpecialWorkspace(PHLMONITOR monitor, std::string address);
     };
 }

--- a/tests/state/WorkspaceLifecyclePolicy.cpp
+++ b/tests/state/WorkspaceLifecyclePolicy.cpp
@@ -52,8 +52,8 @@ class CFakePolicyContext final : public IPolicyContext {
         m_workspaces.emplace_back(SWorkspaceSnapshot{identity, std::string{monitorAddress}});
     }
 
-    void moveWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress) override {
-        m_actions.emplace_back(SRecordedAction{SRecordedAction::eType::MOVE, identity.address, std::string{monitorAddress}});
+    void moveWorkspace(const SWorkspaceIdentity& identity, std::string_view monitorAddress, bool replace) override {
+        m_actions.emplace_back(SRecordedAction{SRecordedAction::eType::MOVE, identity.address, std::format("{} {}", monitorAddress, replace)});
 
         const auto WORKSPACE = std::ranges::find(m_workspaces, identity, &SWorkspaceSnapshot::identity);
         ASSERT_NE(WORKSPACE, m_workspaces.end());
@@ -154,7 +154,7 @@ TEST(WorkspaceLifecyclePolicy, configuredDefaultMovesExistingWorkspaceAndActivat
 
     EXPECT_EQ(context.m_actions,
               (std::vector<SRecordedAction>{
-                  {SRecordedAction::eType::MOVE, "development", "monitor:right"},
+                  {SRecordedAction::eType::MOVE, "development", "monitor:right true"},
                   {SRecordedAction::eType::ACTIVATE, "development", "monitor:right"},
               }));
 }
@@ -203,7 +203,7 @@ TEST(WorkspaceLifecyclePolicy, disconnectRemembersActiveAddressAndReconnectResto
     EXPECT_FALSE(policy.returnMonitorAddress(identity("workspace:left")).has_value());
     EXPECT_EQ(context.m_actions,
               (std::vector<SRecordedAction>{
-                  {SRecordedAction::eType::MOVE, "workspace:left", "monitor:left"},
+                  {SRecordedAction::eType::MOVE, "workspace:left", "monitor:left true"},
                   {SRecordedAction::eType::ACTIVATE, "workspace:left", "monitor:left"},
               }));
 }
@@ -231,7 +231,7 @@ TEST(WorkspaceLifecyclePolicy, reconnectToleratesWorkspaceDestructionDuringMove)
 
     EXPECT_FALSE(policy.returnMonitorAddress(WORKSPACE).has_value());
     EXPECT_FALSE(policy.rememberedActiveWorkspace("monitor:left").has_value());
-    EXPECT_EQ(context.m_actions, (std::vector<SRecordedAction>{{SRecordedAction::eType::MOVE, "workspace:left", "monitor:left"}}));
+    EXPECT_EQ(context.m_actions, (std::vector<SRecordedAction>{{SRecordedAction::eType::MOVE, "workspace:left", "monitor:left true"}}));
 }
 
 TEST(WorkspaceLifecyclePolicy, fallbackRecoveryPreservesRealMonitorProvenance) {
@@ -257,7 +257,7 @@ TEST(WorkspaceLifecyclePolicy, fallbackRecoveryPreservesRealMonitorProvenance) {
     EXPECT_FALSE(policy.returnMonitorAddress(identity("name:active")).has_value());
     EXPECT_EQ(context.m_actions,
               (std::vector<SRecordedAction>{
-                  {SRecordedAction::eType::MOVE, "name:active", "monitor:real"},
+                  {SRecordedAction::eType::MOVE, "name:active", "monitor:real true"},
                   {SRecordedAction::eType::ACTIVATE, "name:active", "monitor:real"},
               }));
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Renames the existing `workspace.created` event to `workspace.created_early`, and then adds a new `workspace.created` that fires when the new workspace has been fully set up (i.e. moved to its relevant monitor, focused if appropriate, populated with the window sent to it if appropriate...).

This means the workspace object that event callbacks receive is fully initialized, and you can do stuff like this, which eliminates the need for the `on_created_empty` workspace rule:
```lua
hl.on("workspace.created", function(ws)
    if ws.empty then
        hl.exec_cmd("kitty", { workspace = ws.name.." silent" })
    end
end)
```

(Once this merges, we can kill that rule, and with it the legacy `[rules] command` exec-with-rules syntax.)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The only slight complication here is that now, anyone who creates a new workspace is responsible for calling `ready()` on it to fire `workspace.created`. That's noted in a comment, though, and is kinda necessary if we want proper behavior from this event.

Unrelated, but I've added a comment regex to disable clang-format on just one line at a time, so we don't have to wrap single lines in `// clang-format off`/`on`.

#### Is it ready for merging, or does it need work?

Should be good, has tests as well.