### PR TITLE
workspace: create named workspaces for bare named lookups

### DIFF
--- a/hyprtester/src/tests/main/workspaces.cpp
+++ b/hyprtester/src/tests/main/workspaces.cpp
@@ -1277,3 +1277,9 @@ TEST_CASE(workspaceSwitchUnfocusesWindowFromOldWorkspace) {
     // TODO: also test when workspaces 1 and 2 are on different workspaces.
     //       At the time of writing, it is broken (i.e., the test would fail).
 }
+
+TEST_CASE(luaFocusCreatesBareNamedWorkspace) {
+    ASSERT(getFromSocket("/repl hl.get_workspace('hi')"), "nil");
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'hi' })"));
+    ASSERT_CONTAINS(getFromSocket("/activeworkspace"), "workspace hi (hi)");
+}

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -277,7 +277,7 @@ void CFocusState::rawMonitorFocus(PHLMONITOR pMonitor) {
 
     const auto PWORKSPACE = pMonitor->m_activeWorkspace;
 
-    const auto WORKSPACE_ADDRESS = PWORKSPACE ? Workspace::selector(*PWORKSPACE) : "";
+    const auto WORKSPACE_ADDRESS = PWORKSPACE ? PWORKSPACE->addressableName() : "";
     const auto WORKSPACE_NAME    = PWORKSPACE ? PWORKSPACE->addressableName() : "?";
 
     IPC::Socket2::sock()->postEvent({.event = "focusedmon", .data = std::format("{},{}", pMonitor->m_name, WORKSPACE_NAME)});

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -278,7 +278,7 @@ void CFocusState::rawMonitorFocus(PHLMONITOR pMonitor) {
     const auto PWORKSPACE = pMonitor->m_activeWorkspace;
 
     const auto WORKSPACE_ADDRESS = PWORKSPACE ? Workspace::selector(*PWORKSPACE) : "";
-    const auto WORKSPACE_NAME    = PWORKSPACE ? PWORKSPACE->displayName() : "?";
+    const auto WORKSPACE_NAME    = PWORKSPACE ? PWORKSPACE->addressableName() : "?";
 
     IPC::Socket2::sock()->postEvent({.event = "focusedmon", .data = std::format("{},{}", pMonitor->m_name, WORKSPACE_NAME)});
     IPC::Socket2::sock()->postEvent({.event = "focusedmonv2", .data = std::format("{},{}", pMonitor->m_name, WORKSPACE_ADDRESS)});

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -468,9 +468,9 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
     Desktop::globalWindowController()->updateAllWindowsDecorations();
 
     if (valid(pWorkspace)) {
-        IPC::Socket2::sock()->postEvent({.event = "movewindow", .data = std::format("{:x},{}", rc<uintptr_t>(this), pWorkspace->displayName())});
+        IPC::Socket2::sock()->postEvent({.event = "movewindow", .data = std::format("{:x},{}", rc<uintptr_t>(this), pWorkspace->addressableName())});
         IPC::Socket2::sock()->postEvent(
-            {.event = "movewindowv2", .data = std::format("{:x},{},{}", rc<uintptr_t>(this), Workspace::selector(*pWorkspace), pWorkspace->displayName())});
+            {.event = "movewindowv2", .data = std::format("{:x},{},{}", rc<uintptr_t>(this), pWorkspace->addressableName(), pWorkspace->addressableName())});
         Event::bus()->m_events.window.moveToWorkspace.emit(m_self.lock(), pWorkspace);
     }
 
@@ -1422,7 +1422,7 @@ void CWindow::mapWindow() {
     m_swallowing->reserveCandidate();
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
-    IPC::Socket2::sock()->postEvent({"openwindow", std::format("{:x},{},{},{}", m_self.lock(), PWORKSPACE->displayName(), m_metadata->appID(), m_metadata->title())});
+    IPC::Socket2::sock()->postEvent({"openwindow", std::format("{:x},{},{},{}", m_self.lock(), PWORKSPACE->addressableName(), m_metadata->appID(), m_metadata->title())});
     Event::bus()->m_events.window.openEarly.emit(m_self.lock());
 
     if (m_swallowing->activate()) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1419,8 +1419,8 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
         g_layoutManager->recalculateMonitor(m_self.lock(), Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_WORKSPACE_CHANGE);
 
         if (!noFocus) {
-            IPC::Socket2::sock()->postEvent({"workspace", pWorkspace->displayName()});
-            IPC::Socket2::sock()->postEvent({"workspacev2", std::format("{},{}", Workspace::selector(*pWorkspace), pWorkspace->displayName())});
+            IPC::Socket2::sock()->postEvent({"workspace", pWorkspace->addressableName()});
+            IPC::Socket2::sock()->postEvent({"workspacev2", std::format("{},{}", pWorkspace->addressableName(), pWorkspace->addressableName())});
             Event::bus()->m_events.workspace.active.emit(pWorkspace);
         }
     }
@@ -1615,7 +1615,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace, bool noFocus)
     }
 
     IPC::Socket2::sock()->postEvent({"activespecial", std::format("{},{}", pWorkspace->displayName(), m_name)});
-    IPC::Socket2::sock()->postEvent({"activespecialv2", std::format("{},{},{}", Workspace::selector(*pWorkspace), pWorkspace->displayName(), m_name)});
+    IPC::Socket2::sock()->postEvent({"activespecialv2", std::format("{},{},{}", pWorkspace->addressableName(), pWorkspace->addressableName(), m_name)});
 
     g_pHyprRenderer->damageMonitor(m_self.lock());
 

--- a/src/state/workspace/PlacementController.cpp
+++ b/src/state/workspace/PlacementController.cpp
@@ -223,18 +223,18 @@ void CPlacementController::swapActiveWorkspaces(PHLMONITOR pMonitorA, PHLMONITOR
             Desktop::FOCUS_REASON_DESKTOP_STATE_CHANGE);
 
         const auto PNEWWORKSPACE = pMonitorA->m_id == Desktop::focusState()->monitor()->m_id ? PWORKSPACEB : PWORKSPACEA;
-        IPC::Socket2::sock()->postEvent({.event = "workspace", .data = PNEWWORKSPACE->displayName()});
-        IPC::Socket2::sock()->postEvent({.event = "workspacev2", .data = std::format("{},{}", ::Workspace::selector(*PNEWWORKSPACE), PNEWWORKSPACE->displayName())});
+        IPC::Socket2::sock()->postEvent({.event = "workspace", .data = PNEWWORKSPACE->addressableName()});
+        IPC::Socket2::sock()->postEvent({.event = "workspacev2", .data = std::format("{},{}", PNEWWORKSPACE->addressableName(), PNEWWORKSPACE->addressableName())});
         Event::bus()->m_events.workspace.active.emit(PNEWWORKSPACE);
     }
 
     // events
-    IPC::Socket2::sock()->postEvent({.event = "moveworkspace", .data = std::format("{},{}", PWORKSPACEA->displayName(), pMonitorB->m_name)});
+    IPC::Socket2::sock()->postEvent({.event = "moveworkspace", .data = std::format("{},{}", PWORKSPACEA->addressableName(), pMonitorB->m_name)});
     IPC::Socket2::sock()->postEvent(
-        {.event = "moveworkspacev2", .data = std::format("{},{},{}", ::Workspace::selector(*PWORKSPACEA), PWORKSPACEA->displayName(), pMonitorB->m_name)});
-    IPC::Socket2::sock()->postEvent({.event = "moveworkspace", .data = std::format("{},{}", PWORKSPACEB->displayName(), pMonitorA->m_name)});
+        {.event = "moveworkspacev2", .data = std::format("{},{},{}", PWORKSPACEA->addressableName(), PWORKSPACEA->addressableName(), pMonitorB->m_name)});
+    IPC::Socket2::sock()->postEvent({.event = "moveworkspace", .data = std::format("{},{}", PWORKSPACEB->addressableName(), pMonitorA->m_name)});
     IPC::Socket2::sock()->postEvent(
-        {.event = "moveworkspacev2", .data = std::format("{},{},{}", ::Workspace::selector(*PWORKSPACEB), PWORKSPACEB->displayName(), pMonitorA->m_name)});
+        {.event = "moveworkspacev2", .data = std::format("{},{},{}", PWORKSPACEB->addressableName(), PWORKSPACEB->addressableName(), pMonitorA->m_name)});
 
     Event::bus()->m_events.workspace.moveToMonitor.emit(PWORKSPACEA, pMonitorB);
     Event::bus()->m_events.workspace.moveToMonitor.emit(PWORKSPACEB, pMonitorA);
@@ -379,8 +379,8 @@ void CPlacementController::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMO
     Desktop::globalWindowController()->updateSuspendedStates();
 
     // event
-    IPC::Socket2::sock()->postEvent({.event = "moveworkspace", .data = std::format("{},{}", pWorkspace->displayName(), pMonitor->m_name)});
-    IPC::Socket2::sock()->postEvent({.event = "moveworkspacev2", .data = std::format("{},{},{}", ::Workspace::selector(*pWorkspace), pWorkspace->displayName(), pMonitor->m_name)});
+    IPC::Socket2::sock()->postEvent({.event = "moveworkspace", .data = std::format("{},{}", pWorkspace->addressableName(), pMonitor->m_name)});
+    IPC::Socket2::sock()->postEvent({.event = "moveworkspacev2", .data = std::format("{},{},{}", pWorkspace->addressableName(), pWorkspace->addressableName(), pMonitor->m_name)});
 
     Event::bus()->m_events.workspace.moveToMonitor.emit(pWorkspace, pMonitor);
 }

--- a/src/state/workspace/Resolver.cpp
+++ b/src/state/workspace/Resolver.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <charconv>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <set>
 #include <vector>
@@ -114,6 +115,14 @@ static std::optional<int64_t> offsetAvailableWorkspace(uint32_t current, int64_t
     return result;
 }
 
+// Resolution here is done in stages, to support all resolution modes.
+// prefix special / special: / name: -> shortcuts
+// prefix empty -> shortcut for empty matching.
+// prev / previous / next -> cycling
+// selectors + (+/-/~) + number -> relative selectors
+// (+/-) + number -> relative moves
+// contains [] -> workspace filters, this is bad input for the resolver
+// fallback: named or ID'd workspace
 State::Workspace::STarget CWorkspaceResolver::getWorkspaceTargetFromString(const std::string& in, std::optional<PHLMONITOR> baseMon) {
     const auto BASEMONITOR = baseMon.value_or(Desktop::focusState()->monitor());
     if (in.empty())
@@ -165,7 +174,7 @@ State::Workspace::STarget CWorkspaceResolver::getWorkspaceTargetFromString(const
         return {};
     }
 
-    if (in.starts_with("prev")) {
+    if (in == "prev" || in == "previous") {
         if (!BASEMONITOR || !valid(BASEMONITOR->m_activeWorkspace))
             return {};
         return Desktop::History::workspaceTracker()->previousWorkspace(BASEMONITOR->m_activeWorkspace).target;
@@ -295,10 +304,23 @@ State::Workspace::STarget CWorkspaceResolver::getWorkspaceTargetFromString(const
         return numberedTarget(std::max(VALUE, sc<int64_t>(1)));
     }
 
-    if (isNumber(in)) {
-        const auto ID = Hyprutils::String::strToNumber<int64_t>(in);
-        return ID ? numberedTarget(std::max(*ID, sc<int64_t>(1))) : State::Workspace::STarget{};
+    if (in.contains('[') || in.contains(']')) {
+        LOG(Log::ERR, "Resolver cannot take workspace filters");
+        return {};
     }
 
-    return targetFor(State::Workspace::state()->query().input(in).run());
+
+    // if it's a number, it's either valid (1 to 32b limit) or invalid
+    // signed 32b limit is documented on the wiki, our internal storage is irrelevant
+    if (isNumber(in)) {
+        const auto ID = Hyprutils::String::strToNumber<int64_t>(in);
+        if (!ID || *ID == 0 || *ID > std::numeric_limits<int32_t>::max()) {
+            LOG(Log::ERR, "Invalid workspace ID for resolving: {}", in);
+            return {};
+        }
+        return numberedTarget(std::max(*ID, sc<int64_t>(1)));
+    }
+
+    // return a named workspace, e.g. "amongus"
+    return {.id = ::Workspace::SWorkspaceSpecialID{}, .address = in, .displayName = in, .type = ::Workspace::eWorkspaceType::NORMAL};
 }

--- a/src/state/workspace/Resolver.cpp
+++ b/src/state/workspace/Resolver.cpp
@@ -309,7 +309,6 @@ State::Workspace::STarget CWorkspaceResolver::getWorkspaceTargetFromString(const
         return {};
     }
 
-
     // if it's a number, it's either valid (1 to 32b limit) or invalid
     // signed 32b limit is documented on the wiki, our internal storage is irrelevant
     if (isNumber(in)) {

--- a/src/workspace/HLWorkspace.cpp
+++ b/src/workspace/HLWorkspace.cpp
@@ -96,7 +96,7 @@ void Workspace::CHLWorkspace::init(PHLWORKSPACE self) {
             Config::Supplementary::executor()->spawnWithRules(*cmd, self);
 
     IPC::Socket2::sock()->postEvent({.event = "createworkspace", .data = m_name});
-    IPC::Socket2::sock()->postEvent({.event = "createworkspacev2", .data = std::format("{},{}", Workspace::selector(*this), displayName())});
+    IPC::Socket2::sock()->postEvent({.event = "createworkspacev2", .data = std::format("{},{}", addressableName(), addressableName())});
     Event::bus()->m_events.workspace.created.emit(self);
 }
 
@@ -111,7 +111,7 @@ Workspace::CHLWorkspace::~CHLWorkspace() {
 
     if (IPC::Socket2::sock()) {
         IPC::Socket2::sock()->postEvent({.event = "destroyworkspace", .data = m_name});
-        IPC::Socket2::sock()->postEvent({.event = "destroyworkspacev2", .data = std::format("{},{}", Workspace::selector(*this), displayName())});
+        IPC::Socket2::sock()->postEvent({.event = "destroyworkspacev2", .data = std::format("{},{}", addressableName(), addressableName())});
     }
 
     Event::bus()->m_events.workspace.removed.emit(m_self);


### PR DESCRIPTION
makes `hl.dsp.focus({ workspace = 'PISS' })` work even when the workspace isnt opened yet