### PR TITLE
fix(config): forward safe mode when generating the default config

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -44,7 +44,7 @@ bool Config::initConfigManager() {
         }
 
         // generate default
-        if (const auto v = g_mgr->generateDefaultConfig(filePath); !v) {
+        if (const auto v = g_mgr->generateDefaultConfig(filePath, CFG_PATH->type == Supplementary::Jeremy::CONFIG_TYPE_SPECIAL); !v) {
             LOG(Log::CRIT, "[cfg] Couldn't generate default config: {}", v.error());
             return false;
         }


### PR DESCRIPTION
### Describe your issue

After any unclean exit, `start-hyprland` restarts the compositor with `--safe-mode`. The session then comes up looking like a **fresh install** — default wallpaper, and the `SUPER + Q` / `SUPER + M` welcome dialog — instead of the intended safe-mode recovery environment.

The user's own config is not loaded, and because the screen presents as a first-run install rather than as "your last session crashed, here is safe mode", it reads as config loss. (The real config is never overwritten — the generated file lands in `$instancePath/recoverycfg.lua` under `/run/user` — but that is not obvious to the person looking at the screen.)

### Cause

Safe mode deliberately withholds the user config, but the flag that says so is dropped on the way to config generation:

1. `start/src/main.cpp` — on an unclean exit the supervisor sets `safeMode = true` and restarts, logging `Hyprland exit not-cleanly, restarting`.
2. `start/src/core/Instance.cpp` — appends `--safe-mode` to the child's argv.
3. `src/config/supplementary/jeremy/Jeremy.cpp:26-27` — in safe mode returns `{.path = <instancePath>/recoverycfg.lua, .type = CONFIG_TYPE_SPECIAL}`. `CONFIG_TYPE_SPECIAL` is returned **only** when `m_safeMode` is set.
4. `src/config/ConfigManager.cpp` — `recoverycfg.lua` never exists in a fresh instance directory, so `initConfigManager()` falls through to generation and calls:
   ```cpp
   g_mgr->generateDefaultConfig(filePath)
   ```
5. `src/config/ConfigManager.hpp:65` — the parameter exists but silently defaults to `false`:
   ```cpp
   virtual std::expected<void, std::string> generateDefaultConfig(const std::filesystem::path&, bool safeMode = false) = 0;
   ```
6. `src/config/lua/ConfigManager.cpp:~1092` — so the `!safeMode` branch runs and writes the full stock `EXAMPLE_CONFIG_LUA`, which is then loaded.

So the safe-mode config generation path is reachable but unreachable in practice: nothing ever passes `safeMode = true`.

Corresponding log sequence from the affected session:

```
ERR  from start-hyprland ]: Hyprland exit not-cleanly, restarting
DEBUG ]: [cfg] Config is either explicit or special
DEBUG ]: [cfg] Config is lua, loading lua mgr
WARN  ]: No config file found; attempting to generate.
```

versus a normal launch on the same machine:

```
DEBUG ]: [cfg] Regular config at /home/<user>/.config/hypr/hyprland.lua
DEBUG ]: [cfg] Using lua config found at /home/<user>/.config/hypr/hyprland.lua
```

### Fix

Forward the flag. `CFG_PATH` is already in scope and `Jeremy.hpp` is already included, so no new include is needed, and `CONFIG_TYPE_SPECIAL` is exactly the "safe mode" signal:

```diff
-        if (const auto v = g_mgr->generateDefaultConfig(filePath); !v) {
+        if (const auto v = g_mgr->generateDefaultConfig(filePath, CFG_PATH->type == Supplementary::Jeremy::CONFIG_TYPE_SPECIAL); !v) {
```

### How to reproduce

Any unclean compositor exit triggers it. In the original case the trigger was a GPU reset on NVIDIA (a burst of `NVRM: Xid 32`, then `Xid 154, GPU recovery action changed from 0x0 (None) to 0x2 (Node Reboot Required)`), which tripped the deliberate abort in `OpenGL.cpp` — that abort is #12485 and is **not** what this PR addresses. Any other unclean exit reaches the same config path.

### Verification

Honest scope, please read before merging:

- The modified translation unit compiles: `g++ -fsyntax-only -std=c++26` on `src/config/ConfigManager.cpp` exits 0 with no diagnostics, and also under `-Wall -Wextra`. Negative controls confirm the check is not vacuous — a bogus enumerator errors at the call site, and an over-long argument list reports the candidate as `(const std::filesystem::path&, bool)`, i.e. the comparison does bind to `safeMode` as `bool`.
- **Not done:** no full build, no link, no runtime test. `cmake` and `meson` were unavailable on the machine this was prepared on, so CI is the first real build of this change.

### System where this was observed

- Hyprland 0.56.2 (`efb50993780079460b0cbed1363e2166a2de1d9f`), Omarchy 4.0.2, Arch, kernel 7.1.9-arch1-2
- aquamarine 0.14.0, hyprutils 0.14.1, hyprlang 0.6.8, hyprgraphics 0.5.1, hyprcursor 0.1.13
- NVIDIA GTX 1080 Ti, driver 580.178.04
- Session started by uwsm as `Exec=/usr/bin/start-hyprland` (no `--config`), Lua config at `~/.config/hypr/hyprland.lua`

The code path above was re-confirmed against `main` (base `3a37b75`), not only against the 0.56.2 tag.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJPjqdZTrP6qC7zafxAmsY
