### PR TITLE
feature: fullscreen controller takeover & restore 

### DIFF
--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -5,6 +5,8 @@
 #include <hyprutils/animation/AnimatedVariable.hpp>
 
 #include "../Group.hpp"
+#include "debug/log/Logger.hpp"
+#include "managers/fullscreen/FullscreenTypes.hpp"
 
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #include <sys/types.h>
@@ -848,15 +850,20 @@ void CWindow::requestClientFullscreen(const SClientFullscreenRequest& request) {
         }
 
         if (m_isMapped) {
-            if (request.fullscreen.value())
+            if (request.fullscreen.value()) {
+                if (BACKEND_REQUEST)
+                    Fullscreen::controller()->beginFullscreenTakeover(m_self.lock());
+
                 Fullscreen::controller()->setFullscreenMode(m_self.lock(), std::nullopt, Fullscreen::FSMODE_FULLSCREEN);
-            else {
+            } else {
+                const auto TAKEOVER_EXECUTED = Fullscreen::controller()->endFullscreenTakeover(m_self.lock());
+
                 // If window's fullscreen, un-fullscreen it. if it's not FS, let it keep its current FS mode
-                if (Fullscreen::controller()->getFullscreenModes(m_self.lock()).client == Fullscreen::FSMODE_FULLSCREEN)
+                if (!TAKEOVER_EXECUTED && Fullscreen::controller()->getFullscreenModes(m_self.lock()).client == Fullscreen::FSMODE_FULLSCREEN)
                     Fullscreen::controller()->setFullscreenMode(m_self.lock(), std::nullopt, Fullscreen::FSMODE_NONE);
             }
         } else if (request.fullscreen.value())
-            m_fullscreenPolicy->setPendingClientRequest(Fullscreen::FSMODE_FULLSCREEN, requestedMonitor);
+            m_fullscreenPolicy->setPendingClientRequest(Fullscreen::FSMODE_FULLSCREEN, requestedMonitor, BACKEND_REQUEST);
         else
             m_fullscreenPolicy->clearPendingClientMode(Fullscreen::FSMODE_FULLSCREEN);
     }
@@ -1205,10 +1212,13 @@ void CWindow::mapWindow() {
     // window rules
     std::optional<Fullscreen::eFullscreenMode> requestedInternalFSMode, requestedClientFSMode;
     std::optional<Fullscreen::SFullscreenMode> requestedFSState;
-    const auto&                                PENDING_CLIENT_FS = m_fullscreenPolicy->pendingClientRequest();
-    requestedClientFSMode                                        = PENDING_CLIENT_FS.mode;
-    if (!requestedClientFSMode.has_value() && m_backend->isX11() && TRAITS.fullscreen)
-        requestedClientFSMode = Fullscreen::FSMODE_FULLSCREEN;
+    const auto&                                PENDING_CLIENT_FS                 = m_fullscreenPolicy->pendingClientRequest();
+    bool                                       requestedClientFSHasBackendOrigin = PENDING_CLIENT_FS.isFromBackend;
+    requestedClientFSMode                                                        = PENDING_CLIENT_FS.mode;
+    if (!requestedClientFSMode.has_value() && m_backend->isX11() && TRAITS.fullscreen) {
+        requestedClientFSMode             = Fullscreen::FSMODE_FULLSCREEN;
+        requestedClientFSHasBackendOrigin = true;
+    }
     MONITORID requestedFSMonitor = PENDING_CLIENT_FS.monitor.value_or(MONITOR_INVALID);
 
     auto      setStaticProps = [&]() {
@@ -1467,6 +1477,17 @@ void CWindow::mapWindow() {
     // It must emit before FS operations so that window has decorations data
     Event::bus()->m_events.window.open.emit(m_self.lock());
 
+    if (requestedClientFSMode == Fullscreen::FSMODE_FULLSCREEN && m_fullscreenPolicy->requestSuppression().fullscreen)
+        requestedClientFSMode.reset();
+    if (requestedClientFSMode == Fullscreen::FSMODE_MAXIMIZED && m_fullscreenPolicy->requestSuppression().maximize)
+        requestedClientFSMode.reset();
+
+    const auto TAKEOVER_MODE = Fullscreen::controller()->getFullscreenWindow(m_workspace) && !(m_state & WINDOW_STATE_NO_INITIAL_FOCUS) && requestedClientFSHasBackendOrigin &&
+        requestedClientFSMode == Fullscreen::FSMODE_FULLSCREEN;
+
+    if (TAKEOVER_MODE)
+        Fullscreen::controller()->beginFullscreenTakeover(m_self.lock());
+
     if (Fullscreen::controller()->hasFullscreen(m_workspace) && !requestedInternalFSMode.has_value() && !requestedClientFSMode.has_value() && !m_target->floating()) {
         if (*PNEWTAKESOVERFS == 0)
             m_state |= WINDOW_STATE_NO_INITIAL_FOCUS;
@@ -1490,11 +1511,6 @@ void CWindow::mapWindow() {
         m_presentation->alpha(WINDOW_ALPHA_ACTIVE)->setValueAndWarp(*PINACTIVEALPHA);
         m_presentation->warpDimPercent(0.F);
     }
-
-    if (requestedClientFSMode == Fullscreen::FSMODE_FULLSCREEN && m_fullscreenPolicy->requestSuppression().fullscreen)
-        requestedClientFSMode.reset();
-    if (requestedClientFSMode == Fullscreen::FSMODE_MAXIMIZED && m_fullscreenPolicy->requestSuppression().maximize)
-        requestedClientFSMode.reset();
 
     if (!(m_state & WINDOW_STATE_NO_INITIAL_FOCUS) && (requestedInternalFSMode.has_value() || requestedClientFSMode.has_value() || requestedFSState.has_value())) {
         // fix fullscreen on requested (basically do a switcheroo)
@@ -1596,7 +1612,10 @@ void CWindow::unmapWindow() {
     const auto SWALLOW_UNMAP_RESULT    = m_swallowing->onUnmap(IS_CURRENT_WINDOW_FS ? std::optional(CURRENT_WINDOW_FS_MODES.internal) : std::nullopt, CURRENT_FS_LAYOUT_HANDLED);
     const auto RESTORED_SWALLOW_WINDOW = SWALLOW_UNMAP_RESULT.restoredWindow;
 
-    if (IS_CURRENT_WINDOW_FS) {
+    const auto TAKEOVER_EXECUTED     = Fullscreen::controller()->endFullscreenTakeover(m_self.lock());
+    const auto FULLSCREEN_OPS_NEEDED = IS_CURRENT_WINDOW_FS && !TAKEOVER_EXECUTED; // otherwise we trust the Fullscreen controller to keep the consistent state
+
+    if (FULLSCREEN_OPS_NEEDED) {
         if (SWALLOW_UNMAP_RESULT.transferredInternalFullscreen)
             Fullscreen::controller()->setFullscreenMode(m_self.lock(), std::nullopt, Fullscreen::FSMODE_NONE, std::nullopt, Fullscreen::FULLSCREEN_MUTATION_TRANSFER);
         else
@@ -1674,7 +1693,7 @@ void CWindow::unmapWindow() {
             else
                 Desktop::focusState()->fullWindowFocus(candidate, m_target->floating() ? FOCUS_REASON_UNMAP_WINDOW_FLOATING : FOCUS_REASON_UNMAP_WINDOW_TILING);
 
-            if ((*PEXITRETAINSFS == 1 || (candidate != nextInGroup && *PEXITRETAINSFS == 3) || (candidate == nextInGroup && *PEXITRETAINSFS == 2)) && IS_CURRENT_WINDOW_FS)
+            if ((*PEXITRETAINSFS == 1 || (candidate != nextInGroup && *PEXITRETAINSFS == 3) || (candidate == nextInGroup && *PEXITRETAINSFS == 2)) && FULLSCREEN_OPS_NEEDED)
                 // set the candidate to the current window's FS state - use the current window's layoutAware FS behaviour
                 Fullscreen::controller()->setFullscreenMode(candidate, CURRENT_WINDOW_FS_MODES.internal, std::nullopt, CURRENT_FS_LAYOUT_HANDLED);
         }

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1482,8 +1482,8 @@ void CWindow::mapWindow() {
     if (requestedClientFSMode == Fullscreen::FSMODE_MAXIMIZED && m_fullscreenPolicy->requestSuppression().maximize)
         requestedClientFSMode.reset();
 
-    const auto TAKEOVER_MODE = Fullscreen::controller()->getFullscreenWindow(m_workspace) && !(m_state & WINDOW_STATE_NO_INITIAL_FOCUS) && requestedClientFSHasBackendOrigin &&
-        requestedClientFSMode == Fullscreen::FSMODE_FULLSCREEN;
+    const auto TAKEOVER_MODE = Fullscreen::controller()->getFullscreenWindow(m_workspace) && !(m_state & WINDOW_STATE_NO_INITIAL_FOCUS) && !requestedFSState.has_value() &&
+        requestedClientFSHasBackendOrigin && requestedClientFSMode == Fullscreen::FSMODE_FULLSCREEN;
 
     if (TAKEOVER_MODE)
         Fullscreen::controller()->beginFullscreenTakeover(m_self.lock());

--- a/src/desktop/view/window/WindowFullscreenPolicy.cpp
+++ b/src/desktop/view/window/WindowFullscreenPolicy.cpp
@@ -26,8 +26,9 @@ const SPendingClientFullscreenRequest& CWindowFullscreenPolicy::pendingClientReq
     return m_pendingClientRequest;
 }
 
-void CWindowFullscreenPolicy::setPendingClientRequest(Fullscreen::eFullscreenMode mode, std::optional<MONITORID> monitor) {
-    m_pendingClientRequest.mode = mode;
+void CWindowFullscreenPolicy::setPendingClientRequest(Fullscreen::eFullscreenMode mode, std::optional<MONITORID> monitor, bool backendOrigin) {
+    m_pendingClientRequest.mode          = mode;
+    m_pendingClientRequest.isFromBackend = backendOrigin;
     if (mode == Fullscreen::FSMODE_FULLSCREEN)
         m_pendingClientRequest.monitor = monitor;
     else

--- a/src/desktop/view/window/WindowFullscreenPolicy.hpp
+++ b/src/desktop/view/window/WindowFullscreenPolicy.hpp
@@ -21,6 +21,7 @@ namespace Desktop::View {
     struct SPendingClientFullscreenRequest {
         std::optional<Fullscreen::eFullscreenMode> mode;
         std::optional<MONITORID>                   monitor;
+        bool                                       isFromBackend{};
     };
 
     class CWindowFullscreenPolicy {
@@ -33,19 +34,19 @@ namespace Desktop::View {
         void                                   setRequestSuppression(const SFullscreenRequestSuppression& suppression);
 
         const SPendingClientFullscreenRequest& pendingClientRequest() const;
-        void                                   setPendingClientRequest(Fullscreen::eFullscreenMode mode, std::optional<MONITORID> monitor = std::nullopt);
-        void                                   clearPendingClientMode(Fullscreen::eFullscreenMode mode);
-        SPendingClientFullscreenRequest        consumePendingClientRequest();
+        void                            setPendingClientRequest(Fullscreen::eFullscreenMode mode, std::optional<MONITORID> monitor = std::nullopt, bool backendOrigin = false);
+        void                            clearPendingClientMode(Fullscreen::eFullscreenMode mode);
+        SPendingClientFullscreenRequest consumePendingClientRequest();
 
-        void                                   expectMaximizeEcho();
-        void                                   clearExpectedMaximizeEcho();
-        bool                                   consumeExpectedMaximizeEcho(bool maximized);
+        void                            expectMaximizeEcho();
+        void                            clearExpectedMaximizeEcho();
+        bool                            consumeExpectedMaximizeEcho(bool maximized);
 
-        bool                                   pinFullscreened() const;
-        void                                   setPinFullscreened(bool pinFullscreened);
+        bool                            pinFullscreened() const;
+        void                            setPinFullscreened(bool pinFullscreened);
 
-        bool                                   restoreClientMaximized() const;
-        void                                   setRestoreClientMaximized(bool restore);
+        bool                            restoreClientMaximized() const;
+        void                            setRestoreClientMaximized(bool restore);
 
       private:
         bool                            m_allowedOverFullscreen = true;

--- a/src/managers/fullscreen/FullscreenController.cpp
+++ b/src/managers/fullscreen/FullscreenController.cpp
@@ -19,10 +19,7 @@
 #include "../../output/Monitor.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../debug/log/Logger.hpp"
-#include "managers/fullscreen/FullscreenTypes.hpp"
-#include <hyprutils/utils/ScopeGuard.hpp>
 #include <optional>
-#include <unordered_map>
 
 using namespace Fullscreen;
 
@@ -298,7 +295,7 @@ void CFullscreenController::beginFullscreenTakeover(const PHLWINDOW window) {
         return;
 
     const auto& CURRENT_FS_WINDOW = getFullscreenWindow(window->m_workspace);
-    if (!CURRENT_FS_WINDOW || CURRENT_FS_WINDOW == window)
+    if (!CURRENT_FS_WINDOW || CURRENT_FS_WINDOW == window || layoutManagedFS(CURRENT_FS_WINDOW))
         return;
 
     const auto [_, TAKEOVER_PUT] = m_takeovers.try_emplace(window,
@@ -346,8 +343,7 @@ bool CFullscreenController::endFullscreenTakeover(const PHLWINDOW window) {
     }
 
     const auto CURRENT = getFullscreenWindow(WORKSPACE);
-    if (/*!DISPLACED->m_isMapped || */
-        DISPLACED->m_workspace != WORKSPACE || (CURRENT && CURRENT != window)) {
+    if (!DISPLACED->mapped() || DISPLACED->m_workspace != WORKSPACE || CURRENT != DISPLACER) {
 
         LOG(Log::DEBUG, "incomplete takeover stored");
         m_takeovers.erase(IT);
@@ -357,7 +353,8 @@ bool CFullscreenController::endFullscreenTakeover(const PHLWINDOW window) {
     m_takeovers.erase(IT);
 
     setFullscreenMode(DISPLACER, eFullscreenMode::FSMODE_NONE, eFullscreenMode::FSMODE_NONE);
-    setFullscreenMode(DISPLACED, TAKEOVER.mode.internal, TAKEOVER.mode.client, TAKEOVER.layoutAware);
+    // Restore the exact mode pair without sync_fullscreen rewriting it or normal collision handling.
+    setFullscreenMode(DISPLACED, TAKEOVER.mode.internal, TAKEOVER.mode.client, TAKEOVER.layoutAware, FULLSCREEN_MUTATION_TRANSFER);
 
     LOG(Log::DEBUG, "takeover complete from {:c} to {:c}", DISPLACER, DISPLACED);
 

--- a/src/managers/fullscreen/FullscreenController.cpp
+++ b/src/managers/fullscreen/FullscreenController.cpp
@@ -19,7 +19,10 @@
 #include "../../output/Monitor.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../debug/log/Logger.hpp"
+#include "managers/fullscreen/FullscreenTypes.hpp"
+#include <hyprutils/utils/ScopeGuard.hpp>
 #include <optional>
+#include <unordered_map>
 
 using namespace Fullscreen;
 
@@ -290,6 +293,77 @@ std::string CFullscreenController::getFullscreenHandlerNameAsString(const PHLWIN
     }
 }
 
+void CFullscreenController::beginFullscreenTakeover(const PHLWINDOW window) {
+    if (!window || !window->m_workspace)
+        return;
+
+    const auto& CURRENT_FS_WINDOW = getFullscreenWindow(window->m_workspace);
+    if (!CURRENT_FS_WINDOW || CURRENT_FS_WINDOW == window)
+        return;
+
+    const auto [_, TAKEOVER_PUT] = m_takeovers.try_emplace(window,
+                                                           SFullscreenTakeover{
+                                                               .displaced   = CURRENT_FS_WINDOW,
+                                                               .displacer   = window,
+                                                               .workspace   = window->m_workspace,
+                                                               .mode        = getFullscreenModes(CURRENT_FS_WINDOW),
+                                                               .layoutAware = layoutManagedFS(CURRENT_FS_WINDOW),
+                                                           });
+
+    if (!TAKEOVER_PUT)
+        LOG(Log::WARN, "failed to place takeover of {:c}", window->m_self.lock());
+    else
+        LOG(Log::INFO, "beginning takeover of {:c}", window->m_self.lock());
+}
+
+void CFullscreenController::cancelFullscreenTakeover(const PHLWINDOW window) {
+    const auto ERASED = m_takeovers.erase(window);
+    if (ERASED)
+        LOG(Log::DEBUG, "erased takeover request for window {:c}", window);
+    else
+        LOG(Log::DEBUG, "not found entry to erase from takeover storage for window {:c}", window);
+}
+
+bool CFullscreenController::endFullscreenTakeover(const PHLWINDOW window) {
+    if (!window)
+        return false;
+
+    const auto IT = m_takeovers.find(window);
+    if (IT == m_takeovers.end()) {
+        LOG(Log::DEBUG, "not found takeover for window {:c}", window);
+        return false;
+    }
+
+    const auto TAKEOVER  = IT->second;
+    const auto DISPLACED = TAKEOVER.displaced.lock();
+    const auto DISPLACER = TAKEOVER.displacer.lock();
+    const auto WORKSPACE = TAKEOVER.workspace.lock();
+
+    if (!DISPLACED || !DISPLACER || !WORKSPACE) {
+        LOG(Log::DEBUG, "incomplete takeover stored");
+        m_takeovers.erase(IT);
+        return false;
+    }
+
+    const auto CURRENT = getFullscreenWindow(WORKSPACE);
+    if (/*!DISPLACED->m_isMapped || */
+        DISPLACED->m_workspace != WORKSPACE || (CURRENT && CURRENT != window)) {
+
+        LOG(Log::DEBUG, "incomplete takeover stored");
+        m_takeovers.erase(IT);
+        return false;
+    }
+
+    m_takeovers.erase(IT);
+
+    setFullscreenMode(DISPLACER, eFullscreenMode::FSMODE_NONE, eFullscreenMode::FSMODE_NONE);
+    setFullscreenMode(DISPLACED, TAKEOVER.mode.internal, TAKEOVER.mode.client, TAKEOVER.layoutAware);
+
+    LOG(Log::DEBUG, "takeover complete from {:c} to {:c}", DISPLACER, DISPLACED);
+
+    return true;
+}
+
 void CFullscreenController::setFullscreenMode(const PHLWINDOW window, std::optional<eFullscreenMode> internal, std::optional<eFullscreenMode> client,
                                               std::optional<bool> layoutAware, eFullscreenMutationContext context) {
     if (!window)
@@ -309,6 +383,8 @@ void CFullscreenController::setFullscreenMode(const PHLWINDOW window, std::optio
 
     eFullscreenMode targetInternalMode = internal.value_or(FSMODE_NONE);
     eFullscreenMode targetClientMode   = client.value_or(FSMODE_NONE);
+
+    LOG(Log::INFO, "setFullscreenMode for window: {}, internal: {}, client: {}", window->m_self.lock(), sc<int8_t>(targetInternalMode), sc<int8_t>(targetClientMode));
 
     /*
         If the past handled mode and current handled mode is not the same for an already FS window, it implies that the window IS FS; we need to move it to the new handler we will use for the current FS request

--- a/src/managers/fullscreen/FullscreenController.cpp
+++ b/src/managers/fullscreen/FullscreenController.cpp
@@ -19,7 +19,9 @@
 #include "../../output/Monitor.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../debug/log/Logger.hpp"
+#include <hyprutils/utils/ScopeGuard.hpp>
 #include <optional>
+#include <mutex>
 
 using namespace Fullscreen;
 
@@ -306,11 +308,10 @@ void CFullscreenController::beginFullscreenTakeover(const PHLWINDOW window) {
                                                                .mode        = getFullscreenModes(CURRENT_FS_WINDOW),
                                                                .layoutAware = layoutManagedFS(CURRENT_FS_WINDOW),
                                                            });
-
-    if (!TAKEOVER_PUT)
-        LOG(Log::WARN, "failed to place takeover of {:c}", window->m_self.lock());
+    if (TAKEOVER_PUT)
+        LOG(Log::DEBUG, "beginning takeover {:c} --> {:c}", CURRENT_FS_WINDOW, window->m_self.lock());
     else
-        LOG(Log::INFO, "beginning takeover of {:c}", window->m_self.lock());
+        LOG(Log::WARN, "failed to place takeover of {:c}", window->m_self.lock());
 }
 
 void CFullscreenController::cancelFullscreenTakeover(const PHLWINDOW window) {
@@ -327,32 +328,33 @@ bool CFullscreenController::endFullscreenTakeover(const PHLWINDOW window) {
 
     const auto IT = m_takeovers.find(window);
     if (IT == m_takeovers.end()) {
-        LOG(Log::DEBUG, "not found takeover for window {:c}", window);
         return false;
     }
 
-    const auto TAKEOVER  = IT->second;
-    const auto DISPLACED = TAKEOVER.displaced.lock();
-    const auto DISPLACER = TAKEOVER.displacer.lock();
-    const auto WORKSPACE = TAKEOVER.workspace.lock();
+    std::once_flag                once{};
+    const auto                    erase = [&once, this, IT] { std::call_once(once, [this, IT] { m_takeovers.erase(IT); }); };
+    Hyprutils::Utils::CScopeGuard eraser(erase);
+
+    const auto                    TAKEOVER  = IT->second;
+    const auto                    DISPLACED = TAKEOVER.displaced.lock();
+    const auto                    DISPLACER = TAKEOVER.displacer.lock();
+    const auto                    WORKSPACE = TAKEOVER.workspace.lock();
 
     if (!DISPLACED || !DISPLACER || !WORKSPACE) {
         LOG(Log::DEBUG, "incomplete takeover stored");
-        m_takeovers.erase(IT);
         return false;
     }
 
     const auto CURRENT = getFullscreenWindow(WORKSPACE);
     if (!DISPLACED->mapped() || DISPLACED->m_workspace != WORKSPACE || CURRENT != DISPLACER) {
-
         LOG(Log::DEBUG, "incomplete takeover stored");
-        m_takeovers.erase(IT);
         return false;
     }
 
-    m_takeovers.erase(IT);
+    erase(); // cleaning up current takeover before the actions to avoid any potential recursion cases
 
     setFullscreenMode(DISPLACER, eFullscreenMode::FSMODE_NONE, eFullscreenMode::FSMODE_NONE);
+
     // Restore the exact mode pair without sync_fullscreen rewriting it or normal collision handling.
     setFullscreenMode(DISPLACED, TAKEOVER.mode.internal, TAKEOVER.mode.client, TAKEOVER.layoutAware, FULLSCREEN_MUTATION_TRANSFER);
 
@@ -380,8 +382,6 @@ void CFullscreenController::setFullscreenMode(const PHLWINDOW window, std::optio
 
     eFullscreenMode targetInternalMode = internal.value_or(FSMODE_NONE);
     eFullscreenMode targetClientMode   = client.value_or(FSMODE_NONE);
-
-    LOG(Log::INFO, "setFullscreenMode for window: {}, internal: {}, client: {}", window->m_self.lock(), sc<int8_t>(targetInternalMode), sc<int8_t>(targetClientMode));
 
     /*
         If the past handled mode and current handled mode is not the same for an already FS window, it implies that the window IS FS; we need to move it to the new handler we will use for the current FS request

--- a/src/managers/fullscreen/FullscreenController.hpp
+++ b/src/managers/fullscreen/FullscreenController.hpp
@@ -4,6 +4,7 @@
 #include "desktop/DesktopTypes.hpp"
 #include "FullscreenTypes.hpp"
 #include <optional>
+#include <unordered_map>
 
 namespace Fullscreen {
 

--- a/src/managers/fullscreen/FullscreenController.hpp
+++ b/src/managers/fullscreen/FullscreenController.hpp
@@ -58,6 +58,12 @@ namespace Fullscreen {
         void setFullscreenMode(const PHLWINDOW window, std::optional<eFullscreenMode> internal = std::nullopt, std::optional<eFullscreenMode> client = std::nullopt,
                                std::optional<bool> layoutAware = std::nullopt, eFullscreenMutationContext context = FULLSCREEN_MUTATION_NORMAL);
 
+        void beginFullscreenTakeover(const PHLWINDOW window);
+
+        bool endFullscreenTakeover(const PHLWINDOW window);
+
+        void cancelFullscreenTakeover(const PHLWINDOW window);
+
         // Misc. Operations
 
         // In order to avoid re-setting an FS window's size over and over again if it's FS and already set to the correct value.
@@ -69,6 +75,16 @@ namespace Fullscreen {
             const WP<IFullscreenHandler> TILED_DEFAULT_FS_HANDLER;
             const WP<IFullscreenHandler> FLOATING_FS_HANDLER;
         };
+
+        struct SFullscreenTakeover {
+            const PHLWINDOWREF    displaced;
+            const PHLWINDOWREF    displacer;
+            const PHLWORKSPACEREF workspace;
+            SFullscreenMode       mode;
+            bool                  layoutAware = false;
+        };
+
+        std::unordered_map<PHLWINDOWREF, SFullscreenTakeover> m_takeovers;
 
         // FS Mode Setter Helpers
         void setWindowFullscreenModeInternal(const PHLWINDOW window, const eFullscreenMode mode, bool layoutAware, eFullscreenMutationContext context);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds to the FullscreenController fullscreen takeover feature support - in case if new window in the workspace was created by the backend + requests fullscreen at the moment of creation - controller remembers current workspace fullscreen state and re-applies it when the window that took FS over the existing one, gets closed
 
It might be useful for various Media / PDF / etc viewers that are spawned from inside of the application and often are fullscreened by default and their termination leads to the reset of the workspace FS state to the default one
 
Changes:
- is_backend bool flag added to the pending fullscreen request
- fullscreen requests with backend source call `beginFullscreenTakeover` in `mapWindow()`
- fullscreened windows try to rollback the FS state with `endFullscreenTakeover` on `unmapWindow()`
 
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Initial impl of the feature is enabled by default and is disabled in case of existence of any config flags overriding FS behavior (like `exit_window_retains_fullscreen`). It is a question to discuss, maybe it should also be guarded by some config as well 

#### Did you use AI in any way shape or form in the making of this PR? If so, detail how you used it. (Undisclosed AI use is a violation of the [AI Policy](https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md) and is punishable)

AI was used for the navigation through the codebase and exploring the corner cases.

#### Is it ready for merging, or does it need work?

Decision about config flag should be made. After agreement on the design of the feature the integration test should also be added